### PR TITLE
Move to proper async heartbeat queuing

### DIFF
--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -217,8 +217,8 @@ async def test_sync_activity_thread_cancel(
 ):
     def wait_cancel() -> str:
         while not temporalio.activity.is_cancelled():
-            temporalio.activity.heartbeat()
             time.sleep(1)
+            temporalio.activity.heartbeat()
         return "Cancelled"
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
@@ -228,7 +228,7 @@ async def test_sync_activity_thread_cancel(
             wait_cancel,
             cancel_after_ms=100,
             wait_for_cancellation=True,
-            heartbeat_timeout_ms=30000,
+            heartbeat_timeout_ms=3000,
             worker_config={"activity_executor": executor},
         )
     assert result.result == "Cancelled"
@@ -236,8 +236,8 @@ async def test_sync_activity_thread_cancel(
 
 def picklable_activity_wait_cancel() -> str:
     while not temporalio.activity.is_cancelled():
-        temporalio.activity.heartbeat()
         time.sleep(1)
+        temporalio.activity.heartbeat()
     return "Cancelled"
 
 
@@ -251,7 +251,7 @@ async def test_sync_activity_process_cancel(
             picklable_activity_wait_cancel,
             cancel_after_ms=100,
             wait_for_cancellation=True,
-            heartbeat_timeout_ms=30000,
+            heartbeat_timeout_ms=3000,
             worker_config={"activity_executor": executor},
         )
     assert result.result == "Cancelled"
@@ -430,8 +430,6 @@ def picklable_heartbeat_details_activity() -> str:
     some_list.append(f"attempt: {info.attempt}")
     temporalio.activity.logger.debug("Heartbeating with value: %s", some_list)
     temporalio.activity.heartbeat(some_list)
-    # TODO(cretz): Remove when we fix multiprocess heartbeats
-    time.sleep(1)
     if len(some_list) < 2:
         raise RuntimeError(f"Try again, list contains: {some_list}")
     return ", ".join(some_list)


### PR DESCRIPTION
## What was changed

Heartbeating using a queue and properly doing an async unregister

## Why?

We're using queuing just to keep the task-count low for repeated heartbeats. We were getting deadlocks on unregister so we properly made that async.

## Checklist

1. Closes #12
