### PR TITLE
adding pre-commit file for blacken-docs, black, isort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,40 @@
+# Environments
+.env
 .venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+.DS_Store
+docs/.DS_Store
 __pycache__
+# Sphinx documentation
 /build
 /dist
 /docs/_autosummary
 /docs/_build
+
 temporalio/api/*
 !temporalio/api/__init__.py
 temporalio/bridge/proto/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/asottile/blacken-docs
+    rev: v1.12.1
+    hooks:
+      - id: blacken-docs
+        additional_dependencies: [black==22.3.0]
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        language_version: python3.8
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [Temporal](https://temporal.io/) is a distributed, scalable, durable, and highly available orchestration engine used to
 execute asynchronous long-running business logic in a scalable and resilient way.
 
-"Temporal Python SDK" is the framework for authoring workflows and activities using the Python programming language.
+_Temporal Python SDK_ is the framework for authoring workflows and activities using the Python programming language.
 
 In addition to this documentation, see the [samples](https://github.com/temporalio/samples-python) repository for code
 examples.
@@ -16,11 +16,11 @@ examples.
 
 The Python SDK is under development. There are no compatibility guarantees nor proper documentation pages at this time.
 
-Currently missing features:
+Currently, missing features:
 
-* Workflow worker support
-* Async activity support (in client or worker)
-* Support for Windows arm, macOS arm (i.e. M1), Linux arm, and Linux x64 glibc < 2.31.
+- Workflow worker support
+- Async activity support (in client or worker)
+- Support for Windows arm, macOS arm (that is M1), Linux arm, and Linux x64 glibc < 2.31.
 
 ## Quick Start
 
@@ -30,10 +30,10 @@ Install the `temporalio` package from [PyPI](https://pypi.org/project/temporalio
 
 These steps can be followed to use with a virtual environment and `pip`:
 
-* [Create a virtual environment](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments)
-* Update `pip` - `python -m pip install -U pip`
-  * Needed because older versions of `pip` may not pick the right wheel
-* Install Temporal SDK - `python -m pip install temporalio`
+- [Create a virtual environment](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments)
+- Update `pip` – `python -m pip install -U pip`
+- Needed because older versions of `pip` may not pick the right wheel
+- Install Temporal SDK – `python -m pip install temporalio`
 
 The SDK is now ready for use.
 
@@ -45,14 +45,18 @@ Create the following script at `start_workflow.py`:
 import asyncio
 from temporalio.client import Client
 
+
 async def main():
-  # Create client connected to server at the given address
-  client = await Client.connect("http://localhost:7233")
+    # Create client connected to server at the given address
+    client = await Client.connect("http://localhost:7233")
 
-  # Start a workflow
-  handle = await client.start_workflow("my workflow name", "some arg", id="my-workflow-id", task_queue="my-task-queue")
+    # Start a workflow
+    handle = await client.start_workflow(
+        "my workflow name", "some arg", id="my-workflow-id", task_queue="my-task-queue"
+    )
 
-  print(f"Workflow started with ID {handle.id}")
+    print(f"Workflow started with ID {handle.id}")
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -61,7 +65,7 @@ if __name__ == "__main__":
 Assuming you have a [Temporal server running on localhost](https://docs.temporal.io/docs/server/quick-install/), this
 will start a workflow:
 
-    python start_workflow.py
+python start_workflow.py
 
 Note that an external worker has to be started with this workflow registered to actually run the workflow.
 
@@ -74,38 +78,41 @@ A client can be created and used to start a workflow like so:
 ```python
 from temporalio.client import Client
 
+
 async def main():
-  # Create client connected to server at the given address and namespace
-  client = await Client.connect("http://localhost:7233", namespace="my-namespace")
+    # Create client connected to server at the given address and namespace
+    client = await Client.connect("http://localhost:7233", namespace="my-namespace")
 
-  # Start a workflow
-  handle = await client.start_workflow("my workflow name", "some arg", id="my-workflow-id", task_queue="my-task-queue")
+    # Start a workflow
+    handle = await client.start_workflow(
+        "my workflow name", "some arg", id="my-workflow-id", task_queue="my-task-queue"
+    )
 
-  # Wait for result
-  result = await handle.result()
-  print(f"Result: {result}")
+    # Wait for result
+    result = await handle.result()
+    print(f"Result: {result}")
 ```
 
 Some things to note about the above code:
 
-* A `Client` does not have an explicit "close"
-* Positional arguments can be passed to `start_workflow`
-* The `handle` represents the workflow that was started and can be used for more than just getting the result
-* Since we are just getting the handle and waiting on the result, we could have called `client.execute_workflow` which
+- A `Client` doesn't have an explicit “close”
+- Positional arguments can be passed to `start_workflow`
+- The `handle` represents the workflow that was started and can be used for more than just getting the result
+- Since we are just getting the handle and waiting on the result, we could have called `client.execute_workflow` which
   does the same thing
-* Clients can have many more options not shown here (e.g. data converters and interceptors)
+- Clients can have many more options not shown here (for example, data converters and interceptors)
 
 #### Data Conversion
 
 Data converters are used to convert raw Temporal payloads to/from actual Python types. A custom data converter of type
 `temporalio.converter.DataConverter` can be set via the `data_converter` client parameter.
 
-The default data converter supports converting multiple types including:
+The default data converter supports converting multiple types, including:
 
-* `None`
-* `bytes`
-* `google.protobuf.message.Message` - As JSON when encoding, but has ability to decode binary proto from other languages
-* Anything that [`json.dump`](https://docs.python.org/3/library/json.html#json.dump) supports
+- `None`
+- `bytes`
+- `google.protobuf.message.Message` - As JSON when encoding, but has ability to decode binary proto from other languages
+- Anything that [`json.dump`](https://docs.python.org/3/library/json.html#json.dump) supports
 
 As a special case in the default converter, [data classes](https://docs.python.org/3/library/dataclasses.html) are
 automatically [converted to dictionaries](https://docs.python.org/3/library/dataclasses.html#dataclasses.asdict) before
@@ -127,30 +134,31 @@ from temporalio.client import Client
 from temporalio.worker import Worker
 from temporalio import activity
 
+
 @activity.defn
 async def say_hello_activity(name: str) -> str:
     return f"Hello, {name}!"
 
 
 async def main(stop_event: asyncio.Event):
-  # Create client connected to server at the given address
-  client = await Client.connect("http://localhost:7233", namespace="my-namespace")
+    # Create client connected to server at the given address
+    client = await Client.connect("http://localhost:7233", namespace="my-namespace")
 
-  # Run the worker until the event is set
-  worker = Worker(client, task_queue="my-task-queue", activities=[say_hello_activity])
-  async with worker:
-    await stop_event.wait()
+    # Run the worker until the event is set
+    worker = Worker(client, task_queue="my-task-queue", activities=[say_hello_activity])
+    async with worker:
+        await stop_event.wait()
 ```
 
 Some things to note about the above code:
 
-* This creates/uses the same client that is used for starting workflows
-* The `say_hello_activity` is `async` which is the recommended activity type (see "Types of Activities" below)
-* The created worker only runs activities, not workflows
-* Activities are passed as a mapping with the key as a string activity name and the value as a callable
-* While this example accepts a stop event and uses `async with`, `run()` and `shutdown()` may be used instead
-* Workers can have many more options not shown here (e.g. data converters and interceptors)
-* A custom name for the activity can be set with a decorator argument, e.g. `@activity.defn(name="my activity")`
+- This creates/uses the same client that is used for starting workflows
+- The `say_hello_activity` is `async` which is the recommended activity type (see "Types of Activities" below)
+- The created worker only runs activities, not workflows
+- Activities are passed as a mapping with the key as a string activity name and the value as a callable
+- While this example accepts a stop event and uses `async with`, `run()` and `shutdown()` may be used instead
+- Workers can have many more options not shown here (for example, data converters and interceptors)
+- A custom name for the activity can be set with a decorator argument, for example, `@activity.defn(name="my activity")`
 
 #### Types of Activities
 
@@ -159,7 +167,7 @@ synchronous multiprocess/other. Only positional parameters are allowed in activi
 
 ##### Asynchronous Activities
 
-Asynchronous activities, i.e. functions using `async def`, are the recommended activity type. When using asynchronous
+Asynchronous activities, that is, functions using `async def`, are the recommended activity type. When using asynchronous
 activities no special worker parameters are needed.
 
 Cancellation for asynchronous activities is done via
@@ -170,11 +178,11 @@ receive cancellation and there are other ways to be notified about cancellation 
 
 ##### Synchronous Activities
 
-Synchronous activities, i.e. functions that do not have `async def`, can be used with workers, but the
+Synchronous activities, that is, functions that do not have `async def`, can be used with workers, but the
 `activity_executor` worker parameter must be set with a `concurrent.futures.Executor` instance to use for executing the
 activities.
 
-Cancellation for synchronous activities is done in the background and the activity must choose to listen for it and
+Cancellation for synchronous activities is done in the background, and the activity must choose to listen for it and
 react appropriately. An activity must heartbeat to receive cancellation and there are other ways to be notified about
 cancellation (see "Activity Context" and "Heartbeating and Cancellation" later).
 
@@ -184,20 +192,19 @@ If `activity_executor` is set to an instance of `concurrent.futures.ThreadPoolEx
 are considered multithreaded activities. Besides `activity_executor`, no other worker parameters are required for
 synchronous multithreaded activities.
 
-###### Synchronous Multiprocess/Other Activities
+###### Synchronous Multi Process/Other Activities
 
-Synchronous activities, i.e. functions that do not have `async def`, can be used with workers, but the
+Synchronous activities, that is, functions that don't have `async def`, can be used with workers, but the
 `activity_executor` worker parameter must be set with a `concurrent.futures.Executor` instance to use for executing the
 activities. If this is _not_ set to an instance of `concurrent.futures.ThreadPoolExecutor` then the synchronous
 activities are considered multiprocess/other activities.
 
-These require special primitives for heartbeating and cancellation. The `shared_state_manager` worker parameter must be
+These require special primitives for heart beating and cancellation. The `shared_state_manager` worker parameter must be
 set to an instance of `temporalio.worker.SharedStateManager`. The most common implementation can be created by passing a
-`multiprocessing.managers.SyncManager` (i.e. result of `multiprocessing.managers.Manager()`) to
+`multiprocessing.managers.SyncManager` (that is, result of `multiprocessing.managers.Manager()`) to
 `temporalio.worker.SharedStateManager.create_from_multiprocessing()`.
 
-Also, all of these activity functions must be
-["picklable"](https://docs.python.org/3/library/pickle.html#what-can-be-pickled-and-unpickled).
+Activity Functions must be ["picklable"](https://docs.python.org/3/library/pickle.html#what-can-be-pickled-and-unpickled).
 
 #### Activity Context
 
@@ -205,16 +212,16 @@ During activity execution, an implicit activity context is set as a
 [context variable](https://docs.python.org/3/library/contextvars.html). The context variable itself is not visible, but
 calls in the `temporalio.activity` package make use of it. Specifically:
 
-* `in_activity()` - Whether an activity context is present
-* `info()` - Returns the immutable info of the currently running activity
-* `heartbeat(*details)` - Record a heartbeat
-* `is_cancelled()` - Whether a cancellation has been requested on this activity
-* `wait_for_cancelled()` - `async` call to wait for cancellation request
-* `wait_for_cancelled_sync(timeout)` - Synchronous blocking call to wait for cancellation request
-* `is_worker_shutdown()` - Whether the worker has started graceful shutdown
-* `wait_for_worker_shutdown()` - `async` call to wait for start of graceful worker shutdown
-* `wait_for_worker_shutdown_sync(timeout)` - Synchronous blocking call to wait for start of graceful worker shutdown
-* `raise_complete_async()` - Raise an error that this activity will be completed asynchronously (i.e. after return of
+- `in_activity()` – Whether an activity context is present
+- `info()` – Returns the immutable info of the currently running activity
+- `heartbeat(*details)` – Record a heartbeat
+- `is_cancelled()` – Whether a cancellation has been requested on this activity
+- `wait_for_cancelled()` - `async` call to wait for cancellation request
+- `wait_for_cancelled_sync(timeout)` – Synchronous blocking call to wait for cancellation request
+- `is_worker_shutdown()` – Whether the worker has started graceful shutdown
+- `wait_for_worker_shutdown()` - `async` call to wait for start of graceful worker shutdown
+- `wait_for_worker_shutdown_sync(timeout)` - Synchronous blocking call to wait for start of graceful worker shutdown
+- `raise_complete_async()` – Raise an error that this activity will be completed asynchronously (that is, after return of
   the activity function in a separate client call)
 
 With the exception of `in_activity()`, if any of the functions are called outside of an activity context, an error
@@ -240,53 +247,53 @@ When the `graceful_shutdown_timeout` worker parameter is given a `datetime.timed
 notify activities of the graceful shutdown. Once that timeout has passed (or if wasn't set), the worker will perform
 cancellation of all outstanding activities.
 
-The `shutdown()` invocation will wait on all activities to complete, so if a long-running activity does not at least
+The `shutdown()` invocation waits for all activities to complete, so if a long-running activity doesn't, at least
 respect cancellation, the shutdown may never complete.
 
 ## Development
 
 The Python SDK is built to work with Python 3.7 and newer. It is built using
-[SDK Core](https://github.com/temporalio/sdk-core/) which is written in Rust.
+[SDK Core](https://github.com/temporalio/sdk-core/), which is written in Rust.
 
 ### Local development environment
 
 - Install the system dependencies:
 
-  - Python >=3.7
-  - [pipx](https://github.com/pypa/pipx#install-pipx) (only needed for installing the two dependencies below)
-  - [poetry](https://github.com/python-poetry/poetry) `pipx install poetry`
-  - [poe](https://github.com/nat-n/poethepoet) `pipx install poethepoet`
+- Python >=3.7
+- [pipx](https://github.com/pypa/pipx#install-pipx) (only needed for installing the two dependencies below)
+- [poetry](https://github.com/python-poetry/poetry) `pipx install poetry`
+- [poe](https://github.com/nat-n/poethepoet) `pipx install poethepoet`
 
 - Use a local virtual env environment (helps IDEs and Windows):
 
-  ```bash
-  poetry config virtualenvs.in-project true
-  ```
+```bash
+poetry config virtualenvs.in-project true
+```
 
 - Install the package dependencies (requires Rust):
 
-  ```bash
-  poetry install
-  ```
+```bash
+poetry install
+```
 
 - Build the project (requires Rust):
 
-  ```bash
-  poe build-develop
-  ```
+```bash
+poe build-develop
+```
 
 - Run the tests (requires Go):
 
-  ```bash
-  poe test
-  ```
+```bash
+poe test
+```
 
 ### Style
 
-* Mostly [Google Style Guide](https://google.github.io/styleguide/pyguide.html). Notable exceptions:
-  * We use [Black](https://github.com/psf/black) for formatting, so that takes precedence
-  * In tests and example code, can import individual classes/functions to make it more readable. Can also do this for
-    rarely in library code for some Python common items (e.g. `dataclass` or `partial`), but not allowed to do this for
-    any `temporalio` packages or any classes/functions that aren't clear when unqualified.
-  * We allow relative imports for private packages
-  * We allow `@staticmethod`
+- Mostly [Google Style Guide](https://google.github.io/styleguide/pyguide.html). Notable exceptions:
+- We use [Black](https://github.com/psf/black) for formatting, so that takes precedence
+- In tests and example code, can import individual classes/functions to make it more readable. Can also do this for
+  rarely in library code for some Python common items (for example, `dataclass` or `partial`), but not allowed to do this for
+  any `temporalio` packages or any classes/functions that aren't clear when unqualified.
+- We allow relative imports for private packages
+- We allow `@staticmethod`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+from datetime import date
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -19,8 +20,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 # -- Project information -----------------------------------------------------
 
 project = "Temporal Python SDK"
-copyright = "2022, Temporal Technologies Inc"
 author = "Temporal Technologies Inc"
+copyright = f"{date.today().year} {author}"
 
 
 # -- General configuration ---------------------------------------------------

--- a/poetry.lock
+++ b/poetry.lock
@@ -56,29 +56,25 @@ lxml = ["lxml"]
 
 [[package]]
 name = "black"
-version = "21.12b0"
+version = "22.3.0"
 description = "The uncompromising code formatter."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6.2"
 
 [package.dependencies]
-click = ">=7.1.2"
+click = ">=8.0.0"
 mypy-extensions = ">=0.4.3"
-pathspec = ">=0.9.0,<1"
+pathspec = ">=0.9.0"
 platformdirs = ">=2"
-tomli = ">=0.2.6,<2.0.0"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
-typing-extensions = [
-    {version = ">=3.10.0.0", markers = "python_version < \"3.10\""},
-    {version = "!=3.10.0.1", markers = "python_version >= \"3.10\""},
-]
+typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.7.4)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-python2 = ["typed-ast (>=1.4.3)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
@@ -128,7 +124,7 @@ unicode_backport = ["unicodedata2"]
 name = "click"
 version = "8.0.4"
 description = "Composable command line interface toolkit"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -140,7 +136,7 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -241,7 +237,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "importlib-metadata"
 version = "4.11.2"
 description = "Read metadata from Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -350,7 +346,7 @@ python2 = ["typed-ast (>=1.4.0,<2)"]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -381,7 +377,7 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 name = "pathspec"
 version = "0.9.0"
 description = "Utility library for gitignore style pattern matching of file paths."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
@@ -400,7 +396,7 @@ testing = ["coverage", "nose"]
 name = "platformdirs"
 version = "2.5.1"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -798,7 +794,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "tomli"
 version = "1.2.3"
 description = "A lil' TOML parser"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -842,7 +838,7 @@ urllib3 = ">=1.26.0"
 name = "typed-ast"
 version = "1.5.2"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -887,7 +883,7 @@ python-versions = "*"
 name = "zipp"
 version = "3.7.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -898,7 +894,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "8bb19baf1cb75bc4e6035ca228de8949df092ad7cf6400952aaa8563cb3f5ebe"
+content-hash = "eb9bd1d42c458ca6ae62aca059a8e187fd2f4ab88b7835ccb210e77bdc7f2506"
 
 [metadata.files]
 alabaster = [
@@ -922,8 +918,29 @@ beautifulsoup4 = [
     {file = "beautifulsoup4-4.10.0.tar.gz", hash = "sha256:c23ad23c521d818955a4151a67d81580319d4bf548d3d49f4223ae041ff98891"},
 ]
 black = [
-    {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
-    {file = "black-21.12b0.tar.gz", hash = "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3"},
+    {file = "black-22.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2497f9c2386572e28921fa8bec7be3e51de6801f7459dffd6e62492531c47e09"},
+    {file = "black-22.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5795a0375eb87bfe902e80e0c8cfaedf8af4d49694d69161e5bd3206c18618bb"},
+    {file = "black-22.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e3556168e2e5c49629f7b0f377070240bd5511e45e25a4497bb0073d9dda776a"},
+    {file = "black-22.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67c8301ec94e3bcc8906740fe071391bce40a862b7be0b86fb5382beefecd968"},
+    {file = "black-22.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:fd57160949179ec517d32ac2ac898b5f20d68ed1a9c977346efbac9c2f1e779d"},
+    {file = "black-22.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cc1e1de68c8e5444e8f94c3670bb48a2beef0e91dddfd4fcc29595ebd90bb9ce"},
+    {file = "black-22.3.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d2fc92002d44746d3e7db7cf9313cf4452f43e9ea77a2c939defce3b10b5c82"},
+    {file = "black-22.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:a6342964b43a99dbc72f72812bf88cad8f0217ae9acb47c0d4f141a6416d2d7b"},
+    {file = "black-22.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:328efc0cc70ccb23429d6be184a15ce613f676bdfc85e5fe8ea2a9354b4e9015"},
+    {file = "black-22.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06f9d8846f2340dfac80ceb20200ea5d1b3f181dd0556b47af4e8e0b24fa0a6b"},
+    {file = "black-22.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:ad4efa5fad66b903b4a5f96d91461d90b9507a812b3c5de657d544215bb7877a"},
+    {file = "black-22.3.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e8477ec6bbfe0312c128e74644ac8a02ca06bcdb8982d4ee06f209be28cdf163"},
+    {file = "black-22.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:637a4014c63fbf42a692d22b55d8ad6968a946b4a6ebc385c5505d9625b6a464"},
+    {file = "black-22.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:863714200ada56cbc366dc9ae5291ceb936573155f8bf8e9de92aef51f3ad0f0"},
+    {file = "black-22.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10dbe6e6d2988049b4655b2b739f98785a884d4d6b85bc35133a8fb9a2233176"},
+    {file = "black-22.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:cee3e11161dde1b2a33a904b850b0899e0424cc331b7295f2a9698e79f9a69a0"},
+    {file = "black-22.3.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5891ef8abc06576985de8fa88e95ab70641de6c1fca97e2a15820a9b69e51b20"},
+    {file = "black-22.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:30d78ba6bf080eeaf0b7b875d924b15cd46fec5fd044ddfbad38c8ea9171043a"},
+    {file = "black-22.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ee8f1f7228cce7dffc2b464f07ce769f478968bfb3dd1254a4c2eeed84928aad"},
+    {file = "black-22.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ee227b696ca60dd1c507be80a6bc849a5a6ab57ac7352aad1ffec9e8b805f21"},
+    {file = "black-22.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:9b542ced1ec0ceeff5b37d69838106a6348e60db7b8fdd245294dc1d26136265"},
+    {file = "black-22.3.0-py3-none-any.whl", hash = "sha256:bc58025940a896d7e5356952228b68f793cf5fcb342be703c3a2669a1488cb72"},
+    {file = "black-22.3.0.tar.gz", hash = "sha256:35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79"},
 ]
 bleach = [
     {file = "bleach-4.1.0-py2.py3-none-any.whl", hash = "sha256:4d2651ab93271d1129ac9cbc679f524565cc8a1b791909c4a51eac4446a15994"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,10 @@ protobuf = "^3.19.4"
 python = "^3.7"
 types-protobuf = "^3.19.6"
 typing-extensions = "^4.0.1"
+black = "^22.3.0"
 
 [tool.poetry.dev-dependencies]
-black = "^21.12b0"
+black = "^22.3.0"
 furo = "^2022.3.4"
 grpcio-tools = "^1.43.0"
 isort = "^5.10.1"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
To enforce **Black** on code contributions, I added a pre-commit config file.
`.pre-commit-config.yaml`

Blacken-docs pre-commit uses Black formatter on doc strings.
Black pre-commit formats .py files.
Isort pre-commit orders imports.

Imported the date package for `docs/conf.py` to keep copy write information updated.

Fixed small doc issues in the Readme
## Why?
<!-- Tell your future self why have you made these changes -->
To enforce standards as described in the readme
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Ran `pre-commit run --all-files` with zero issues.

3. Any docs updates needed?
No.
