### PR TITLE
More tests, docs, and minor things

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           go-version: "1.17"
       - run: python -m pip install --upgrade wheel poetry poethepoet
-      - run: poetry install
+      - run: poetry install --no-root
       - run: poe gen-protos
       - run: poetry build
       - run: poe fix-wheel

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sdk-core"]
 	path = temporalio/bridge/sdk-core
-	url = git@github.com:temporalio/sdk-core.git
+	url = https://github.com/temporalio/sdk-core.git

--- a/README.md
+++ b/README.md
@@ -9,10 +9,29 @@ execute asynchronous long-running business logic in a scalable and resilient way
 
 "Temporal Python SDK" is the framework for authoring workflows and activities using the Python programming language.
 
-In addition to this documentation, see:
+Also see:
 
 * [Code Samples](https://github.com/temporalio/samples-python)
 * [API Documentation](https://python.temporal.io)
+
+In addition to features common across all Temporal SDKs, the Python SDK also has the following interesting features:
+
+**Type Safe**
+
+This library uses the latest typing and MyPy support with generics to ensure all calls can be typed. For example,
+starting a workflow with an `int` parameter when it accepts a `str` parameter would cause MyPy to fail.
+
+**Different Activity Types**
+
+The activity worker has been developed to work with `async def`, threaded, and multiprocess activities. While
+`async def` activities are the easiest and recommended, care has been taken to make heartbeating and cancellation also
+work across threads/processes.
+
+**Custom `asyncio` Event Loop**
+
+The workflow implementation basically turns `async def` functions into workflows backed by a distributed, fault-tolerant
+event loop. This means task management, sleep, cancellation, etc have all been developed to seamlessly integrate with
+`asyncio` concepts.
 
 **⚠️ UNDER DEVELOPMENT**
 
@@ -20,7 +39,6 @@ The Python SDK is under development. There are no compatibility guarantees nor p
 
 Currently missing features:
 
-* Async activity support (in client or worker)
 * Support for Windows arm, macOS arm (i.e. M1), Linux arm, and Linux x64 glibc < 2.31.
 * Full documentation
 
@@ -143,6 +161,15 @@ Some things to note about the above code:
   does the same thing
 * Clients can have many more options not shown here (e.g. data converters and interceptors)
 * A string can be used instead of the method reference to call a workflow by name (e.g. if defined in another language)
+
+Clients also provide a shallow copy of their config for use in making slightly different clients backed by the same
+connection. For instance, given the `client` above, this is how to have a client in another namespace:
+
+```python
+config = client.config()
+config["namespace"] = "my-other-namespace"
+other_ns_client = Client(**config)
+```
 
 #### Data Conversion
 
@@ -395,6 +422,16 @@ protect against cancellation. The following tasks, when cancelled, perform a Tem
 When the workflow itself is requested to cancel, `Task.cancel` is called on the main workflow task. Therefore,
 `asyncio.CancelledError` can be caught in order to handle the cancel gracefully.
 
+Workflows follow `asyncio` cancellation rules exactly which can cause confusion among Python developers. Cancelling a
+task doesn't always cancel the thing it created. For example, given
+`task = asyncio.create_task(workflow.start_child_workflow(...`, calling `task.cancel` does not cancel the child
+workflow, it only cancels the starting of it, which has no effect if it has already started. However, cancelling the
+result of `handle = await workflow.start_child_workflow(...` or
+`task = asyncio.create_task(workflow.execute_child_workflow(...` _does_ cancel the child workflow.
+
+Also, due to Temporal rules, a cancellation request is a state not an event. Therefore, repeated cancellation requests
+are not delivered, only the first. If the workflow chooses swallow a cancellation, it cannot be requested again.
+
 #### Workflow Utilities
 
 While running in a workflow, in addition to features documented elsewhere, the following items are available from the
@@ -407,11 +444,15 @@ While running in a workflow, in addition to features documented elsewhere, the f
 
 #### Exceptions
 
-TODO
+* Workflows can raise exceptions to fail the workflow
+* Using `temporalio.exceptions.ApplicationError`, exceptions can be marked as non-retryable or include details
 
 #### External Workflows
 
-TODO
+* `workflow.get_external_workflow_handle()` inside a workflow returns a handle to interact with another workflow
+* `workflow.get_external_workflow_handle_for()` can be used instead for a type safe handle
+* `await signal()` can be called on the handle to signal the external workflow
+* `await cancel()` can be called on the handle to send a cancel to the external workflow
 
 ### Activities
 
@@ -531,54 +572,135 @@ The Python SDK is built to work with Python 3.7 and newer. It is built using
 
 ### Building
 
-- Install the system dependencies:
+#### Prepare
 
-  - Python >=3.7
-  - [pipx](https://github.com/pypa/pipx#install-pipx) (only needed for installing the two dependencies below)
-  - [poetry](https://github.com/python-poetry/poetry) `pipx install poetry`
-  - [poe](https://github.com/nat-n/poethepoet) `pipx install poethepoet`
+To build the SDK from source for use as a dependency, the following prerequisites are required:
 
-- Clone the project recursively:
+* [Python](https://www.python.org/) >= 3.7
+* [Rust](https://www.rust-lang.org/)
+* [pipx](https://github.com/pypa/pipx#install-pipx) (only needed for installing the two dependencies below)
+* [poetry](https://github.com/python-poetry/poetry) `pipx install poetry`
+* [poe](https://github.com/nat-n/poethepoet) `pipx install poethepoet`
 
-  ```bash
-  git clone --recursive git@github.com:temporalio/sdk-python.git
-  cd sdk-python
-  ```
+With the prerequisites installed, first clone the SDK repository recursively:
 
-TODO(cretz): The rest
+```bash
+git clone --recursive https://github.com/temporalio/sdk-python.git
+cd sdk-python
+```
 
-### Local development environment
+Use `poetry` to install the dependencies with `--no-root` to not install this package:
 
-- Install the system dependencies:
+```bash
+poetry install --no-root
+```
 
-  - Python >=3.7
-  - [pipx](https://github.com/pypa/pipx#install-pipx) (only needed for installing the two dependencies below)
-  - [poetry](https://github.com/python-poetry/poetry) `pipx install poetry`
-  - [poe](https://github.com/nat-n/poethepoet) `pipx install poethepoet`
+Now generate the protobuf code:
 
-- Use a local virtual env environment (helps IDEs and Windows):
+```bash
+poe gen-protos
+```
 
-  ```bash
-  poetry config virtualenvs.in-project true
-  ```
+#### Build
 
-- Install the package dependencies (requires Rust):
+Now perform the release build:
 
-  ```bash
-  poetry install
-  ```
+```bash
+poetry build
+```
 
-- Build the project (requires Rust):
+This will take a while because Rust will compile the core project in release mode (see "Local SDK development
+environment" for the quicker approach to local development).
 
-  ```bash
-  poe build-develop
-  ```
+The compiled wheel doesn't have the exact right tags yet for use, so run this script to fix it:
 
-- Run the tests (requires Go):
+```bash
+poe fix-wheel
+```
 
-  ```bash
-  poe test
-  ```
+The `whl` wheel file in `dist/` is now ready to use.
+
+#### Use
+
+The wheel can now be installed into any virtual environment.
+
+For example,
+[create a virtual environment](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments)
+somewhere and then run the following inside the virtual environment:
+
+```bash
+pip install /path/to/cloned/sdk-python/dist/*.whl
+```
+
+Create this Python file at `example.py`:
+
+```python
+import asyncio
+from temporalio import workflow, activity
+from temporalio.client import Client
+from temporalio.worker import Worker
+
+@workflow.defn
+class SayHello:
+    @workflow.run
+    async def run(self, name: str) -> str:
+        return f"Hello, {name}!"
+
+async def main():
+    client = await Client.connect("http://localhost:7233")
+    async with Worker(client, task_queue="my-task-queue", workflows=[SayHello]):
+        result = await client.execute_workflow(SayHello.run, "Temporal",
+            id="my-workflow-id", task_queue="my-task-queue")
+        print(f"Result: {result}")
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Assuming there is a [local Temporal server](https://docs.temporal.io/docs/server/quick-install/) running, executing the
+file with `python` (or `python3` if necessary) will give:
+
+    Result: Hello, Temporal!
+
+### Local SDK development environment
+
+For local development, it is often quicker to use debug builds and a local virtual environment.
+
+While not required, it often helps IDEs if we put the virtual environment `.venv` directory in the project itself. This
+can be configured system-wide via:
+
+```bash
+poetry config virtualenvs.in-project true
+```
+
+Now perform the same steps as the "Prepare" section above by installing the prerequisites, cloning the project,
+installing dependencies, and generating the protobuf code:
+
+```bash
+git clone --recursive https://github.com/temporalio/sdk-python.git
+cd sdk-python
+poetry install --no-root
+poe gen-protos
+```
+
+Now compile the Rust extension in develop mode which is quicker than release mode:
+
+```bash
+poe build-develop
+```
+
+That step can be repeated for any Rust changes made.
+
+The environment is now ready to develop in.
+
+#### Testing
+
+Tests currently require [Go](https://go.dev/) to be installed since they use an embedded Temporal server as a library.
+With `Go` installed, run the following to execute tests:
+
+```bash
+poe test
+```
 
 ### Style
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ execute asynchronous long-running business logic in a scalable and resilient way
 
 "Temporal Python SDK" is the framework for authoring workflows and activities using the Python programming language.
 
-In addition to this documentation, see the [samples](https://github.com/temporalio/samples-python) repository for code
-examples.
+In addition to this documentation, see:
+
+* [Code Samples](https://github.com/temporalio/samples-python)
+* [API Documentation](https://python.temporal.io)
 
 **⚠️ UNDER DEVELOPMENT**
 
@@ -35,7 +37,7 @@ These steps can be followed to use with a virtual environment and `pip`:
   * Needed because older versions of `pip` may not pick the right wheel
 * Install Temporal SDK - `python -m pip install temporalio`
 
-The SDK is now ready for use.
+The SDK is now ready for use. To build from source, see "Building" near the end of this documentation.
 
 ### Implementing a Workflow
 
@@ -526,6 +528,24 @@ respect cancellation, the shutdown may never complete.
 
 The Python SDK is built to work with Python 3.7 and newer. It is built using
 [SDK Core](https://github.com/temporalio/sdk-core/) which is written in Rust.
+
+### Building
+
+- Install the system dependencies:
+
+  - Python >=3.7
+  - [pipx](https://github.com/pypa/pipx#install-pipx) (only needed for installing the two dependencies below)
+  - [poetry](https://github.com/python-poetry/poetry) `pipx install poetry`
+  - [poe](https://github.com/nat-n/poethepoet) `pipx install poethepoet`
+
+- Clone the project recursively:
+
+  ```bash
+  git clone --recursive git@github.com:temporalio/sdk-python.git
+  cd sdk-python
+  ```
+
+TODO(cretz): The rest
 
 ### Local development environment
 

--- a/temporalio/common.py
+++ b/temporalio/common.py
@@ -1,5 +1,7 @@
 """Common code used in the Temporal SDK."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import IntEnum
@@ -34,6 +36,21 @@ class RetryPolicy:
 
     non_retryable_error_types: Optional[Iterable[str]] = None
     """List of error types that are not retryable."""
+
+    @staticmethod
+    def from_proto(proto: temporalio.api.common.v1.RetryPolicy) -> RetryPolicy:
+        """Create a retry policy from the proto object."""
+        return RetryPolicy(
+            initial_interval=proto.initial_interval.ToTimedelta(),
+            backoff_coefficient=proto.backoff_coefficient,
+            maximum_interval=proto.maximum_interval.ToTimedelta()
+            if proto.HasField("maximum_interval")
+            else None,
+            maximum_attempts=proto.maximum_attempts,
+            non_retryable_error_types=proto.non_retryable_error_types
+            if proto.non_retryable_error_types
+            else None,
+        )
 
     def apply_to_proto(self, proto: temporalio.api.common.v1.RetryPolicy) -> None:
         """Apply the fields in this policy to the given proto object."""

--- a/temporalio/worker/workflow.py
+++ b/temporalio/worker/workflow.py
@@ -35,10 +35,6 @@ logger = logging.getLogger(__name__)
 # Set to true to log all activations and completions
 LOG_PROTOS = False
 
-# Maximum amount of seconds a thread can run a workflow activation before a
-# deadlock is assumed
-DEADLOCK_TIMEOUT_SECONDS = 2
-
 
 class _WorkflowWorker:
     def __init__(
@@ -74,6 +70,9 @@ class _WorkflowWorker:
                 self._interceptor_classes.append(interceptor_class)
         self._type_hint_eval_str = type_hint_eval_str
         self._running_workflows: Dict[str, WorkflowInstance] = {}
+
+        # Unless there's a truthy TEMPORAL_DEBUG env var, set deadlock timeout
+        self._deadlock_timeout_seconds = None if os.environ.get("TEMPORAL_DEBUG") else 2
 
         # Validate and build workflow dict
         self._workflows: Dict[str, temporalio.workflow._Definition] = {}
@@ -116,7 +115,7 @@ class _WorkflowWorker:
     async def _handle_activation(
         self, act: temporalio.bridge.proto.workflow_activation.WorkflowActivation
     ) -> None:
-        global LOG_PROTOS, DEADLOCK_TIMEOUT_SECONDS
+        global LOG_PROTOS
 
         # Build default success completion (e.g. remove-job-only activations)
         completion = (
@@ -155,11 +154,11 @@ class _WorkflowWorker:
                 # Wait for deadlock timeout and set commands if successful
                 try:
                     completion = await asyncio.wait_for(
-                        activate_task, DEADLOCK_TIMEOUT_SECONDS
+                        activate_task, self._deadlock_timeout_seconds
                     )
                 except asyncio.TimeoutError:
                     raise RuntimeError(
-                        f"Potential deadlock detected, workflow didn't yield within {DEADLOCK_TIMEOUT_SECONDS} second(s)"
+                        f"Potential deadlock detected, workflow didn't yield within {self._deadlock_timeout_seconds} second(s)"
                     )
         except Exception as err:
             logger.exception(
@@ -252,6 +251,9 @@ class _WorkflowWorker:
             else None,
             namespace=self._namespace,
             parent=parent,
+            retry_policy=temporalio.common.RetryPolicy.from_proto(start.retry_policy)
+            if start.HasField("retry_policy")
+            else None,
             run_id=act.run_id,
             run_timeout=start.workflow_run_timeout.ToTimedelta()
             if start.HasField("workflow_run_timeout")

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -266,6 +266,7 @@ class Info:
     execution_timeout: Optional[timedelta]
     namespace: str
     parent: Optional[ParentInfo]
+    retry_policy: Optional[temporalio.common.RetryPolicy]
     run_id: str
     run_timeout: Optional[timedelta]
     start_time: datetime
@@ -275,14 +276,17 @@ class Info:
     workflow_type: str
 
     # TODO(cretz): memo
-    # TODO(cretz): retry_policy
     # TODO(cretz): search_attributes
 
     def _logger_details(self) -> Mapping[str, Any]:
         return {
+            # TODO(cretz): worker ID?
+            "attempt": self.attempt,
+            "namespace": self.namespace,
+            "run_id": self.run_id,
+            "task_queue": self.task_queue,
             "workflow_id": self.workflow_id,
             "workflow_type": self.workflow_type,
-            # TODO(cretz): more
         }
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -50,7 +50,6 @@ async def test_start_id_reuse(client: Client, worker: ExternalWorker):
         task_queue=worker.task_queue,
     )
     assert "some result" == await handle.result()
-
     # Run again with reject duplicate
     with pytest.raises(RPCError) as err:
         handle = await client.start_workflow(
@@ -396,7 +395,3 @@ async def test_tls_config(tls_client: Optional[Client]):
         )
     )
     assert resp.namespace_info.name == tls_client.namespace
-
-
-# TODO:
-# * Payload codec applying to results and errors

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -264,7 +264,3 @@ def test_workflow_defn_bad_dynamic():
     with pytest.raises(RuntimeError) as err:
         workflow.query(dynamic=True)(BadDynamic.some_dynamic2)
     assert "must have 3 arguments" in str(err.value)
-
-
-# TODO:
-# * Only positional params on run, signal, and query


### PR DESCRIPTION
## What was changed

* More README docs including build docs (opened #40 for more docstring docs)
* Update core submodule origin URL to be http instead of SSH
* Add retry policy to workflow info
* Support disabling deadlock timeout with env var
* Track tasks ourselves to since Python only uses weak references for them (see https://bugs.python.org/issue21163 and others)
* Give descriptive task names in Python versions that support it
* Many more tests

## Checklist

1. Closes #28
2. Closes #39