### PR TITLE
Remove direct grpcio dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -910,7 +910,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "bd43bfd7047120f2bf06b0fe6558fa6ac9a21255b632c2b847e6c6509fcf12de"
+content-hash = "f33749f7d00b89981e98eaf3f235893d82c206c3a5391f5d1209d4a6242e726a"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,11 @@ script = "build.py"
 dacite = "^1.6.0"
 # Due to grpcio binaries not supporting macOS ARM currently (see
 # https://github.com/grpc/grpc/issues/27506,
-# https://github.com/grpc/grpc/issues/28387, etc) we have to use non-binary. But
-# until Poetry 1.2 is released and
-# https://github.com/python-poetry/poetry/pull/5609 merged, we have to specify
-# the tarball instead.
-grpcio = [
-  { version = "^1.46.0", markers = "sys_platform != 'darwin' or platform_machine != 'arm64'" },
-  { url = "https://files.pythonhosted.org/packages/61/dd/d8eda79197a1275e06621850775c7bbf34a141ff92553754dde4e87d7551/grpcio-1.46.3.tar.gz", markers = "sys_platform == 'darwin' and platform_machine == 'arm64'" },
-]
+# https://github.com/grpc/grpc/issues/28387, etc) we would have to use
+# non-binary. But until Poetry 1.2 is released and
+# https://github.com/python-poetry/poetry/pull/5609 merged, it is not supported.
+# We cannot use a direct dependency because PyPI fails the upload.
+grpcio = "^1.46.3"
 protobuf = "^3.20.1"
 python = "^3.7"
 types-protobuf = "^3.19.21"


### PR DESCRIPTION
## What was changed

Removed the direct grpcio dependency and rely on PyPI version still.

## Why?

In issue #46, we tried to mitigate the lack of `grpcio` mac arm support by referencing a dependency directly. While this is ok during build time, it is not when uploading to PyPI:

> Invalid value for requires_dist. Error: Can't have direct dependency: 'grpcio @ https://files.pythonhosted.org/packages/61/dd/d8eda79197a1275e06621850775c7bbf34a141ff92553754dde4e87d7551/grpcio-1.46.3.tar.gz ; sys_platform == "darwin" and platform_machine

So we have removed it. Preliminary tests show this may end up building from source for `grpcio` when `pip` gets it as a dependency. This is the best we can do right now.