### PR TITLE
Fix CI Rust cache working directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: temporalio/bridge
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python }}
@@ -93,6 +95,8 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: temporalio/bridge
       - uses: actions/setup-python@v1
         with:
           python-version: "3.10"


### PR DESCRIPTION
## What was changed

Fix CI Rust cache working directory

## Why?

Was not caching because cargo root wasn't repo root