### PR TITLE
Remove macOS-ARM support from missing features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The Python SDK is under development. There are no compatibility guarantees nor p
 
 Currently missing features:
 
-* Support for Windows arm, macOS arm (i.e. M1), Linux arm, and Linux x64 glibc < 2.31.
+* Support for Windows arm, Linux arm, and Linux x64 glibc < 2.31.
 * Full documentation
 
 ## Quick Start


### PR DESCRIPTION
Last week's 0.1a2 release added support for ARM-based (e.g., M1) Macs, but the README.md file still lists this as a missing feature, and this PR corrects it.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
