### PR TITLE
Remove activity info retry policy

### DIFF
--- a/temporalio/activity.py
+++ b/temporalio/activity.py
@@ -86,7 +86,6 @@ class Info:
     heartbeat_details: Iterable[Any]
     heartbeat_timeout: Optional[timedelta]
     is_local: bool
-    retry_policy: Optional[temporalio.common.RetryPolicy]
     schedule_to_close_timeout: Optional[timedelta]
     scheduled_time: datetime
     start_to_close_timeout: Optional[timedelta]

--- a/temporalio/worker/activity.py
+++ b/temporalio/worker/activity.py
@@ -342,20 +342,19 @@ class _ActivityWorker:
                     start.current_attempt_scheduled_time
                 ),
                 heartbeat_details=heartbeat_details,
-                heartbeat_timeout=start.heartbeat_timeout.ToTimedelta()
+                heartbeat_timeout=_proto_to_non_zero_timedelta(start.heartbeat_timeout)
                 if start.HasField("heartbeat_timeout")
                 else None,
                 is_local=start.is_local,
-                retry_policy=temporalio.common.RetryPolicy.from_proto(
-                    start.retry_policy
+                schedule_to_close_timeout=_proto_to_non_zero_timedelta(
+                    start.schedule_to_close_timeout
                 )
-                if start.HasField("retry_policy")
-                else None,
-                schedule_to_close_timeout=start.schedule_to_close_timeout.ToTimedelta()
                 if start.HasField("schedule_to_close_timeout")
                 else None,
                 scheduled_time=_proto_to_datetime(start.scheduled_time),
-                start_to_close_timeout=start.start_to_close_timeout.ToTimedelta()
+                start_to_close_timeout=_proto_to_non_zero_timedelta(
+                    start.start_to_close_timeout
+                )
                 if start.HasField("start_to_close_timeout")
                 else None,
                 started_time=_proto_to_datetime(start.started_time),
@@ -796,3 +795,11 @@ def _proto_to_datetime(
 ) -> datetime:
     # Protobuf doesn't set the timezone but we want to
     return ts.ToDatetime().replace(tzinfo=timezone.utc)
+
+
+def _proto_to_non_zero_timedelta(
+    dur: google.protobuf.duration_pb2.Duration,
+) -> Optional[timedelta]:
+    if dur.nanos == 0 and dur.seconds == 0:
+        return None
+    return dur.ToTimedelta()

--- a/tests/worker/test_activity.py
+++ b/tests/worker/test_activity.py
@@ -98,14 +98,18 @@ async def test_activity_info(client: Client, worker: ExternalWorker):
     assert info.activity_id
     assert info.activity_type == "capture_info"
     assert info.attempt == 1
+    assert abs(
+        info.current_attempt_scheduled_time - datetime.now(timezone.utc)
+    ) < timedelta(seconds=5)
     assert info.heartbeat_details == []
-    assert info.heartbeat_timeout == timedelta()
-    # TODO(cretz): Broken?
-    # assert info.schedule_to_close_timeout is None
+    assert info.heartbeat_timeout is None
+    assert not info.is_local
+    assert info.schedule_to_close_timeout is None
     assert abs(info.scheduled_time - datetime.now(timezone.utc)) < timedelta(seconds=5)
     assert info.start_to_close_timeout == timedelta(seconds=4)
     assert abs(info.started_time - datetime.now(timezone.utc)) < timedelta(seconds=5)
     assert info.task_queue == result.act_task_queue
+    assert info.task_token
     assert info.workflow_id == result.handle.id
     assert info.workflow_namespace == client.namespace
     assert info.workflow_run_id == result.handle.first_execution_run_id


### PR DESCRIPTION
## What was changed

* Remove `activity.info().retry_policy`
* Cleanup other activity info timedelta values

## Why?

* The retry policy that comes from the server for activity tasks _is not_ the one passed in when executing the activity
* Durations coming back from Core are unfortunately present-but-zero for not-present timeouts

## Checklist

1. Closes #62
