### PR TITLE
Type refactoring and activity class/method support

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,8 @@ Some things to note about the above code:
   capabilities are needed.
 * Local activities work very similarly except the functions are `workflow.start_local_activity()` and
   `workflow.execute_local_activity()`
+* Activities that are defined on a callable class (i.e. with `__call__`) or a class method, have to use that callable
+  as the first parameter. That means a do-nothing class may need to be instantiated to have access to the callable.
 
 #### Invoking Child Workflows
 
@@ -482,6 +484,13 @@ Some things to note about activity definitions:
 * Long running activities should regularly heartbeat and handle cancellation
 * Activities can only have positional arguments. Best practice is to only take a single argument that is an
   object/dataclass of fields that can be added to as needed.
+* Callable classes (i.e. with `__call__` defined) may be defined as activities, but then an _instance_ of the class must
+  be what is registered with the worker which will be used during invocation. Similarly, an _instance_ of the class must
+  be what is used to call the activity from the workflow even though that instance is a dummy instance and is not the
+  one used for invocation.
+* Methods on classes may be defined as activities. Similar to callable classes above, it is the method reference that
+  must be used during worker registration and during workflow invocation. The latter means that there will likely need
+  to be a dummy instance during workflow to have access to the method reference.
 
 #### Types of Activities
 

--- a/README.md
+++ b/README.md
@@ -379,8 +379,12 @@ Some things to note about the above code:
   capabilities are needed.
 * Local activities work very similarly except the functions are `workflow.start_local_activity()` and
   `workflow.execute_local_activity()`
-* Activities that are defined on a callable class (i.e. with `__call__`) or a class method, have to use that callable
-  as the first parameter. That means a do-nothing class may need to be instantiated to have access to the callable.
+* Activities can be methods of a class. Invokers should use `workflow.start_activity_method()`,
+  `workflow.execute_activity_method()`, `workflow.start_local_activity_method()`, and
+  `workflow.execute_local_activity_method()` instead.
+* Activities can callable classes (i.e. that define `__call__`). Invokers should use `workflow.start_activity_class()`,
+  `workflow.execute_activity_class()`, `workflow.start_local_activity_class()`, and
+  `workflow.execute_local_activity_class()` instead.
 
 #### Invoking Child Workflows
 
@@ -467,7 +471,7 @@ While running in a workflow, in addition to features documented elsewhere, the f
 
 #### Definition
 
-Activities are functions decorated with `@activity.defn` like so:
+Activities are decorated with `@activity.defn` like so:
 
 ```python
 from temporalio import activity
@@ -484,13 +488,10 @@ Some things to note about activity definitions:
 * Long running activities should regularly heartbeat and handle cancellation
 * Activities can only have positional arguments. Best practice is to only take a single argument that is an
   object/dataclass of fields that can be added to as needed.
-* Callable classes (i.e. with `__call__` defined) may be defined as activities, but then an _instance_ of the class must
-  be what is registered with the worker which will be used during invocation. Similarly, an _instance_ of the class must
-  be what is used to call the activity from the workflow even though that instance is a dummy instance and is not the
-  one used for invocation.
-* Methods on classes may be defined as activities. Similar to callable classes above, it is the method reference that
-  must be used during worker registration and during workflow invocation. The latter means that there will likely need
-  to be a dummy instance during workflow to have access to the method reference.
+* Activities can be defined on methods instead of top-level functions. This allows the instance to carry state that an
+  activity may need (e.g. a DB connection). The instance method should be what is registered with the worker.
+* Activities can also be defined on callable classes (i.e. classes with `__call__`). An instance of the class should be
+  what is registered with the worker.
 
 #### Types of Activities
 
@@ -730,6 +731,6 @@ poe test
   * We use [Black](https://github.com/psf/black) for formatting, so that takes precedence
   * In tests and example code, can import individual classes/functions to make it more readable. Can also do this for
     rarely in library code for some Python common items (e.g. `dataclass` or `partial`), but not allowed to do this for
-    any `temporalio` packages or any classes/functions that aren't clear when unqualified.
+    any `temporalio` packages (except `temporalio.types`) or any classes/functions that aren't clear when unqualified.
   * We allow relative imports for private packages
   * We allow `@staticmethod`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ html-output = "build/apidocs"
 intersphinx = ["https://docs.python.org/3/objects.inv", "https://googleapis.dev/python/protobuf/latest/objects.inv"]
 privacy = [
   "PRIVATE:temporalio.bridge",
+  "PRIVATE:temporalio.types",
   "HIDDEN:temporalio.worker.activity",
   "HIDDEN:temporalio.worker.interceptor",
   "HIDDEN:temporalio.worker.worker",

--- a/temporalio/activity.py
+++ b/temporalio/activity.py
@@ -27,7 +27,6 @@ from typing import (
     NoReturn,
     Optional,
     Tuple,
-    TypeVar,
     overload,
 )
 
@@ -35,20 +34,20 @@ import temporalio.api.common.v1
 import temporalio.common
 import temporalio.exceptions
 
-ActivityFunc = TypeVar("ActivityFunc", bound=Callable[..., Any])
+from .types import CallableType
 
 
 @overload
-def defn(fn: ActivityFunc) -> ActivityFunc:
+def defn(fn: CallableType) -> CallableType:
     ...
 
 
 @overload
-def defn(*, name: str) -> Callable[[ActivityFunc], ActivityFunc]:
+def defn(*, name: str) -> Callable[[CallableType], CallableType]:
     ...
 
 
-def defn(fn: Optional[ActivityFunc] = None, *, name: Optional[str] = None):
+def defn(fn: Optional[CallableType] = None, *, name: Optional[str] = None):
     """Decorator for activity functions.
 
     Activities can be async or non-async.
@@ -58,7 +57,7 @@ def defn(fn: Optional[ActivityFunc] = None, *, name: Optional[str] = None):
         name: Name to use for the activity. Defaults to function ``__name__``.
     """
 
-    def with_name(name: str, fn: ActivityFunc) -> ActivityFunc:
+    def with_name(name: str, fn: CallableType) -> CallableType:
         # This performs validation
         _Definition._apply_to_callable(fn, name)
         return fn

--- a/temporalio/client.py
+++ b/temporalio/client.py
@@ -37,11 +37,17 @@ import temporalio.workflow
 import temporalio.workflow_service
 from temporalio.workflow_service import RetryConfig, RPCError, RPCStatusCode, TLSConfig
 
-LocalParamType = TypeVar("LocalParamType")
-LocalReturnType = TypeVar("LocalReturnType")
-WorkflowClass = TypeVar("WorkflowClass")
-WorkflowReturnType = TypeVar("WorkflowReturnType")
-MultiParamSpec = ParamSpec("MultiParamSpec")
+from .types import (
+    LocalReturnType,
+    MethodAsyncNoParam,
+    MethodAsyncSingleParam,
+    MethodSyncOrAsyncNoParam,
+    MethodSyncOrAsyncSingleParam,
+    MultiParamSpec,
+    ParamType,
+    ReturnType,
+    SelfType,
+)
 
 
 class Client:
@@ -198,7 +204,7 @@ class Client:
     @overload
     async def start_workflow(
         self,
-        workflow: Callable[[WorkflowClass], Awaitable[WorkflowReturnType]],
+        workflow: MethodAsyncNoParam[SelfType, ReturnType],
         *,
         id: str,
         task_queue: str,
@@ -213,17 +219,15 @@ class Client:
         header: Optional[Mapping[str, Any]] = None,
         start_signal: Optional[str] = None,
         start_signal_args: Iterable[Any] = [],
-    ) -> WorkflowHandle[WorkflowClass, WorkflowReturnType]:
+    ) -> WorkflowHandle[SelfType, ReturnType]:
         ...
 
     # Overload for single-param workflow
     @overload
     async def start_workflow(
         self,
-        workflow: Callable[
-            [WorkflowClass, LocalParamType], Awaitable[WorkflowReturnType]
-        ],
-        arg: LocalParamType,
+        workflow: MethodAsyncSingleParam[SelfType, ParamType, ReturnType],
+        arg: ParamType,
         *,
         id: str,
         task_queue: str,
@@ -238,7 +242,7 @@ class Client:
         header: Optional[Mapping[str, Any]] = None,
         start_signal: Optional[str] = None,
         start_signal_args: Iterable[Any] = [],
-    ) -> WorkflowHandle[WorkflowClass, WorkflowReturnType]:
+    ) -> WorkflowHandle[SelfType, ReturnType]:
         ...
 
     # Overload for multi-param workflow
@@ -246,7 +250,7 @@ class Client:
     async def start_workflow(
         self,
         workflow: Callable[
-            Concatenate[WorkflowClass, MultiParamSpec], Awaitable[WorkflowReturnType]
+            Concatenate[SelfType, MultiParamSpec], Awaitable[ReturnType]
         ],
         *,
         args: Iterable[Any],
@@ -263,7 +267,7 @@ class Client:
         header: Optional[Mapping[str, Any]] = None,
         start_signal: Optional[str] = None,
         start_signal_args: Iterable[Any] = [],
-    ) -> WorkflowHandle[WorkflowClass, WorkflowReturnType]:
+    ) -> WorkflowHandle[SelfType, ReturnType]:
         ...
 
     # Overload for string-name workflow
@@ -377,7 +381,7 @@ class Client:
     @overload
     async def execute_workflow(
         self,
-        workflow: Callable[[WorkflowClass], Awaitable[WorkflowReturnType]],
+        workflow: MethodAsyncNoParam[SelfType, ReturnType],
         *,
         id: str,
         task_queue: str,
@@ -392,17 +396,15 @@ class Client:
         header: Optional[Mapping[str, Any]] = None,
         start_signal: Optional[str] = None,
         start_signal_args: Iterable[Any] = [],
-    ) -> WorkflowReturnType:
+    ) -> ReturnType:
         ...
 
     # Overload for single-param workflow
     @overload
     async def execute_workflow(
         self,
-        workflow: Callable[
-            [WorkflowClass, LocalParamType], Awaitable[WorkflowReturnType]
-        ],
-        arg: LocalParamType,
+        workflow: MethodAsyncSingleParam[SelfType, ParamType, ReturnType],
+        arg: ParamType,
         *,
         id: str,
         task_queue: str,
@@ -417,7 +419,7 @@ class Client:
         header: Optional[Mapping[str, Any]] = None,
         start_signal: Optional[str] = None,
         start_signal_args: Iterable[Any] = [],
-    ) -> WorkflowReturnType:
+    ) -> ReturnType:
         ...
 
     # Overload for multi-param workflow
@@ -425,7 +427,7 @@ class Client:
     async def execute_workflow(
         self,
         workflow: Callable[
-            Concatenate[WorkflowClass, MultiParamSpec], Awaitable[WorkflowReturnType]
+            Concatenate[SelfType, MultiParamSpec], Awaitable[ReturnType]
         ],
         *,
         args: Iterable[Any],
@@ -442,7 +444,7 @@ class Client:
         header: Optional[Mapping[str, Any]] = None,
         start_signal: Optional[str] = None,
         start_signal_args: Iterable[Any] = [],
-    ) -> WorkflowReturnType:
+    ) -> ReturnType:
         ...
 
     # Overload for string-name workflow
@@ -546,14 +548,14 @@ class Client:
     def get_workflow_handle_for(
         self,
         workflow: Union[
-            Callable[[WorkflowClass, LocalParamType], Awaitable[WorkflowReturnType]],
-            Callable[[WorkflowClass], Awaitable[WorkflowReturnType]],
+            MethodAsyncNoParam[SelfType, ReturnType],
+            MethodAsyncSingleParam[SelfType, Any, ReturnType],
         ],
         workflow_id: str,
         *,
         run_id: Optional[str] = None,
         first_execution_run_id: Optional[str] = None,
-    ) -> WorkflowHandle[WorkflowClass, WorkflowReturnType]:
+    ) -> WorkflowHandle[SelfType, ReturnType]:
         """Get a typed workflow handle to an existing workflow by its ID.
 
         This is the same as :py:meth:`get_workflow_handle` but typed. Note, the
@@ -641,7 +643,7 @@ class ClientConfig(TypedDict, total=False):
     type_hint_eval_str: bool
 
 
-class WorkflowHandle(Generic[WorkflowClass, WorkflowReturnType]):
+class WorkflowHandle(Generic[SelfType, ReturnType]):
     """Handle for interacting with a workflow.
 
     This is usually created via :py:meth:`Client.get_workflow_handle` or
@@ -714,7 +716,7 @@ class WorkflowHandle(Generic[WorkflowClass, WorkflowReturnType]):
         """
         return self._first_execution_run_id
 
-    async def result(self, *, follow_runs: bool = True) -> WorkflowReturnType:
+    async def result(self, *, follow_runs: bool = True) -> ReturnType:
         """Wait for result of the workflow.
 
         This will use :py:attr:`result_run_id` if present to base the result on.
@@ -772,10 +774,10 @@ class WorkflowHandle(Generic[WorkflowClass, WorkflowReturnType]):
                     type_hints,
                 )
                 if not results:
-                    return cast(WorkflowReturnType, None)
+                    return cast(ReturnType, None)
                 elif len(results) > 1:
                     warnings.warn(f"Expected single result, got {len(results)}")
-                return cast(WorkflowReturnType, results[0])
+                return cast(ReturnType, results[0])
             elif event.HasField("workflow_execution_failed_event_attributes"):
                 fail_attr = event.workflow_execution_failed_event_attributes
                 # Follow execution
@@ -891,9 +893,7 @@ class WorkflowHandle(Generic[WorkflowClass, WorkflowReturnType]):
     @overload
     async def query(
         self,
-        query: Callable[
-            [WorkflowClass], Union[Awaitable[LocalReturnType], LocalReturnType]
-        ],
+        query: MethodSyncOrAsyncNoParam[SelfType, LocalReturnType],
         *,
         reject_condition: Optional[temporalio.common.QueryRejectCondition] = None,
     ) -> LocalReturnType:
@@ -903,11 +903,8 @@ class WorkflowHandle(Generic[WorkflowClass, WorkflowReturnType]):
     @overload
     async def query(
         self,
-        query: Callable[
-            [WorkflowClass, LocalParamType],
-            Union[Awaitable[LocalReturnType], LocalReturnType],
-        ],
-        arg: LocalParamType,
+        query: MethodSyncOrAsyncSingleParam[SelfType, ParamType, LocalReturnType],
+        arg: ParamType,
         *,
         reject_condition: Optional[temporalio.common.QueryRejectCondition] = None,
     ) -> LocalReturnType:
@@ -918,7 +915,7 @@ class WorkflowHandle(Generic[WorkflowClass, WorkflowReturnType]):
     async def query(
         self,
         query: Callable[
-            Concatenate[WorkflowClass, MultiParamSpec],
+            Concatenate[SelfType, MultiParamSpec],
             Union[Awaitable[LocalReturnType], LocalReturnType],
         ],
         *,
@@ -1005,7 +1002,7 @@ class WorkflowHandle(Generic[WorkflowClass, WorkflowReturnType]):
     @overload
     async def signal(
         self,
-        signal: Callable[[WorkflowClass], Union[Awaitable[None], None]],
+        signal: MethodSyncOrAsyncNoParam[SelfType, None],
     ) -> None:
         ...
 
@@ -1013,8 +1010,8 @@ class WorkflowHandle(Generic[WorkflowClass, WorkflowReturnType]):
     @overload
     async def signal(
         self,
-        signal: Callable[[WorkflowClass, LocalParamType], Union[Awaitable[None], None]],
-        arg: LocalParamType,
+        signal: MethodSyncOrAsyncSingleParam[SelfType, ParamType, None],
+        arg: ParamType,
     ) -> None:
         ...
 
@@ -1023,7 +1020,7 @@ class WorkflowHandle(Generic[WorkflowClass, WorkflowReturnType]):
     async def signal(
         self,
         signal: Callable[
-            Concatenate[WorkflowClass, MultiParamSpec], Union[Awaitable[None], None]
+            Concatenate[SelfType, MultiParamSpec], Union[Awaitable[None], None]
         ],
         *,
         args: Iterable[Any],

--- a/temporalio/types.py
+++ b/temporalio/types.py
@@ -1,0 +1,134 @@
+"""Advanced types."""
+
+from typing import Any, Awaitable, Callable, Type, TypeVar, Union
+
+from typing_extensions import ParamSpec, Protocol
+
+AnyType = TypeVar("AnyType")
+ClassType = TypeVar("ClassType", bound=Type)
+SelfType = TypeVar("SelfType")
+ParamType = TypeVar("ParamType")
+ReturnType = TypeVar("ReturnType", covariant=True)
+LocalReturnType = TypeVar("LocalReturnType", covariant=True)
+CallableType = TypeVar("CallableType", bound=Callable[..., Any])
+CallableAsyncType = TypeVar("CallableAsyncType", bound=Callable[..., Awaitable[Any]])
+CallableSyncOrAsyncReturnNoneType = TypeVar(
+    "CallableSyncOrAsyncReturnNoneType",
+    bound=Callable[..., Union[None, Awaitable[None]]],
+)
+MultiParamSpec = ParamSpec("MultiParamSpec")
+
+
+ProtocolParamType = TypeVar("ProtocolParamType", contravariant=True)
+ProtocolReturnType = TypeVar("ProtocolReturnType", covariant=True)
+ProtocolSelfType = TypeVar("ProtocolSelfType", contravariant=True)
+
+
+class CallableAsyncNoParam(Protocol[ProtocolReturnType]):
+    """Generic callable type."""
+
+    def __call__(self) -> Awaitable[ProtocolReturnType]:
+        """Generic callable type callback."""
+        ...
+
+
+class CallableSyncNoParam(Protocol[ProtocolReturnType]):
+    """Generic callable type."""
+
+    def __call__(self) -> ProtocolReturnType:
+        """Generic callable type callback."""
+        ...
+
+
+class CallableAsyncSingleParam(Protocol[ProtocolParamType, ProtocolReturnType]):
+    """Generic callable type."""
+
+    def __call__(self, __arg: ProtocolParamType) -> Awaitable[ProtocolReturnType]:
+        """Generic callable type callback."""
+        ...
+
+
+class CallableSyncSingleParam(Protocol[ProtocolParamType, ProtocolReturnType]):
+    """Generic callable type."""
+
+    def __call__(self, __arg: ProtocolParamType) -> ProtocolReturnType:
+        """Generic callable type callback."""
+        ...
+
+
+class MethodAsyncNoParam(Protocol[ProtocolSelfType, ProtocolReturnType]):
+    """Generic callable type."""
+
+    def __call__(__self, self: ProtocolSelfType) -> Awaitable[ProtocolReturnType]:
+        """Generic callable type callback."""
+        ...
+
+
+class MethodSyncNoParam(Protocol[ProtocolSelfType, ProtocolReturnType]):
+    """Generic callable type."""
+
+    def __call__(__self, self: ProtocolSelfType) -> ProtocolReturnType:
+        """Generic callable type callback."""
+        ...
+
+
+class MethodAsyncSingleParam(
+    Protocol[ProtocolSelfType, ProtocolParamType, ProtocolReturnType]
+):
+    """Generic callable type."""
+
+    def __call__(
+        __self, self: ProtocolSelfType, __arg: ProtocolParamType
+    ) -> Awaitable[ProtocolReturnType]:
+        """Generic callable type callback."""
+        ...
+
+
+class MethodSyncSingleParam(
+    Protocol[ProtocolSelfType, ProtocolParamType, ProtocolReturnType]
+):
+    """Generic callable type."""
+
+    def __call__(
+        __self, self: ProtocolSelfType, __arg: ProtocolParamType
+    ) -> ProtocolReturnType:
+        """Generic callable type callback."""
+        ...
+
+
+class MethodSyncOrAsyncNoParam(Protocol[ProtocolSelfType, ProtocolReturnType]):
+    """Generic callable type."""
+
+    def __call__(
+        __self, self: ProtocolSelfType
+    ) -> Union[ProtocolReturnType, Awaitable[ProtocolReturnType]]:
+        """Generic callable type callback."""
+        ...
+
+
+class MethodSyncOrAsyncSingleParam(
+    Protocol[ProtocolSelfType, ProtocolParamType, ProtocolReturnType]
+):
+    """Generic callable type."""
+
+    def __call__(
+        __self, self: ProtocolSelfType, __param: ProtocolParamType
+    ) -> Union[ProtocolReturnType, Awaitable[ProtocolReturnType]]:
+        """Generic callable type callback."""
+        ...
+
+
+# TODO(cretz): Open MyPy bug on this, see https://gitter.im/python/typing?at=62cc24c5904f20479ac0c854
+
+# class CallableAsyncMultiParam(Protocol[ReturnType]):
+#     def __call__(self, *__args: Any) -> Awaitable[ReturnType]:
+#         ...
+# class CallableSyncMultiParam(Protocol[ReturnType]):
+#     def __call__(self, *__args: Any) -> ReturnType:
+#         ...
+# class MethodAsyncMultiParam(Protocol[SelfType, ReturnType]):
+#     def __call__(__self, self: SelfType, *__args: Any) -> Awaitable[ReturnType]:
+#         ...
+
+# TODO(cretz): Does not work, see https://github.com/python/mypy/issues/11855
+# MethodAsyncMultiParam = Callable[Concatenate[SelfType, MultiParamSpec], Awaitable[ReturnType]]

--- a/temporalio/worker/activity.py
+++ b/temporalio/worker/activity.py
@@ -267,7 +267,7 @@ class _ActivityWorker:
                 )
 
             # Setup events
-            if not inspect.iscoroutinefunction(activity_def.fn):
+            if not activity_def.is_async:
                 running_activity.sync = True
                 # If we're in a thread-pool executor we can use threading events
                 # otherwise we must use manager events
@@ -521,7 +521,8 @@ class _ActivityInboundImpl(ActivityInboundInterceptor):
 
     async def execute_activity(self, input: ExecuteActivityInput) -> Any:
         # Handle synchronous activity
-        if not inspect.iscoroutinefunction(input.fn):
+        is_async = inspect.iscoroutinefunction(input.fn) or inspect.iscoroutinefunction(input.fn.__call__)  # type: ignore
+        if not is_async:
             # We execute a top-level function via the executor. It is top-level
             # because it needs to be picklable. Also, by default Python does not
             # propagate contextvars into executor futures so we don't either

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -27,39 +27,52 @@ from typing import (
     Optional,
     Tuple,
     Type,
-    TypeVar,
     Union,
     cast,
     overload,
 )
 
-from typing_extensions import Concatenate, Literal, ParamSpec, TypedDict
+from typing_extensions import Concatenate, Literal, TypedDict
 
 import temporalio.bridge.proto.child_workflow
 import temporalio.bridge.proto.workflow_commands
 import temporalio.common
 import temporalio.exceptions
 
-WorkflowClass = TypeVar("WorkflowClass", bound=Type)
-ExternalWorkflowClass = TypeVar("ExternalWorkflowClass")
-LocalParamType = TypeVar("LocalParamType")
-ActivityReturnType = TypeVar("ActivityReturnType")
-WorkflowReturnType = TypeVar("WorkflowReturnType")
-MultiParamSpec = ParamSpec("MultiParamSpec")
-T = TypeVar("T")
+from .types import (
+    AnyType,
+    CallableAsyncNoParam,
+    CallableAsyncSingleParam,
+    CallableAsyncType,
+    CallableSyncNoParam,
+    CallableSyncOrAsyncReturnNoneType,
+    CallableSyncSingleParam,
+    CallableType,
+    ClassType,
+    MethodAsyncNoParam,
+    MethodAsyncSingleParam,
+    MethodSyncNoParam,
+    MethodSyncOrAsyncNoParam,
+    MethodSyncOrAsyncSingleParam,
+    MethodSyncSingleParam,
+    MultiParamSpec,
+    ParamType,
+    ReturnType,
+    SelfType,
+)
 
 
 @overload
-def defn(cls: WorkflowClass) -> WorkflowClass:
+def defn(cls: ClassType) -> ClassType:
     ...
 
 
 @overload
-def defn(*, name: str) -> Callable[[WorkflowClass], WorkflowClass]:
+def defn(*, name: str) -> Callable[[ClassType], ClassType]:
     ...
 
 
-def defn(cls: Optional[WorkflowClass] = None, *, name: Optional[str] = None):
+def defn(cls: Optional[ClassType] = None, *, name: Optional[str] = None):
     """Decorator for workflow classes.
 
     This must be set on any registered workflow class (it is ignored if on a
@@ -70,7 +83,7 @@ def defn(cls: Optional[WorkflowClass] = None, *, name: Optional[str] = None):
         name: Name to use for the workflow. Defaults to class ``__name__``.
     """
 
-    def with_name(name: str, cls: WorkflowClass) -> WorkflowClass:
+    def with_name(name: str, cls: ClassType) -> ClassType:
         # This performs validation
         _Definition._apply_to_class(cls, name)
         return cls
@@ -84,10 +97,7 @@ def defn(cls: Optional[WorkflowClass] = None, *, name: Optional[str] = None):
     return with_name(cls.__name__, cls)
 
 
-WorkflowRunFunc = TypeVar("WorkflowRunFunc", bound=Callable[..., Awaitable[Any]])
-
-
-def run(fn: WorkflowRunFunc) -> WorkflowRunFunc:
+def run(fn: CallableAsyncType) -> CallableAsyncType:
     """Decorator for the workflow run method.
 
     This must be set on one and only one async method defined on the same class
@@ -113,30 +123,27 @@ def run(fn: WorkflowRunFunc) -> WorkflowRunFunc:
     return fn
 
 
-WorkflowSignalFunc = TypeVar(
-    "WorkflowSignalFunc", bound=Callable[..., Union[None, Awaitable[None]]]
-)
-
-
 @overload
-def signal(fn: WorkflowSignalFunc) -> WorkflowSignalFunc:
+def signal(fn: CallableSyncOrAsyncReturnNoneType) -> CallableSyncOrAsyncReturnNoneType:
     ...
 
 
 @overload
-def signal(*, name: str) -> Callable[[WorkflowSignalFunc], WorkflowSignalFunc]:
+def signal(
+    *, name: str
+) -> Callable[[CallableSyncOrAsyncReturnNoneType], CallableSyncOrAsyncReturnNoneType]:
     ...
 
 
 @overload
 def signal(
     *, dynamic: Literal[True]
-) -> Callable[[WorkflowSignalFunc], WorkflowSignalFunc]:
+) -> Callable[[CallableSyncOrAsyncReturnNoneType], CallableSyncOrAsyncReturnNoneType]:
     ...
 
 
 def signal(
-    fn: Optional[WorkflowSignalFunc] = None,
+    fn: Optional[CallableSyncOrAsyncReturnNoneType] = None,
     *,
     name: Optional[str] = None,
     dynamic: Optional[bool] = False,
@@ -162,7 +169,9 @@ def signal(
             present.
     """
 
-    def with_name(name: Optional[str], fn: WorkflowSignalFunc) -> WorkflowSignalFunc:
+    def with_name(
+        name: Optional[str], fn: CallableSyncOrAsyncReturnNoneType
+    ) -> CallableSyncOrAsyncReturnNoneType:
         if not name:
             _assert_dynamic_signature(fn)
         # TODO(cretz): Validate type attributes?
@@ -178,28 +187,23 @@ def signal(
     return with_name(fn.__name__, fn)
 
 
-WorkflowQueryFunc = TypeVar("WorkflowQueryFunc", bound=Callable[..., Any])
-
-
 @overload
-def query(fn: WorkflowQueryFunc) -> WorkflowQueryFunc:
+def query(fn: CallableType) -> CallableType:
     ...
 
 
 @overload
-def query(*, name: str) -> Callable[[WorkflowQueryFunc], WorkflowQueryFunc]:
+def query(*, name: str) -> Callable[[CallableType], CallableType]:
     ...
 
 
 @overload
-def query(
-    *, dynamic: Literal[True]
-) -> Callable[[WorkflowQueryFunc], WorkflowQueryFunc]:
+def query(*, dynamic: Literal[True]) -> Callable[[CallableType], CallableType]:
     ...
 
 
 def query(
-    fn: Optional[WorkflowQueryFunc] = None,
+    fn: Optional[CallableType] = None,
     *,
     name: Optional[str] = None,
     dynamic: Optional[bool] = False,
@@ -225,7 +229,7 @@ def query(
             present.
     """
 
-    def with_name(name: Optional[str], fn: WorkflowQueryFunc) -> WorkflowQueryFunc:
+    def with_name(name: Optional[str], fn: CallableType) -> CallableType:
         if not name:
             _assert_dynamic_signature(fn)
         # TODO(cretz): Validate type attributes?
@@ -831,16 +835,16 @@ class _QueryDefinition:
 # See https://mypy.readthedocs.io/en/latest/runtime_troubles.html#using-classes-that-are-generic-in-stubs-but-not-at-runtime
 if TYPE_CHECKING:
 
-    class _AsyncioTask(asyncio.Task[T]):
+    class _AsyncioTask(asyncio.Task[AnyType]):
         pass
 
 else:
 
-    class _AsyncioTask(Generic[T], asyncio.Task):
+    class _AsyncioTask(Generic[AnyType], asyncio.Task):
         pass
 
 
-class ActivityHandle(_AsyncioTask[ActivityReturnType]):
+class ActivityHandle(_AsyncioTask[ReturnType]):
     """Handle returned from :py:func:`start_activity` and
     :py:func:`start_local_activity`.
 
@@ -882,7 +886,7 @@ class ActivityConfig(TypedDict, total=False):
 # Overload for async no-param activity
 @overload
 def start_activity(
-    activity: Callable[[], Awaitable[ActivityReturnType]],
+    activity: CallableAsyncNoParam[ReturnType],
     *,
     activity_id: Optional[str] = None,
     task_queue: Optional[str] = None,
@@ -892,14 +896,14 @@ def start_activity(
     heartbeat_timeout: Optional[timedelta] = None,
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityHandle[ActivityReturnType]:
+) -> ActivityHandle[ReturnType]:
     ...
 
 
 # Overload for sync no-param activity
 @overload
 def start_activity(
-    activity: Callable[[], ActivityReturnType],
+    activity: CallableSyncNoParam[ReturnType],
     *,
     activity_id: Optional[str] = None,
     task_queue: Optional[str] = None,
@@ -909,15 +913,15 @@ def start_activity(
     heartbeat_timeout: Optional[timedelta] = None,
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityHandle[ActivityReturnType]:
+) -> ActivityHandle[ReturnType]:
     ...
 
 
 # Overload for async single-param activity
 @overload
 def start_activity(
-    activity: Callable[[LocalParamType], Awaitable[ActivityReturnType]],
-    arg: LocalParamType,
+    activity: CallableAsyncSingleParam[ParamType, ReturnType],
+    arg: ParamType,
     *,
     activity_id: Optional[str] = None,
     task_queue: Optional[str] = None,
@@ -927,15 +931,15 @@ def start_activity(
     heartbeat_timeout: Optional[timedelta] = None,
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityHandle[ActivityReturnType]:
+) -> ActivityHandle[ReturnType]:
     ...
 
 
 # Overload for sync single-param activity
 @overload
 def start_activity(
-    activity: Callable[[LocalParamType], ActivityReturnType],
-    arg: LocalParamType,
+    activity: CallableSyncSingleParam[ParamType, ReturnType],
+    arg: ParamType,
     *,
     activity_id: Optional[str] = None,
     task_queue: Optional[str] = None,
@@ -945,14 +949,14 @@ def start_activity(
     heartbeat_timeout: Optional[timedelta] = None,
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityHandle[ActivityReturnType]:
+) -> ActivityHandle[ReturnType]:
     ...
 
 
 # Overload for async multi-param activity
 @overload
 def start_activity(
-    activity: Callable[..., Awaitable[ActivityReturnType]],
+    activity: Callable[..., Awaitable[ReturnType]],
     *,
     args: Iterable[Any],
     activity_id: Optional[str] = None,
@@ -963,14 +967,14 @@ def start_activity(
     heartbeat_timeout: Optional[timedelta] = None,
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityHandle[ActivityReturnType]:
+) -> ActivityHandle[ReturnType]:
     ...
 
 
 # Overload for sync multi-param activity
 @overload
 def start_activity(
-    activity: Callable[..., ActivityReturnType],
+    activity: Callable[..., ReturnType],
     *,
     args: Iterable[Any],
     activity_id: Optional[str] = None,
@@ -981,7 +985,7 @@ def start_activity(
     heartbeat_timeout: Optional[timedelta] = None,
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityHandle[ActivityReturnType]:
+) -> ActivityHandle[ReturnType]:
     ...
 
 
@@ -1065,7 +1069,7 @@ def start_activity(
 # Overload for async no-param activity
 @overload
 async def execute_activity(
-    activity: Callable[[], Awaitable[ActivityReturnType]],
+    activity: CallableAsyncNoParam[ReturnType],
     *,
     activity_id: Optional[str] = None,
     task_queue: Optional[str] = None,
@@ -1075,14 +1079,14 @@ async def execute_activity(
     heartbeat_timeout: Optional[timedelta] = None,
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityReturnType:
+) -> ReturnType:
     ...
 
 
 # Overload for sync no-param activity
 @overload
 async def execute_activity(
-    activity: Callable[[], ActivityReturnType],
+    activity: CallableSyncNoParam[ReturnType],
     *,
     activity_id: Optional[str] = None,
     task_queue: Optional[str] = None,
@@ -1092,15 +1096,15 @@ async def execute_activity(
     heartbeat_timeout: Optional[timedelta] = None,
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityReturnType:
+) -> ReturnType:
     ...
 
 
 # Overload for async single-param activity
 @overload
 async def execute_activity(
-    activity: Callable[[LocalParamType], Awaitable[ActivityReturnType]],
-    arg: LocalParamType,
+    activity: CallableAsyncSingleParam[ParamType, ReturnType],
+    arg: ParamType,
     *,
     activity_id: Optional[str] = None,
     task_queue: Optional[str] = None,
@@ -1110,15 +1114,15 @@ async def execute_activity(
     heartbeat_timeout: Optional[timedelta] = None,
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityReturnType:
+) -> ReturnType:
     ...
 
 
 # Overload for sync single-param activity
 @overload
 async def execute_activity(
-    activity: Callable[[LocalParamType], ActivityReturnType],
-    arg: LocalParamType,
+    activity: CallableSyncSingleParam[ParamType, ReturnType],
+    arg: ParamType,
     *,
     activity_id: Optional[str] = None,
     task_queue: Optional[str] = None,
@@ -1128,14 +1132,14 @@ async def execute_activity(
     heartbeat_timeout: Optional[timedelta] = None,
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityReturnType:
+) -> ReturnType:
     ...
 
 
 # Overload for async multi-param activity
 @overload
 async def execute_activity(
-    activity: Callable[..., Awaitable[ActivityReturnType]],
+    activity: Callable[..., Awaitable[ReturnType]],
     *,
     args: Iterable[Any],
     activity_id: Optional[str] = None,
@@ -1146,14 +1150,14 @@ async def execute_activity(
     heartbeat_timeout: Optional[timedelta] = None,
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityReturnType:
+) -> ReturnType:
     ...
 
 
 # Overload for sync multi-param activity
 @overload
 async def execute_activity(
-    activity: Callable[..., ActivityReturnType],
+    activity: Callable[..., ReturnType],
     *,
     args: Iterable[Any],
     activity_id: Optional[str] = None,
@@ -1164,7 +1168,7 @@ async def execute_activity(
     heartbeat_timeout: Optional[timedelta] = None,
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityReturnType:
+) -> ReturnType:
     ...
 
 
@@ -1201,9 +1205,563 @@ async def execute_activity(
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
 ) -> Any:
-    """Start a local workflow and wait for completion.
+    """Start an activity and wait for completion.
 
     This is a shortcut for ``await`` :py:meth:`start_activity`.
+    """
+    # We call the runtime directly instead of top-level start_activity to ensure
+    # we don't miss new parameters
+    return await _Runtime.current().workflow_start_activity(
+        activity,
+        *temporalio.common._arg_or_args(arg, args),
+        activity_id=activity_id,
+        task_queue=task_queue,
+        schedule_to_close_timeout=schedule_to_close_timeout,
+        schedule_to_start_timeout=schedule_to_start_timeout,
+        start_to_close_timeout=start_to_close_timeout,
+        heartbeat_timeout=heartbeat_timeout,
+        retry_policy=retry_policy,
+        cancellation_type=cancellation_type,
+    )
+
+
+# Overload for async no-param activity
+@overload
+def start_activity_class(
+    activity: Type[CallableAsyncNoParam[ReturnType]],
+    *,
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for sync no-param activity
+@overload
+def start_activity_class(
+    activity: Type[CallableSyncNoParam[ReturnType]],
+    *,
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for async single-param activity
+@overload
+def start_activity_class(
+    activity: Type[CallableAsyncSingleParam[ParamType, ReturnType]],
+    arg: ParamType,
+    *,
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for sync single-param activity
+@overload
+def start_activity_class(
+    activity: Type[CallableSyncSingleParam[ParamType, ReturnType]],
+    arg: ParamType,
+    *,
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for async multi-param activity
+@overload
+def start_activity_class(
+    activity: Type[Callable[..., Awaitable[ReturnType]]],
+    *,
+    args: Iterable[Any],
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for sync multi-param activity
+@overload
+def start_activity_class(
+    activity: Type[Callable[..., ReturnType]],
+    *,
+    args: Iterable[Any],
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+def start_activity_class(
+    activity: Type[Callable],
+    arg: Any = temporalio.common._arg_unset,
+    *,
+    args: Iterable[Any] = [],
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[Any]:
+    """Start an activity from a callable class.
+
+    See :py:meth:`start_activity` for parameter and return details.
+    """
+    return _Runtime.current().workflow_start_activity(
+        activity,
+        *temporalio.common._arg_or_args(arg, args),
+        activity_id=activity_id,
+        task_queue=task_queue,
+        schedule_to_close_timeout=schedule_to_close_timeout,
+        schedule_to_start_timeout=schedule_to_start_timeout,
+        start_to_close_timeout=start_to_close_timeout,
+        heartbeat_timeout=heartbeat_timeout,
+        retry_policy=retry_policy,
+        cancellation_type=cancellation_type,
+    )
+
+
+# Overload for async no-param activity
+@overload
+async def execute_activity_class(
+    activity: Type[CallableAsyncNoParam[ReturnType]],
+    *,
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for sync no-param activity
+@overload
+async def execute_activity_class(
+    activity: Type[CallableSyncNoParam[ReturnType]],
+    *,
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for async single-param activity
+@overload
+async def execute_activity_class(
+    activity: Type[CallableAsyncSingleParam[ParamType, ReturnType]],
+    arg: ParamType,
+    *,
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for sync single-param activity
+@overload
+async def execute_activity_class(
+    activity: Type[CallableSyncSingleParam[ParamType, ReturnType]],
+    arg: ParamType,
+    *,
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for async multi-param activity
+@overload
+async def execute_activity_class(
+    activity: Type[Callable[..., Awaitable[ReturnType]]],
+    *,
+    args: Iterable[Any],
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for sync multi-param activity
+@overload
+async def execute_activity_class(
+    activity: Type[Callable[..., ReturnType]],
+    *,
+    args: Iterable[Any],
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+async def execute_activity_class(
+    activity: Type[Callable],
+    arg: Any = temporalio.common._arg_unset,
+    *,
+    args: Iterable[Any] = [],
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> Any:
+    """Start an activity from a callable class and wait for completion.
+
+    This is a shortcut for ``await`` :py:meth:`start_activity_class`.
+    """
+    return await _Runtime.current().workflow_start_activity(
+        activity,
+        *temporalio.common._arg_or_args(arg, args),
+        activity_id=activity_id,
+        task_queue=task_queue,
+        schedule_to_close_timeout=schedule_to_close_timeout,
+        schedule_to_start_timeout=schedule_to_start_timeout,
+        start_to_close_timeout=start_to_close_timeout,
+        heartbeat_timeout=heartbeat_timeout,
+        retry_policy=retry_policy,
+        cancellation_type=cancellation_type,
+    )
+
+
+# Overload for async no-param activity
+@overload
+def start_activity_method(
+    activity: MethodAsyncNoParam[SelfType, ReturnType],
+    *,
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for sync no-param activity
+@overload
+def start_activity_method(
+    activity: MethodSyncNoParam[SelfType, ReturnType],
+    *,
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for async single-param activity
+@overload
+def start_activity_method(
+    activity: MethodAsyncSingleParam[SelfType, ParamType, ReturnType],
+    arg: ParamType,
+    *,
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for sync single-param activity
+@overload
+def start_activity_method(
+    activity: MethodSyncSingleParam[SelfType, ParamType, ReturnType],
+    arg: ParamType,
+    *,
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for async multi-param activity
+@overload
+def start_activity_method(
+    activity: Callable[Concatenate[SelfType, MultiParamSpec], Awaitable[ReturnType]],
+    *,
+    args: Iterable[Any],
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for sync multi-param activity
+@overload
+def start_activity_method(
+    activity: Callable[Concatenate[SelfType, MultiParamSpec], ReturnType],
+    *,
+    args: Iterable[Any],
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+def start_activity_method(
+    activity: Callable,
+    arg: Any = temporalio.common._arg_unset,
+    *,
+    args: Iterable[Any] = [],
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[Any]:
+    """Start an activity from a method.
+
+    See :py:meth:`start_activity` for parameter and return details.
+    """
+    return _Runtime.current().workflow_start_activity(
+        activity,
+        *temporalio.common._arg_or_args(arg, args),
+        activity_id=activity_id,
+        task_queue=task_queue,
+        schedule_to_close_timeout=schedule_to_close_timeout,
+        schedule_to_start_timeout=schedule_to_start_timeout,
+        start_to_close_timeout=start_to_close_timeout,
+        heartbeat_timeout=heartbeat_timeout,
+        retry_policy=retry_policy,
+        cancellation_type=cancellation_type,
+    )
+
+
+# Overload for async no-param activity
+@overload
+async def execute_activity_method(
+    activity: MethodAsyncNoParam[SelfType, ReturnType],
+    *,
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for sync no-param activity
+@overload
+async def execute_activity_method(
+    activity: MethodSyncNoParam[SelfType, ReturnType],
+    *,
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for async single-param activity
+@overload
+async def execute_activity_method(
+    activity: MethodAsyncSingleParam[SelfType, ParamType, ReturnType],
+    arg: ParamType,
+    *,
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for sync single-param activity
+@overload
+async def execute_activity_method(
+    activity: MethodSyncSingleParam[SelfType, ParamType, ReturnType],
+    arg: ParamType,
+    *,
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for async multi-param activity
+@overload
+async def execute_activity_method(
+    activity: Callable[Concatenate[SelfType, MultiParamSpec], Awaitable[ReturnType]],
+    *,
+    args: Iterable[Any],
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for sync multi-param activity
+@overload
+async def execute_activity_method(
+    activity: Callable[Concatenate[SelfType, MultiParamSpec], ReturnType],
+    *,
+    args: Iterable[Any],
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+async def execute_activity_method(
+    activity: Callable,
+    arg: Any = temporalio.common._arg_unset,
+    *,
+    args: Iterable[Any] = [],
+    activity_id: Optional[str] = None,
+    task_queue: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    heartbeat_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> Any:
+    """Start an activity from a method and wait for completion.
+
+    This is a shortcut for ``await`` :py:meth:`start_activity_method`.
     """
     # We call the runtime directly instead of top-level start_activity to ensure
     # we don't miss new parameters
@@ -1238,7 +1796,7 @@ class LocalActivityConfig(TypedDict, total=False):
 # Overload for async no-param activity
 @overload
 def start_local_activity(
-    activity: Callable[[], Awaitable[ActivityReturnType]],
+    activity: CallableAsyncNoParam[ReturnType],
     *,
     activity_id: Optional[str] = None,
     schedule_to_close_timeout: Optional[timedelta] = None,
@@ -1247,14 +1805,14 @@ def start_local_activity(
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     local_retry_threshold: Optional[timedelta] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityHandle[ActivityReturnType]:
+) -> ActivityHandle[ReturnType]:
     ...
 
 
 # Overload for sync no-param activity
 @overload
 def start_local_activity(
-    activity: Callable[[], ActivityReturnType],
+    activity: CallableSyncNoParam[ReturnType],
     *,
     activity_id: Optional[str] = None,
     schedule_to_close_timeout: Optional[timedelta] = None,
@@ -1263,15 +1821,15 @@ def start_local_activity(
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     local_retry_threshold: Optional[timedelta] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityHandle[ActivityReturnType]:
+) -> ActivityHandle[ReturnType]:
     ...
 
 
 # Overload for async single-param activity
 @overload
 def start_local_activity(
-    activity: Callable[[LocalParamType], Awaitable[ActivityReturnType]],
-    arg: LocalParamType,
+    activity: CallableAsyncSingleParam[ParamType, ReturnType],
+    arg: ParamType,
     *,
     activity_id: Optional[str] = None,
     schedule_to_close_timeout: Optional[timedelta] = None,
@@ -1280,15 +1838,15 @@ def start_local_activity(
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     local_retry_threshold: Optional[timedelta] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityHandle[ActivityReturnType]:
+) -> ActivityHandle[ReturnType]:
     ...
 
 
 # Overload for sync single-param activity
 @overload
 def start_local_activity(
-    activity: Callable[[LocalParamType], ActivityReturnType],
-    arg: LocalParamType,
+    activity: CallableSyncSingleParam[ParamType, ReturnType],
+    arg: ParamType,
     *,
     activity_id: Optional[str] = None,
     schedule_to_close_timeout: Optional[timedelta] = None,
@@ -1297,14 +1855,14 @@ def start_local_activity(
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     local_retry_threshold: Optional[timedelta] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityHandle[ActivityReturnType]:
+) -> ActivityHandle[ReturnType]:
     ...
 
 
 # Overload for async multi-param activity
 @overload
 def start_local_activity(
-    activity: Callable[..., Awaitable[ActivityReturnType]],
+    activity: Callable[..., Awaitable[ReturnType]],
     *,
     args: Iterable[Any],
     activity_id: Optional[str] = None,
@@ -1314,14 +1872,14 @@ def start_local_activity(
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     local_retry_threshold: Optional[timedelta] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityHandle[ActivityReturnType]:
+) -> ActivityHandle[ReturnType]:
     ...
 
 
 # Overload for sync multi-param activity
 @overload
 def start_local_activity(
-    activity: Callable[..., ActivityReturnType],
+    activity: Callable[..., ReturnType],
     *,
     args: Iterable[Any],
     activity_id: Optional[str] = None,
@@ -1331,7 +1889,7 @@ def start_local_activity(
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     local_retry_threshold: Optional[timedelta] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityHandle[ActivityReturnType]:
+) -> ActivityHandle[ReturnType]:
     ...
 
 
@@ -1408,7 +1966,7 @@ def start_local_activity(
 # Overload for async no-param activity
 @overload
 async def execute_local_activity(
-    activity: Callable[[], Awaitable[ActivityReturnType]],
+    activity: CallableAsyncNoParam[ReturnType],
     *,
     activity_id: Optional[str] = None,
     schedule_to_close_timeout: Optional[timedelta] = None,
@@ -1417,14 +1975,14 @@ async def execute_local_activity(
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     local_retry_threshold: Optional[timedelta] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityReturnType:
+) -> ReturnType:
     ...
 
 
 # Overload for sync no-param activity
 @overload
 async def execute_local_activity(
-    activity: Callable[[], ActivityReturnType],
+    activity: CallableSyncNoParam[ReturnType],
     *,
     activity_id: Optional[str] = None,
     schedule_to_close_timeout: Optional[timedelta] = None,
@@ -1433,15 +1991,15 @@ async def execute_local_activity(
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     local_retry_threshold: Optional[timedelta] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityReturnType:
+) -> ReturnType:
     ...
 
 
 # Overload for async single-param activity
 @overload
 async def execute_local_activity(
-    activity: Callable[[LocalParamType], Awaitable[ActivityReturnType]],
-    arg: LocalParamType,
+    activity: CallableAsyncSingleParam[ParamType, ReturnType],
+    arg: ParamType,
     *,
     activity_id: Optional[str] = None,
     schedule_to_close_timeout: Optional[timedelta] = None,
@@ -1450,15 +2008,15 @@ async def execute_local_activity(
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     local_retry_threshold: Optional[timedelta] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityReturnType:
+) -> ReturnType:
     ...
 
 
 # Overload for sync single-param activity
 @overload
 async def execute_local_activity(
-    activity: Callable[[LocalParamType], ActivityReturnType],
-    arg: LocalParamType,
+    activity: CallableSyncSingleParam[ParamType, ReturnType],
+    arg: ParamType,
     *,
     activity_id: Optional[str] = None,
     schedule_to_close_timeout: Optional[timedelta] = None,
@@ -1467,14 +2025,14 @@ async def execute_local_activity(
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     local_retry_threshold: Optional[timedelta] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityReturnType:
+) -> ReturnType:
     ...
 
 
 # Overload for async multi-param activity
 @overload
 async def execute_local_activity(
-    activity: Callable[..., Awaitable[ActivityReturnType]],
+    activity: Callable[..., Awaitable[ReturnType]],
     *,
     args: Iterable[Any],
     activity_id: Optional[str] = None,
@@ -1484,14 +2042,14 @@ async def execute_local_activity(
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     local_retry_threshold: Optional[timedelta] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityReturnType:
+) -> ReturnType:
     ...
 
 
 # Overload for sync multi-param activity
 @overload
 async def execute_local_activity(
-    activity: Callable[..., ActivityReturnType],
+    activity: Callable[..., ReturnType],
     *,
     args: Iterable[Any],
     activity_id: Optional[str] = None,
@@ -1501,7 +2059,7 @@ async def execute_local_activity(
     retry_policy: Optional[temporalio.common.RetryPolicy] = None,
     local_retry_threshold: Optional[timedelta] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
-) -> ActivityReturnType:
+) -> ReturnType:
     ...
 
 
@@ -1536,7 +2094,7 @@ async def execute_local_activity(
     local_retry_threshold: Optional[timedelta] = None,
     cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
 ) -> Any:
-    """Start a local workflow and wait for completion.
+    """Start a local activity and wait for completion.
 
     This is a shortcut for ``await`` :py:meth:`start_local_activity`.
     """
@@ -1555,9 +2113,531 @@ async def execute_local_activity(
     )
 
 
-class ChildWorkflowHandle(
-    _AsyncioTask[WorkflowReturnType], Generic[ExternalWorkflowClass, WorkflowReturnType]
-):
+# Overload for async no-param activity
+@overload
+def start_local_activity_class(
+    activity: Type[CallableAsyncNoParam[ReturnType]],
+    *,
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for sync no-param activity
+@overload
+def start_local_activity_class(
+    activity: Type[CallableSyncNoParam[ReturnType]],
+    *,
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for async single-param activity
+@overload
+def start_local_activity_class(
+    activity: Type[CallableAsyncSingleParam[ParamType, ReturnType]],
+    arg: ParamType,
+    *,
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for sync single-param activity
+@overload
+def start_local_activity_class(
+    activity: Type[CallableSyncSingleParam[ParamType, ReturnType]],
+    arg: ParamType,
+    *,
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for async multi-param activity
+@overload
+def start_local_activity_class(
+    activity: Type[Callable[..., Awaitable[ReturnType]]],
+    *,
+    args: Iterable[Any],
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for sync multi-param activity
+@overload
+def start_local_activity_class(
+    activity: Type[Callable[..., ReturnType]],
+    *,
+    args: Iterable[Any],
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+def start_local_activity_class(
+    activity: Type[Callable],
+    arg: Any = temporalio.common._arg_unset,
+    *,
+    args: Iterable[Any] = [],
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[Any]:
+    """Start a local activity from a callable class.
+
+    See :py:meth:`start_local_activity` for parameter and return details.
+    """
+    return _Runtime.current().workflow_start_local_activity(
+        activity,
+        *temporalio.common._arg_or_args(arg, args),
+        activity_id=activity_id,
+        schedule_to_close_timeout=schedule_to_close_timeout,
+        schedule_to_start_timeout=schedule_to_start_timeout,
+        start_to_close_timeout=start_to_close_timeout,
+        retry_policy=retry_policy,
+        local_retry_threshold=local_retry_threshold,
+        cancellation_type=cancellation_type,
+    )
+
+
+# Overload for async no-param activity
+@overload
+async def execute_local_activity_class(
+    activity: Type[CallableAsyncNoParam[ReturnType]],
+    *,
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for sync no-param activity
+@overload
+async def execute_local_activity_class(
+    activity: Type[CallableSyncNoParam[ReturnType]],
+    *,
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for async single-param activity
+@overload
+async def execute_local_activity_class(
+    activity: Type[CallableAsyncSingleParam[ParamType, ReturnType]],
+    arg: ParamType,
+    *,
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for sync single-param activity
+@overload
+async def execute_local_activity_class(
+    activity: Type[CallableSyncSingleParam[ParamType, ReturnType]],
+    arg: ParamType,
+    *,
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for async multi-param activity
+@overload
+async def execute_local_activity_class(
+    activity: Type[Callable[..., Awaitable[ReturnType]]],
+    *,
+    args: Iterable[Any],
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for sync multi-param activity
+@overload
+async def execute_local_activity_class(
+    activity: Type[Callable[..., ReturnType]],
+    *,
+    args: Iterable[Any],
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+async def execute_local_activity_class(
+    activity: Type[Callable],
+    arg: Any = temporalio.common._arg_unset,
+    *,
+    args: Iterable[Any] = [],
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> Any:
+    """Start a local activity from a callable class and wait for completion.
+
+    This is a shortcut for ``await`` :py:meth:`start_local_activity_class`.
+    """
+    # We call the runtime directly instead of top-level start_local_activity to
+    # ensure we don't miss new parameters
+    return await _Runtime.current().workflow_start_local_activity(
+        activity,
+        *temporalio.common._arg_or_args(arg, args),
+        activity_id=activity_id,
+        schedule_to_close_timeout=schedule_to_close_timeout,
+        schedule_to_start_timeout=schedule_to_start_timeout,
+        start_to_close_timeout=start_to_close_timeout,
+        retry_policy=retry_policy,
+        local_retry_threshold=local_retry_threshold,
+        cancellation_type=cancellation_type,
+    )
+
+
+# Overload for async no-param activity
+@overload
+def start_local_activity_method(
+    activity: MethodAsyncNoParam[SelfType, ReturnType],
+    *,
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for sync no-param activity
+@overload
+def start_local_activity_method(
+    activity: MethodSyncNoParam[SelfType, ReturnType],
+    *,
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for async single-param activity
+@overload
+def start_local_activity_method(
+    activity: MethodAsyncSingleParam[SelfType, ParamType, ReturnType],
+    arg: ParamType,
+    *,
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for sync single-param activity
+@overload
+def start_local_activity_method(
+    activity: MethodSyncSingleParam[SelfType, ParamType, ReturnType],
+    arg: ParamType,
+    *,
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for async multi-param activity
+@overload
+def start_local_activity_method(
+    activity: Callable[Concatenate[SelfType, MultiParamSpec], Awaitable[ReturnType]],
+    *,
+    args: Iterable[Any],
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+# Overload for sync multi-param activity
+@overload
+def start_local_activity_method(
+    activity: Callable[Concatenate[SelfType, MultiParamSpec], ReturnType],
+    *,
+    args: Iterable[Any],
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[ReturnType]:
+    ...
+
+
+def start_local_activity_method(
+    activity: Callable,
+    arg: Any = temporalio.common._arg_unset,
+    *,
+    args: Iterable[Any] = [],
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ActivityHandle[Any]:
+    """Start a local activity from a method.
+
+    See :py:meth:`start_local_activity` for parameter and return details.
+    """
+    return _Runtime.current().workflow_start_local_activity(
+        activity,
+        *temporalio.common._arg_or_args(arg, args),
+        activity_id=activity_id,
+        schedule_to_close_timeout=schedule_to_close_timeout,
+        schedule_to_start_timeout=schedule_to_start_timeout,
+        start_to_close_timeout=start_to_close_timeout,
+        retry_policy=retry_policy,
+        local_retry_threshold=local_retry_threshold,
+        cancellation_type=cancellation_type,
+    )
+
+
+# Overload for async no-param activity
+@overload
+async def execute_local_activity_method(
+    activity: MethodAsyncNoParam[SelfType, ReturnType],
+    *,
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for sync no-param activity
+@overload
+async def execute_local_activity_method(
+    activity: MethodSyncNoParam[SelfType, ReturnType],
+    *,
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for async single-param activity
+@overload
+async def execute_local_activity_method(
+    activity: MethodAsyncSingleParam[SelfType, ParamType, ReturnType],
+    arg: ParamType,
+    *,
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for sync single-param activity
+@overload
+async def execute_local_activity_method(
+    activity: MethodSyncSingleParam[SelfType, ParamType, ReturnType],
+    arg: ParamType,
+    *,
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for async multi-param activity
+@overload
+async def execute_local_activity_method(
+    activity: Callable[Concatenate[SelfType, MultiParamSpec], Awaitable[ReturnType]],
+    *,
+    args: Iterable[Any],
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+# Overload for sync multi-param activity
+@overload
+async def execute_local_activity_method(
+    activity: Callable[Concatenate[SelfType, MultiParamSpec], ReturnType],
+    *,
+    args: Iterable[Any],
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> ReturnType:
+    ...
+
+
+async def execute_local_activity_method(
+    activity: Callable,
+    arg: Any = temporalio.common._arg_unset,
+    *,
+    args: Iterable[Any] = [],
+    activity_id: Optional[str] = None,
+    schedule_to_close_timeout: Optional[timedelta] = None,
+    schedule_to_start_timeout: Optional[timedelta] = None,
+    start_to_close_timeout: Optional[timedelta] = None,
+    retry_policy: Optional[temporalio.common.RetryPolicy] = None,
+    local_retry_threshold: Optional[timedelta] = None,
+    cancellation_type: ActivityCancellationType = ActivityCancellationType.TRY_CANCEL,
+) -> Any:
+    """Start a local activity from a method and wait for completion.
+
+    This is a shortcut for ``await`` :py:meth:`start_local_activity_method`.
+    """
+    # We call the runtime directly instead of top-level start_local_activity to
+    # ensure we don't miss new parameters
+    return await _Runtime.current().workflow_start_local_activity(
+        activity,
+        *temporalio.common._arg_or_args(arg, args),
+        activity_id=activity_id,
+        schedule_to_close_timeout=schedule_to_close_timeout,
+        schedule_to_start_timeout=schedule_to_start_timeout,
+        start_to_close_timeout=start_to_close_timeout,
+        retry_policy=retry_policy,
+        local_retry_threshold=local_retry_threshold,
+        cancellation_type=cancellation_type,
+    )
+
+
+class ChildWorkflowHandle(_AsyncioTask[ReturnType], Generic[SelfType, ReturnType]):
     """Handle for interacting with a child workflow.
 
     This is created via :py:func:`start_child_workflow`.
@@ -1578,7 +2658,15 @@ class ChildWorkflowHandle(
     @overload
     async def signal(
         self,
-        signal: Callable[[ExternalWorkflowClass], Union[Awaitable[None], None]],
+        signal: MethodSyncOrAsyncNoParam[SelfType, None],
+    ) -> None:
+        ...
+
+    @overload
+    async def signal(
+        self,
+        signal: MethodSyncOrAsyncSingleParam[SelfType, ParamType, None],
+        arg: ParamType,
     ) -> None:
         ...
 
@@ -1586,9 +2674,10 @@ class ChildWorkflowHandle(
     async def signal(
         self,
         signal: Callable[
-            [ExternalWorkflowClass, LocalParamType], Union[Awaitable[None], None]
+            Concatenate[SelfType, MultiParamSpec], Union[Awaitable[None], None]
         ],
-        arg: LocalParamType,
+        *,
+        args: Iterable[Any],
     ) -> None:
         ...
 
@@ -1677,7 +2766,7 @@ class ChildWorkflowConfig(TypedDict, total=False):
 # Overload for no-param workflow
 @overload
 async def start_child_workflow(
-    workflow: Callable[[ExternalWorkflowClass], Awaitable[WorkflowReturnType]],
+    workflow: MethodAsyncNoParam[SelfType, ReturnType],
     *,
     id: str,
     task_queue: Optional[str] = None,
@@ -1692,17 +2781,15 @@ async def start_child_workflow(
     cron_schedule: str = "",
     memo: Optional[Mapping[str, Any]] = None,
     search_attributes: Optional[temporalio.common.SearchAttributes] = None,
-) -> ChildWorkflowHandle[ExternalWorkflowClass, WorkflowReturnType]:
+) -> ChildWorkflowHandle[SelfType, ReturnType]:
     ...
 
 
 # Overload for single-param workflow
 @overload
 async def start_child_workflow(
-    workflow: Callable[
-        [ExternalWorkflowClass, LocalParamType], Awaitable[WorkflowReturnType]
-    ],
-    arg: LocalParamType,
+    workflow: MethodAsyncSingleParam[SelfType, ParamType, ReturnType],
+    arg: ParamType,
     *,
     id: str,
     task_queue: Optional[str] = None,
@@ -1717,17 +2804,14 @@ async def start_child_workflow(
     cron_schedule: str = "",
     memo: Optional[Mapping[str, Any]] = None,
     search_attributes: Optional[temporalio.common.SearchAttributes] = None,
-) -> ChildWorkflowHandle[ExternalWorkflowClass, WorkflowReturnType]:
+) -> ChildWorkflowHandle[SelfType, ReturnType]:
     ...
 
 
 # Overload for multi-param workflow
 @overload
 async def start_child_workflow(
-    workflow: Callable[
-        Concatenate[ExternalWorkflowClass, MultiParamSpec],
-        Awaitable[WorkflowReturnType],
-    ],
+    workflow: Callable[Concatenate[SelfType, MultiParamSpec], Awaitable[ReturnType]],
     *,
     args: Iterable[Any],
     id: str,
@@ -1743,7 +2827,7 @@ async def start_child_workflow(
     cron_schedule: str = "",
     memo: Optional[Mapping[str, Any]] = None,
     search_attributes: Optional[temporalio.common.SearchAttributes] = None,
-) -> ChildWorkflowHandle[ExternalWorkflowClass, WorkflowReturnType]:
+) -> ChildWorkflowHandle[SelfType, ReturnType]:
     ...
 
 
@@ -1840,7 +2924,7 @@ async def start_child_workflow(
 # Overload for no-param workflow
 @overload
 async def execute_child_workflow(
-    workflow: Callable[[ExternalWorkflowClass], Awaitable[WorkflowReturnType]],
+    workflow: MethodAsyncNoParam[SelfType, ReturnType],
     *,
     id: str,
     task_queue: Optional[str] = None,
@@ -1855,17 +2939,15 @@ async def execute_child_workflow(
     cron_schedule: str = "",
     memo: Optional[Mapping[str, Any]] = None,
     search_attributes: Optional[temporalio.common.SearchAttributes] = None,
-) -> WorkflowReturnType:
+) -> ReturnType:
     ...
 
 
 # Overload for single-param workflow
 @overload
 async def execute_child_workflow(
-    workflow: Callable[
-        [ExternalWorkflowClass, LocalParamType], Awaitable[WorkflowReturnType]
-    ],
-    arg: LocalParamType,
+    workflow: MethodAsyncSingleParam[SelfType, ParamType, ReturnType],
+    arg: ParamType,
     *,
     id: str,
     task_queue: Optional[str] = None,
@@ -1880,17 +2962,14 @@ async def execute_child_workflow(
     cron_schedule: str = "",
     memo: Optional[Mapping[str, Any]] = None,
     search_attributes: Optional[temporalio.common.SearchAttributes] = None,
-) -> WorkflowReturnType:
+) -> ReturnType:
     ...
 
 
 # Overload for multi-param workflow
 @overload
 async def execute_child_workflow(
-    workflow: Callable[
-        Concatenate[ExternalWorkflowClass, MultiParamSpec],
-        Awaitable[WorkflowReturnType],
-    ],
+    workflow: Callable[Concatenate[SelfType, MultiParamSpec], Awaitable[ReturnType]],
     *,
     args: Iterable[Any],
     id: str,
@@ -1906,7 +2985,7 @@ async def execute_child_workflow(
     cron_schedule: str = "",
     memo: Optional[Mapping[str, Any]] = None,
     search_attributes: Optional[temporalio.common.SearchAttributes] = None,
-) -> WorkflowReturnType:
+) -> ReturnType:
     ...
 
 
@@ -1979,7 +3058,7 @@ async def execute_child_workflow(
     return await handle
 
 
-class ExternalWorkflowHandle(Generic[ExternalWorkflowClass]):
+class ExternalWorkflowHandle(Generic[SelfType]):
     """Handle for interacting with an external workflow.
 
     This is created via :py:func:`get_external_workflow_handle` or
@@ -1999,17 +3078,15 @@ class ExternalWorkflowHandle(Generic[ExternalWorkflowClass]):
     @overload
     async def signal(
         self,
-        signal: Callable[[ExternalWorkflowClass], Union[Awaitable[None], None]],
+        signal: MethodSyncOrAsyncNoParam[SelfType, None],
     ) -> None:
         ...
 
     @overload
     async def signal(
         self,
-        signal: Callable[
-            [ExternalWorkflowClass, LocalParamType], Union[Awaitable[None], None]
-        ],
-        arg: LocalParamType,
+        signal: MethodSyncOrAsyncSingleParam[SelfType, ParamType, None],
+        arg: ParamType,
     ) -> None:
         ...
 
@@ -2070,13 +3147,12 @@ def get_external_workflow_handle(
 
 def get_external_workflow_handle_for(
     workflow: Union[
-        Callable[[ExternalWorkflowClass, LocalParamType], Awaitable[Any]],
-        Callable[[ExternalWorkflowClass], Awaitable[Any]],
+        MethodAsyncNoParam[SelfType, Any], MethodAsyncSingleParam[SelfType, Any, Any]
     ],
     workflow_id: str,
     *,
     run_id: Optional[str] = None,
-) -> ExternalWorkflowHandle[ExternalWorkflowClass]:
+) -> ExternalWorkflowHandle[SelfType]:
     """Get a typed workflow handle to an existing workflow by its ID.
 
     This is the same as :py:func:`get_external_workflow_handle` but typed. Note,
@@ -2127,7 +3203,7 @@ def continue_as_new(
 @overload
 def continue_as_new(
     *,
-    workflow: Callable[[WorkflowClass], Any],
+    workflow: MethodAsyncNoParam[SelfType, Any],
     task_queue: Optional[str] = None,
     run_timeout: Optional[timedelta] = None,
     task_timeout: Optional[timedelta] = None,
@@ -2140,9 +3216,9 @@ def continue_as_new(
 # Overload for single-param workflow
 @overload
 def continue_as_new(
-    arg: LocalParamType,
+    arg: ParamType,
     *,
-    workflow: Callable[[WorkflowClass, LocalParamType], Any],
+    workflow: MethodAsyncSingleParam[SelfType, ParamType, Any],
     task_queue: Optional[str] = None,
     run_timeout: Optional[timedelta] = None,
     task_timeout: Optional[timedelta] = None,
@@ -2156,7 +3232,7 @@ def continue_as_new(
 @overload
 def continue_as_new(
     *,
-    workflow: Callable[Concatenate[WorkflowClass, MultiParamSpec], Any],
+    workflow: Callable[Concatenate[SelfType, MultiParamSpec], Awaitable[Any]],
     args: Iterable[Any],
     task_queue: Optional[str] = None,
     run_timeout: Optional[timedelta] = None,


### PR DESCRIPTION
## What was changed

* Refactored to use callable protocols instead of callables where possible and moved into new `temporalio.types` package
* Support registering activity methods and calling them via `start_activity_method`, `execute_activity_method`, `start_local_activity_method`, and `execute_local_activity_method`
* Support registering activity classes and calling them via `start_activity_class`, `execute_activity_class`, `start_local_activity_class`, and `execute_local_activity_class`

## Why?

Followup from #66 where we decided that instead of requiring fake instances each time you want to invoke an activity class/method, it's better to have first class support with overloads. We could not reasonably add overloads to the existing activity invocation functions without causing ambiguity that would give false negatives on bad types.

## Checklist

1. Closes #52
2. Closes #68
