### PR TITLE
Add get_current_history_length() to workflow info

### DIFF
--- a/temporalio/worker/workflow_instance.py
+++ b/temporalio/worker/workflow_instance.py
@@ -149,6 +149,7 @@ class _WorkflowInstanceImpl(
         self._info = det.info
         self._primary_task: Optional[asyncio.Task[None]] = None
         self._time = 0.0
+        self._current_history_length = 0
         # Handles which are ready to run on the next event loop iteration
         self._ready: Deque[asyncio.Handle] = collections.deque()
         self._conditions: List[Tuple[Callable[[], bool], asyncio.Future]] = []
@@ -231,6 +232,7 @@ class _WorkflowInstanceImpl(
         )
         self._current_completion.successful.SetInParent()
         self._current_activation_error: Optional[Exception] = None
+        self._current_history_length = act.history_length
         self._time = act.timestamp.ToMicroseconds() / 1e6
         self._is_replaying = act.is_replaying
 
@@ -651,6 +653,9 @@ class _WorkflowInstanceImpl(
         )
         # TODO(cretz): Why can't MyPy infer the above never returns?
         raise RuntimeError("Unreachable")
+
+    def workflow_get_current_history_length(self) -> int:
+        return self._current_history_length
 
     def workflow_get_external_workflow_handle(
         self, id: str, *, run_id: Optional[str]

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -293,6 +293,14 @@ class Info:
             "workflow_type": self.workflow_type,
         }
 
+    def get_current_history_length(self) -> int:
+        """Get the current number of events in history.
+
+        Returns:
+            Current number of events in history (up until the current task).
+        """
+        return _Runtime.current().workflow_get_current_history_length()
+
 
 @dataclass(frozen=True)
 class ParentInfo:
@@ -345,6 +353,10 @@ class _Runtime(ABC):
         memo: Optional[Mapping[str, Any]],
         search_attributes: Optional[temporalio.common.SearchAttributes],
     ) -> NoReturn:
+        ...
+
+    @abstractmethod
+    def workflow_get_current_history_length(self) -> int:
         ...
 
     @abstractmethod

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -110,7 +110,9 @@ class InfoWorkflow:
     @workflow.run
     async def run(self) -> Dict:
         # Convert to JSON and back so it'll stringify un-JSON-able pieces
-        return json.loads(json.dumps(dataclasses.asdict(workflow.info()), default=str))
+        ret = dataclasses.asdict(workflow.info())
+        ret["current_history_length"] = workflow.info().get_current_history_length()
+        return json.loads(json.dumps(ret, default=str))
 
 
 async def test_workflow_info(client: Client):
@@ -130,6 +132,7 @@ async def test_workflow_info(client: Client):
         )
         assert info["attempt"] == 1
         assert info["cron_schedule"] is None
+        assert info["current_history_length"] == 3
         assert info["execution_timeout"] is None
         assert info["namespace"] == client.namespace
         assert info["retry_policy"] == json.loads(


### PR DESCRIPTION
## What was changed

Add `get_current_history_length()` on the workflow info instance

## Why?

Users need length for some continue-as-new checks. Like Go at https://github.com/temporalio/sdk-go/pull/851, we have chosen to put this as a getter on the info. We chose to use an explicit method instead of a property getter so it is clear to users this is not a property on the frozen workflow info.