### PR TITLE
Support IntEnum in converter

### DIFF
--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -9,6 +9,7 @@ import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
+from enum import IntEnum
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, Type
 
 import dacite
@@ -386,6 +387,7 @@ class JSONPlainPayloadConverter(EncodingPayloadConverter):
     _encoder: Optional[Type[json.JSONEncoder]]
     _decoder: Optional[Type[json.JSONDecoder]]
     _encoding: str
+    _dacite_config: dacite.Config
 
     def __init__(
         self,
@@ -405,6 +407,7 @@ class JSONPlainPayloadConverter(EncodingPayloadConverter):
         self._encoder = encoder
         self._decoder = decoder
         self._encoding = encoding
+        self._dacite_config = dacite.Config(cast=[IntEnum])
 
     @property
     def encoding(self) -> str:
@@ -431,6 +434,11 @@ class JSONPlainPayloadConverter(EncodingPayloadConverter):
         """See base class."""
         try:
             obj = json.loads(payload.data, cls=self._decoder)
+
+            # If the object is an int and the type hint is an IntEnum, convert
+            if isinstance(obj, int) and type_hint and issubclass(type_hint, IntEnum):
+                obj = type_hint(obj)
+
             # If the object is a dict and the type hint is present for a data
             # class, we instantiate the data class with the value
             if (
@@ -439,7 +447,8 @@ class JSONPlainPayloadConverter(EncodingPayloadConverter):
                 and dataclasses.is_dataclass(type_hint)
             ):
                 # We have to use dacite here to handle nested dataclasses
-                obj = dacite.from_dict(type_hint, obj)
+                obj = dacite.from_dict(type_hint, obj, self._dacite_config)
+
             return obj
         except json.JSONDecodeError as err:
             raise RuntimeError("Failed parsing") from err


### PR DESCRIPTION
## What was changed

Added support for `IntEnum` in converter including raw int conversion _and_ type-hint-based conversion.

## Why?

This is an easily serializable type in each direction. Note, a regular `Enum` is not easily serializable in each direction and will continue to fail.