### PR TITLE
Minor exception-related updates

### DIFF
--- a/temporalio/worker/activity.py
+++ b/temporalio/worker/activity.py
@@ -419,7 +419,7 @@ class _ActivityWorker:
                     and running_activity.cancelled_due_to_heartbeat_error
                 ):
                     err = running_activity.cancelled_due_to_heartbeat_error
-                    temporalio.activity.logger.debug(
+                    temporalio.activity.logger.warning(
                         f"Completing as failure during heartbeat with error of type {type(err)}: {err}",
                     )
                     await temporalio.exceptions.encode_exception_to_failure(
@@ -439,8 +439,8 @@ class _ActivityWorker:
                         completion.result.cancelled.failure,
                     )
                 else:
-                    temporalio.activity.logger.debug(
-                        "Completing as failed", exc_info=True
+                    temporalio.activity.logger.warning(
+                        "Completing activity as failed", exc_info=True
                     )
                     await temporalio.exceptions.encode_exception_to_failure(
                         err,

--- a/temporalio/worker/workflow_instance.py
+++ b/temporalio/worker/workflow_instance.py
@@ -264,7 +264,10 @@ class _WorkflowInstanceImpl(
                 # Run one iteration of the loop
                 self._run_once()
         except Exception as err:
-            logger.exception(f"Failed activation on workflow with run ID {act.run_id}")
+            logger.warning(
+                f"Failed activation on workflow {self._info.workflow_type} with ID {self._info.workflow_id} and run ID {self._info.run_id}",
+                exc_info=True,
+            )
             # Set completion failure
             self._current_completion.failed.failure.SetInParent()
             try:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -45,7 +45,6 @@ def test_exception_format():
     apply_exception_to_failure(
         actual_err, temporalio.converter.default().payload_converter, failure
     )
-    print("FAILURE", failure)
     failure_error = failure_to_error(
         failure, temporalio.converter.default().payload_converter
     )
@@ -57,7 +56,11 @@ def test_exception_format():
 
     # Append the stack and format the exception and check the output
     append_temporal_stack(failure_error)
-    output = "".join(traceback.format_exception(failure_error))
+    output = "".join(
+        traceback.format_exception(
+            type(failure_error), failure_error, failure_error.__traceback__
+        )
+    )
     assert "temporalio.exceptions.ApplicationError: ValueError: error1" in output
     assert "temporalio.exceptions.ApplicationError: RuntimeError: error" in output
     assert output.count("\nStack:\n") == 2

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,68 @@
+import logging
+import logging.handlers
+import traceback
+from typing import Optional
+
+import temporalio.converter
+from temporalio.api.failure.v1 import Failure
+from temporalio.exceptions import (
+    ApplicationError,
+    FailureError,
+    apply_exception_to_failure,
+    failure_to_error,
+)
+
+
+# This is an example of appending the stack to every Temporal failure error
+def append_temporal_stack(exc: Optional[BaseException]) -> None:
+    while exc:
+        # Only append if it doesn't appear already there
+        if (
+            isinstance(exc, FailureError)
+            and exc.failure
+            and exc.failure.stack_trace
+            and len(exc.args) == 1
+            and "\nStack:\n" not in exc.args[0]
+        ):
+            exc.args = (f"{exc}\nStack:\n{exc.failure.stack_trace.rstrip()}",)
+        exc = exc.__cause__
+
+
+def test_exception_format():
+    # Cause a nested exception
+    actual_err: Exception
+    try:
+        try:
+            raise ValueError("error1")
+        except Exception as err:
+            raise RuntimeError("error2") from err
+    except Exception as err:
+        actual_err = err
+    assert actual_err
+
+    # Convert to failure and back
+    failure = Failure()
+    apply_exception_to_failure(
+        actual_err, temporalio.converter.default().payload_converter, failure
+    )
+    print("FAILURE", failure)
+    failure_error = failure_to_error(
+        failure, temporalio.converter.default().payload_converter
+    )
+    # Confirm type is prepended
+    assert isinstance(failure_error, ApplicationError)
+    assert "RuntimeError: error2" == str(failure_error)
+    assert isinstance(failure_error.cause, ApplicationError)
+    assert "ValueError: error1" == str(failure_error.cause)
+
+    # Append the stack and format the exception and check the output
+    append_temporal_stack(failure_error)
+    output = "".join(traceback.format_exception(failure_error))
+    assert "temporalio.exceptions.ApplicationError: ValueError: error1" in output
+    assert "temporalio.exceptions.ApplicationError: RuntimeError: error" in output
+    assert output.count("\nStack:\n") == 2
+
+    # This shows how it might look for those with debugging on
+    logging.getLogger(__name__).debug(
+        "Showing appended exception", exc_info=failure_error
+    )

--- a/tests/worker/test_activity.py
+++ b/tests/worker/test_activity.py
@@ -168,7 +168,7 @@ async def test_activity_failure(client: Client, worker: ExternalWorker):
 
     with pytest.raises(WorkflowFailureError) as err:
         await _execute_workflow_with_activity(client, worker, raise_error)
-    assert str(assert_activity_application_error(err.value)) == "oh no!"
+    assert str(assert_activity_application_error(err.value)) == "RuntimeError: oh no!"
 
 
 @activity.defn
@@ -185,7 +185,7 @@ async def test_sync_activity_process_failure(client: Client, worker: ExternalWor
                 picklable_activity_failure,
                 worker_config={"activity_executor": executor},
             )
-    assert str(assert_activity_application_error(err.value)) == "oh no!"
+    assert str(assert_activity_application_error(err.value)) == "RuntimeError: oh no!"
 
 
 async def test_activity_bad_params(client: Client, worker: ExternalWorker):
@@ -324,7 +324,7 @@ async def test_activity_does_not_exist(client: Client, worker: ExternalWorker):
                 task_queue=worker.task_queue,
             )
     assert str(assert_activity_application_error(err.value)) == (
-        "Activity function wrong_activity is not registered on this worker, "
+        "NotFoundError: Activity function wrong_activity is not registered on this worker, "
         "available activities: say_hello"
     )
 
@@ -561,7 +561,10 @@ async def test_activity_error_non_retryable_type(
             retry_max_attempts=100,
             non_retryable_error_types=["Cannot retry me"],
         )
-    assert str(assert_activity_application_error(err.value)) == "Do not retry me"
+    assert (
+        str(assert_activity_application_error(err.value))
+        == "Cannot retry me: Do not retry me"
+    )
 
 
 async def test_activity_logging(client: Client, worker: ExternalWorker):


### PR DESCRIPTION
## What was changed

* Alter `ApplicationError` to prepend the type to the message if present when showing the string format
* Change workflow activation failures from `ERROR` to `WARN`
* Change activity failures from `DEBUG` to `WARN`
* Add example in test case showing how to append stack trace

## Checklist

1. Relates to #58