### PR TITLE
Improves typing of SearchAttributes

### DIFF
--- a/temporalio/common.py
+++ b/temporalio/common.py
@@ -130,12 +130,14 @@ class QueryRejectCondition(IntEnum):
     """See :py:attr:`temporalio.api.enums.v1.QueryRejectCondition.QUERY_REJECT_CONDITION_NOT_COMPLETED_CLEANLY`."""
 
 
-SearchAttributeValue: TypeAlias = Union[str, int, float, bool, datetime]
-
 # We choose to make this a list instead of an iterable so we can catch if people
 # are not sending lists each time but maybe accidentally sending a string (which
 # is iterable)
-SearchAttributes: TypeAlias = Mapping[str, List[SearchAttributeValue]]
+SearchAttributeValues: TypeAlias = Union[
+    List[str], List[int], List[float], List[bool], List[datetime]
+]
+
+SearchAttributes: TypeAlias = Mapping[str, SearchAttributeValues]
 
 
 # Should be set as the "arg" argument for _arg_or_args checks where the argument

--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -620,7 +620,7 @@ def encode_search_attributes(
 
 
 def encode_search_attribute_values(
-    vals: List[temporalio.common.SearchAttributeValue],
+    vals: temporalio.common.SearchAttributeValues,
 ) -> temporalio.api.common.v1.Payload:
     """Convert search attribute values into a payload.
 

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -1192,13 +1192,14 @@ class SearchAttributeWorkflow:
 
     @workflow.signal
     def do_search_attribute_update(self) -> None:
+        empty_float_list: List[float] = []
         workflow.upsert_search_attributes(
             {
                 f"{sa_prefix}text": ["text3"],
                 # We intentionally leave keyword off to confirm it still comes back
                 f"{sa_prefix}int": [123, 456],
                 # Empty list to confirm removed
-                f"{sa_prefix}double": [],
+                f"{sa_prefix}double": empty_float_list,
                 f"{sa_prefix}bool": [False],
                 f"{sa_prefix}datetime": [
                     datetime(2003, 4, 5, 6, 7, 8, tzinfo=timezone(timedelta(hours=9)))


### PR DESCRIPTION
## What was changed
Change typing of search attributes to a union of lists with single types as opposed to a list of unions.

## Why?
To set a search attribute to a list, you have to explicitly cast the list to be of type `List[SearchAttributeValue]` because lists are invariant and otherwise you get a mypy error. We could use `Sequence` to get around this, but I think it would be best to type as a union of list types rather than a list of unions because multiple values for the same key should be the same type anyway, otherwise ElasticSearch and maybe Temporal would probably throw an error.

## Checklist
1. How was this tested:
I ran mypy and the tests
