### PR TITLE
Fix activity class type hinting when not instantiated

### DIFF
--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -732,16 +732,17 @@ def _type_hints_from_func(
     # the func. This mimics inspect logic inside Python.
     if (
         not inspect.isfunction(func)
-        and not isinstance(func, type)
         and not isinstance(func, _non_user_defined_callables)
         and not isinstance(func, types.MethodType)
     ):
-        # Callable instance
-        call_func = getattr(type(func), "__call__", None)
+        # Class type or Callable instance
+        tmp_func = func if isinstance(func, type) else type(func)
+        call_func = getattr(tmp_func, "__call__", None)
         if call_func is not None and not isinstance(
-            type(func), _non_user_defined_callables
+            tmp_func, _non_user_defined_callables
         ):
             func = call_func
+
     # We use inspect.signature for the parameter names and kinds, but we cannot
     # use it for annotations because those that are using deferred hinting (i.e.
     # from __future__ import annotations) only work with the eval_str parameter

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -172,5 +172,6 @@ def test_type_hints_from_func():
     assert_hints(some_hinted_func)
     assert_hints(some_hinted_func_async)
     assert_hints(MyCallableClass())
+    assert_hints(MyCallableClass)
     assert_hints(MyCallableClass.some_method)
     assert_hints(MyCallableClass().some_method)

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -2081,9 +2081,11 @@ class CallableClassActivity:
 class ActivityCallableClassWorkflow:
     @workflow.run
     async def run(self, to_add: MyDataClass) -> MyDataClass:
-        return await workflow.execute_activity_class(
+        result = await workflow.execute_activity_class(
             CallableClassActivity, to_add, start_to_close_timeout=timedelta(seconds=30)
         )
+        assert isinstance(result, MyDataClass)
+        return result
 
 
 async def test_workflow_activity_callable_class(client: Client):


### PR DESCRIPTION
I've noticed that when executing a class activity, the type hinting was not taken into account. I've reflected this into the unit test with an additional assert.

This match the behavior of the docs where the usage is to pass the class type, not its instance:

```python
result = await workflow.execute_activity_class(
    CallableClassActivity, to_add, start_to_close_timeout=timedelta(seconds=30)
)
```

Signed-off-by: Adrien Fillon <adrien.fillon@manomano.com>

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

`_type_hints_from_func` was not taking into account when passed with a callable class

## Why?
<!-- Tell your future self why have you made these changes -->

So we can properly execute class-based activities by passing the class instead of the instance

## Checklist
<!--- add/delete as needed --->

1. Closes N/A <!-- add issue number here -->

2. How was this tested: Unit testing
<!--- Please describe how you tested your changes/how we can test them -->

4. Any docs updates needed? N/A
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
