### PR TITLE
Add flag for opting into worker build id versioning

### DIFF
--- a/temporalio/bridge/Cargo.lock
+++ b/temporalio/bridge/Cargo.lock
@@ -1820,6 +1820,7 @@ dependencies = [
  "derive_more",
  "enum_dispatch",
  "futures",
+ "futures-util",
  "governor",
  "http",
  "hyper",

--- a/temporalio/bridge/src/worker.rs
+++ b/temporalio/bridge/src/worker.rs
@@ -36,6 +36,7 @@ pub struct WorkerConfig {
     sticky_queue_schedule_to_start_timeout_millis: u64,
     max_heartbeat_throttle_interval_millis: u64,
     default_heartbeat_throttle_interval_millis: u64,
+    use_worker_versioning: bool,
 }
 
 pub fn new_worker(client: &client::ClientRef, config: WorkerConfig) -> PyResult<WorkerRef> {
@@ -180,6 +181,7 @@ impl TryFrom<WorkerConfig> for temporal_sdk_core::WorkerConfig {
             .default_heartbeat_throttle_interval(Duration::from_millis(
                 conf.default_heartbeat_throttle_interval_millis,
             ))
+            .use_worker_versioning(conf.use_worker_versioning)
             .build()
             .map_err(|err| PyValueError::new_err(format!("Invalid worker config: {}", err)))
     }

--- a/temporalio/bridge/worker.py
+++ b/temporalio/bridge/worker.py
@@ -37,6 +37,7 @@ class WorkerConfig:
     sticky_queue_schedule_to_start_timeout_millis: int
     max_heartbeat_throttle_interval_millis: int
     default_heartbeat_throttle_interval_millis: int
+    use_worker_versioning: bool
 
 
 class Worker:

--- a/temporalio/worker/worker.py
+++ b/temporalio/worker/worker.py
@@ -67,6 +67,7 @@ class Worker:
         graceful_shutdown_timeout: timedelta = timedelta(),
         shared_state_manager: Optional[SharedStateManager] = None,
         debug_mode: bool = False,
+        use_worker_versioning: bool = False,
     ) -> None:
         """Create a worker to process workflows and/or activities.
 
@@ -146,6 +147,8 @@ class Worker:
                 sandboxing in order to make using a debugger easier. If false
                 but the environment variable ``TEMPORAL_DEBUG`` is truthy, this
                 will be set to true.
+            use_worker_versioning: If true, this worker opts into worker build id
+                based versioning. See the documentation at TODO for more.
         """
         if not activities and not workflows:
             raise ValueError("At least one activity or workflow must be specified")
@@ -206,6 +209,7 @@ class Worker:
             graceful_shutdown_timeout=graceful_shutdown_timeout,
             shared_state_manager=shared_state_manager,
             debug_mode=debug_mode,
+            use_worker_versioning=use_worker_versioning,
         )
         self._task: Optional[asyncio.Task] = None
 
@@ -366,6 +370,7 @@ class WorkerConfig(TypedDict, total=False):
     graceful_shutdown_timeout: timedelta
     shared_state_manager: Optional[SharedStateManager]
     debug_mode: bool
+    use_worker_versioning: bool
 
 
 _default_build_id: Optional[str] = None


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added flag for opting into the new versioning feature

Keeping this draft since it would be confusing if we cut a release with this in it before server is released with it, and docs exist, etc etc. @cretz If we have a good way we can check this in but keep it hidden, that would be awesome.
