### PR TITLE
README: Fix import name in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ import asyncio
 from temporalio.client import Client
 
 # Import the workflow from the previous code
-from my_worker_package import SayHello
+from run_worker import SayHello
 
 async def main():
     # Create client connected to server at the given address


### PR DESCRIPTION
## What was changed
In `README.md` correct a placeholder package name to the correct name used in the example. 

## Why?
So that copy-pasting the example runs correctly, without modifications.

## Checklist
How was this tested:
* Installed python sdk.
* Ran quickstart example, making no additional modifications to the code.
* Witness `Result: Hello, my name!` as expected.
