### PR TITLE
Add StrEnum conversion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The default data converter supports converting multiple types including:
   * Iterables including ones JSON dump may not support by default, e.g. `set`
   * Any class with a `dict()` method and a static `parse_obj()` method, e.g.
     [Pydantic models](https://pydantic-docs.helpmanual.io/usage/models)
-  * [IntEnum](https://docs.python.org/3/library/enum.html) based enumerates
+  * [IntEnum, StrEnum](https://docs.python.org/3/library/enum.html) based enumerates
 
 For converting from JSON, the workflow/activity type hint is taken into account to convert to the proper type. Care has
 been taken to support all common typings including `Optional`, `Union`, all forms of iterables and mappings, `NewType`,

--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -878,7 +878,7 @@ def value_to_type(hint: Type, value: Any) -> Any:
     if inspect.isclass(hint) and issubclass(hint, StrEnum):
         if not isinstance(value, str):
             raise TypeError(
-                f"Cannot convert to enum {hint}, value not an integer, value is {type(value)}"
+                f"Cannot convert to enum {hint}, value not a string, value is {type(value)}"
             )
         return hint(value)
 

--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -10,7 +10,7 @@ import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
-from enum import IntEnum
+from enum import IntEnum, StrEnum
 from typing import (
     Any,
     Dict,
@@ -869,6 +869,14 @@ def value_to_type(hint: Type, value: Any) -> Any:
     # IntEnum
     if inspect.isclass(hint) and issubclass(hint, IntEnum):
         if not isinstance(value, int):
+            raise TypeError(
+                f"Cannot convert to enum {hint}, value not an integer, value is {type(value)}"
+            )
+        return hint(value)
+
+    # StrEnum
+    if inspect.isclass(hint) and issubclass(hint, StrEnum):
+        if not isinstance(value, str):
             raise TypeError(
                 f"Cannot convert to enum {hint}, value not an integer, value is {type(value)}"
             )

--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -7,10 +7,11 @@ import collections.abc
 import dataclasses
 import inspect
 import json
+import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
-from enum import IntEnum, StrEnum
+from enum import IntEnum
 from typing import (
     Any,
     Dict,
@@ -32,6 +33,10 @@ from typing_extensions import Literal
 
 import temporalio.api.common.v1
 import temporalio.common
+
+# StrEnum is available in 3.11+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
 
 
 class PayloadConverter(ABC):
@@ -874,13 +879,14 @@ def value_to_type(hint: Type, value: Any) -> Any:
             )
         return hint(value)
 
-    # StrEnum
-    if inspect.isclass(hint) and issubclass(hint, StrEnum):
-        if not isinstance(value, str):
-            raise TypeError(
-                f"Cannot convert to enum {hint}, value not a string, value is {type(value)}"
-            )
-        return hint(value)
+    # StrEnum, available in 3.11+
+    if sys.version_info >= (3, 11):
+        if inspect.isclass(hint) and issubclass(hint, StrEnum):
+            if not isinstance(value, str):
+                raise TypeError(
+                    f"Cannot convert to enum {hint}, value not a string, value is {type(value)}"
+                )
+            return hint(value)
 
     # Iterable. We intentionally put this last as it catches several others.
     if inspect.isclass(origin) and issubclass(origin, collections.abc.Iterable):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -5,7 +5,7 @@ import sys
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum, IntEnum
+from enum import Enum, IntEnum, StrEnum
 from typing import (
     Any,
     Deque,
@@ -44,6 +44,10 @@ class NonSerializableEnum(Enum):
 
 class SerializableEnum(IntEnum):
     FOO = 1
+
+
+class SerializableStrEnum(StrEnum):
+    FOO = "foo"
 
 
 @dataclass
@@ -107,8 +111,8 @@ async def test_converter_default():
         await assert_payload(NonSerializableClass(), None, None)
     assert "not JSON serializable" in str(excinfo.value)
 
-    # Bad enum type. We do not allow non-int enums due to ambiguity in
-    # rebuilding and other confusion.
+    # Bad enum type. We do not allow non-int or non-str enums due to ambiguity
+    # in rebuilding and other confusion.
     with pytest.raises(TypeError) as excinfo:
         await assert_payload(NonSerializableEnum.FOO, None, None)
     assert "not JSON serializable" in str(excinfo.value)
@@ -294,6 +298,10 @@ def test_json_type_hints():
     # IntEnum
     ok(SerializableEnum, SerializableEnum.FOO)
     ok(List[SerializableEnum], [SerializableEnum.FOO, SerializableEnum.FOO])
+
+    # StrEnum
+    ok(SerializableStrEnum, SerializableStrEnum.FOO)
+    ok(List[SerializableStrEnum], [SerializableStrEnum.FOO, SerializableStrEnum.FOO])
 
     # 3.10+ checks
     if sys.version_info >= (3, 10):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -5,7 +5,7 @@ import sys
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum, IntEnum, StrEnum
+from enum import Enum, IntEnum
 from typing import (
     Any,
     Deque,
@@ -33,6 +33,10 @@ import temporalio.common
 import temporalio.converter
 from temporalio.api.common.v1 import Payload as AnotherNameForPayload
 
+# StrEnum is available in 3.11+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+
 
 class NonSerializableClass:
     pass
@@ -46,8 +50,10 @@ class SerializableEnum(IntEnum):
     FOO = 1
 
 
-class SerializableStrEnum(StrEnum):
-    FOO = "foo"
+if sys.version_info >= (3, 11):
+
+    class SerializableStrEnum(StrEnum):
+        FOO = "foo"
 
 
 @dataclass
@@ -299,9 +305,14 @@ def test_json_type_hints():
     ok(SerializableEnum, SerializableEnum.FOO)
     ok(List[SerializableEnum], [SerializableEnum.FOO, SerializableEnum.FOO])
 
-    # StrEnum
-    ok(SerializableStrEnum, SerializableStrEnum.FOO)
-    ok(List[SerializableStrEnum], [SerializableStrEnum.FOO, SerializableStrEnum.FOO])
+    # StrEnum is available in 3.11+
+    if sys.version_info >= (3, 11):
+        # StrEnum
+        ok(SerializableStrEnum, SerializableStrEnum.FOO)
+        ok(
+            List[SerializableStrEnum],
+            [SerializableStrEnum.FOO, SerializableStrEnum.FOO],
+        )
 
     # 3.10+ checks
     if sys.version_info >= (3, 10):


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add support for string-based Enum

## Why?
String-based enum is apparently widely used, along with int-based enums. Python-sdk already has a support int-based enum, and it makes sense also to support another most popular enum, string.

## Checklist
<!--- add/delete as needed --->

1. Closes #176 

2. How was this tested:
Tested with updated unit test

3. Any docs updates needed?
Readme was slightly updated
