### PR TITLE
Memoize patched calls and support UUID conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,11 @@ The default data converter supports converting multiple types including:
   * Iterables including ones JSON dump may not support by default, e.g. `set`
   * Any class with a `dict()` method and a static `parse_obj()` method, e.g.
     [Pydantic models](https://pydantic-docs.helpmanual.io/usage/models)
+    * Note, this doesn't mean every Pydantic field can be converted, only fields which the data converter supports
   * [IntEnum, StrEnum](https://docs.python.org/3/library/enum.html) based enumerates
+  * [UUID](https://docs.python.org/3/library/uuid.html)
+
+This notably doesn't include any `date`, `time`, or `datetime` objects as they may not work across SDKs.
 
 For converting from JSON, the workflow/activity type hint is taken into account to convert to the proper type. Care has
 been taken to support all common typings including `Optional`, `Union`, all forms of iterables and mappings, `NewType`,

--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -9,6 +9,7 @@ import inspect
 import json
 import sys
 import traceback
+import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
@@ -426,6 +427,9 @@ class AdvancedJSONEncoder(json.JSONEncoder):
         # Support for non-list iterables like set
         if not isinstance(o, list) and isinstance(o, collections.abc.Iterable):
             return list(o)
+        # Support for UUID
+        if isinstance(o, uuid.UUID):
+            return str(o)
         return super().default(o)
 
 
@@ -1272,6 +1276,10 @@ def value_to_type(hint: Type, value: Any) -> Any:
                     f"Cannot convert to enum {hint}, value not a string, value is {type(value)}"
                 )
             return hint(value)
+
+    # UUID
+    if inspect.isclass(hint) and issubclass(hint, uuid.UUID):
+        return hint(value)
 
     # Iterable. We intentionally put this last as it catches several others.
     if inspect.isclass(origin) and issubclass(origin, collections.abc.Iterable):

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -194,6 +194,7 @@ class _WorkflowInstanceImpl(
         # Patches we have been notified of and patches that have been sent
         self._patches_notified: Set[str] = set()
         self._patches_sent: Set[str] = set()
+        self._patches_memoized: Dict[str, bool] = {}
 
         # Tasks stored by asyncio are weak references and therefore can get GC'd
         # which can cause warnings like "Task was destroyed but it is pending!".
@@ -739,7 +740,14 @@ class _WorkflowInstanceImpl(
         )[0]
 
     def workflow_patch(self, id: str, *, deprecated: bool) -> bool:
+        # We use a previous memoized result of this if present. If this is being
+        # deprecated, we can still use memoized result and skip the command.
+        use_patch = self._patches_memoized.get(id)
+        if use_patch is not None:
+            return use_patch
+
         use_patch = not self._is_replaying or id in self._patches_notified
+        self._patches_memoized[id] = use_patch
         # Only add patch command if never sent before for this ID
         if use_patch and not id in self._patches_sent:
             command = self._add_command()

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -191,9 +191,8 @@ class _WorkflowInstanceImpl(
         self._is_replaying: bool = False
         self._random = random.Random(det.randomness_seed)
 
-        # Patches we have been notified of and patches that have been sent
+        # Patches we have been notified of and memoized patch responses
         self._patches_notified: Set[str] = set()
-        self._patches_sent: Set[str] = set()
         self._patches_memoized: Dict[str, bool] = {}
 
         # Tasks stored by asyncio are weak references and therefore can get GC'd
@@ -748,12 +747,10 @@ class _WorkflowInstanceImpl(
 
         use_patch = not self._is_replaying or id in self._patches_notified
         self._patches_memoized[id] = use_patch
-        # Only add patch command if never sent before for this ID
-        if use_patch and not id in self._patches_sent:
+        if use_patch:
             command = self._add_command()
             command.set_patch_marker.patch_id = id
             command.set_patch_marker.deprecated = deprecated
-            self._patches_sent.add(id)
         return use_patch
 
     def workflow_random(self) -> random.Random:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -25,6 +25,7 @@ from typing import (
     Type,
     Union,
 )
+from uuid import UUID, uuid4
 
 import pydantic
 import pytest
@@ -224,6 +225,7 @@ class NestedDataClass:
     foo: str
     bar: List[NestedDataClass] = dataclasses.field(default_factory=list)
     baz: Optional[NestedDataClass] = None
+    qux: Optional[UUID] = None
 
 
 class MyTypedDict(TypedDict):
@@ -239,6 +241,7 @@ class MyTypedDictNotTotal(TypedDict, total=False):
 class MyPydanticClass(pydantic.BaseModel):
     foo: str
     bar: List[MyPydanticClass]
+    baz: Optional[UUID] = None
 
 
 def test_json_type_hints():
@@ -287,6 +290,7 @@ def test_json_type_hints():
     ok(NestedDataClass, NestedDataClass("foo"))
     ok(NestedDataClass, NestedDataClass("foo", baz=NestedDataClass("bar")))
     ok(NestedDataClass, NestedDataClass("foo", bar=[NestedDataClass("bar")]))
+    ok(NestedDataClass, NestedDataClass("foo", qux=uuid4()))
     # Missing required dataclass fields causes failure
     ok(NestedDataClass, {"foo": "bar"}, NestedDataClass("bar"))
     fail(NestedDataClass, {})
@@ -346,6 +350,8 @@ def test_json_type_hints():
     ok(SerializableEnum, SerializableEnum.FOO)
     ok(List[SerializableEnum], [SerializableEnum.FOO, SerializableEnum.FOO])
 
+    # UUID
+
     # StrEnum is available in 3.11+
     if sys.version_info >= (3, 11):
         # StrEnum
@@ -364,7 +370,9 @@ def test_json_type_hints():
     # Pydantic
     ok(
         MyPydanticClass,
-        MyPydanticClass(foo="foo", bar=[MyPydanticClass(foo="baz", bar=[])]),
+        MyPydanticClass(
+            foo="foo", bar=[MyPydanticClass(foo="baz", bar=[])], baz=uuid4()
+        ),
     )
     ok(List[MyPydanticClass], [MyPydanticClass(foo="foo", bar=[])])
     fail(List[MyPydanticClass], [MyPydanticClass(foo="foo", bar=[]), 5])


### PR DESCRIPTION
## What was changed

:boom: Breaking change - now `workflow.patched()` calls always return the same boolean for the life of the workflow code. This will break users with running workflows that make multiple `workflow.patched` for the same key in the same workflow (e.g. in a loop, etc).

## Why?

We were not memoizing before and people want to be able to check the same patch key at different parts of workflow code. IT was deemed acceptable to make this break while Python was in beta.

## Checklist

1. Relates to #143