### PR TITLE
Sandbox and type fixes

### DIFF
--- a/temporalio/bridge/runtime.py
+++ b/temporalio/bridge/runtime.py
@@ -147,5 +147,5 @@ class TelemetryConfig:
     logging: Optional[LoggingConfig] = LoggingConfig.default
     """Logging configuration."""
 
-    metrics: Optional[PrometheusConfig] = None
+    metrics: Optional[MetricsConfig] = None
     """Metrics configuration."""

--- a/temporalio/contrib/opentelemetry.py
+++ b/temporalio/contrib/opentelemetry.py
@@ -35,6 +35,14 @@ import temporalio.exceptions
 import temporalio.worker
 import temporalio.workflow
 
+# OpenTelemetry dynamically, lazily chooses its context implementation at
+# runtime. When first accessed, they use pkg_resources.iter_entry_points + load.
+# The load uses built-in open() which we don't allow in sandbox mode at runtime,
+# only import time. Therefore if the first use of a OTel context is inside the
+# sandbox, which it may be for a workflow worker, this will fail. So instead we
+# eagerly reference it here to force loading at import time instead of lazily.
+opentelemetry.context.get_current()
+
 default_text_map_propagator = opentelemetry.propagators.composite.CompositePropagator(
     [
         opentelemetry.trace.propagation.tracecontext.TraceContextTextMapPropagator(),

--- a/temporalio/worker/workflow_sandbox/_restrictions.py
+++ b/temporalio/worker/workflow_sandbox/_restrictions.py
@@ -437,7 +437,7 @@ SandboxRestrictions.invalid_module_members_default = SandboxMatcher(
         # TODO(cretz): Fix issues with class extensions on restricted proxy
         # "argparse": SandboxMatcher.all_uses_runtime,
         "bz2": SandboxMatcher(use={"open"}),
-        "concurrent": SandboxMatcher.all_uses_runtime,
+        "concurrent": SandboxMatcher(children={"futures": SandboxMatcher.all_uses_runtime}),
         # Python's own re lib registers itself. This is mostly ok to not
         # restrict since it's just global picklers that people may want to
         # register globally.

--- a/temporalio/worker/workflow_sandbox/_restrictions.py
+++ b/temporalio/worker/workflow_sandbox/_restrictions.py
@@ -437,7 +437,9 @@ SandboxRestrictions.invalid_module_members_default = SandboxMatcher(
         # TODO(cretz): Fix issues with class extensions on restricted proxy
         # "argparse": SandboxMatcher.all_uses_runtime,
         "bz2": SandboxMatcher(use={"open"}),
-        "concurrent": SandboxMatcher(children={"futures": SandboxMatcher.all_uses_runtime}),
+        "concurrent": SandboxMatcher(
+            children={"futures": SandboxMatcher.all_uses_runtime}
+        ),
         # Python's own re lib registers itself. This is mostly ok to not
         # restrict since it's just global picklers that people may want to
         # register globally.

--- a/tests/worker/workflow_sandbox/test_runner.py
+++ b/tests/worker/workflow_sandbox/test_runner.py
@@ -206,6 +206,8 @@ async def test_workflow_sandbox_restrictions(client: Client):
             # General library allowed calls
             "import datetime\ndatetime.date(2001, 1, 1)",
             "import uuid\nuuid.uuid5(uuid.NAMESPACE_DNS, 'example.com')",
+            # Other imports we want to allow
+            "from concurrent.futures import ThreadPoolExecutor",
         ]
         for code in valid_code_to_check:
             await client.execute_workflow(

--- a/tests/worker/workflow_sandbox/test_runner.py
+++ b/tests/worker/workflow_sandbox/test_runner.py
@@ -7,13 +7,14 @@ import os
 import time
 import uuid
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, timedelta
+from enum import IntEnum
 from typing import Callable, Dict, List, Optional, Sequence, Type
 
 import pytest
 
 import temporalio.worker.workflow_sandbox._restrictions
-from temporalio import workflow
+from temporalio import activity, workflow
 from temporalio.client import Client, WorkflowFailureError, WorkflowHandle
 from temporalio.exceptions import ApplicationError
 from temporalio.worker import Worker
@@ -305,6 +306,53 @@ async def test_workflow_sandbox_access_stack(client: Client):
     async with new_worker(client, AccessStackWorkflow) as worker:
         assert "run" == await client.execute_workflow(
             AccessStackWorkflow.run,
+            id=f"workflow-{uuid.uuid4()}",
+            task_queue=worker.task_queue,
+        )
+
+
+class InstanceCheckEnum(IntEnum):
+    FOO = 1
+    BAR = 2
+
+
+@dataclass
+class InstanceCheckData:
+    some_enum: InstanceCheckEnum
+
+
+@activity.defn
+async def instance_check_activity(param: InstanceCheckData) -> InstanceCheckData:
+    assert isinstance(param, InstanceCheckData)
+    assert param.some_enum is InstanceCheckEnum.BAR
+    return param
+
+
+@workflow.defn
+class InstanceCheckWorkflow:
+    @workflow.run
+    async def run(self, param: InstanceCheckData) -> InstanceCheckData:
+        assert isinstance(param, InstanceCheckData)
+        assert param.some_enum is InstanceCheckEnum.BAR
+        # Exec child if not a child, otherwise exec activity
+        if workflow.info().parent is None:
+            return await workflow.execute_child_workflow(
+                InstanceCheckWorkflow.run, param
+            )
+        return await workflow.execute_activity(
+            instance_check_activity,
+            param,
+            schedule_to_close_timeout=timedelta(minutes=1),
+        )
+
+
+async def test_workflow_sandbox_instance_check(client: Client):
+    async with new_worker(
+        client, InstanceCheckWorkflow, activities=[instance_check_activity]
+    ) as worker:
+        await client.execute_workflow(
+            InstanceCheckWorkflow.run,
+            InstanceCheckData(some_enum=InstanceCheckEnum.BAR),
             id=f"workflow-{uuid.uuid4()}",
             task_queue=worker.task_queue,
         )


### PR DESCRIPTION
## What was changed

* Allow imports from `concurrent.futures` (inadvertently blocked before)
* Fix type hinting inside of sandbox by using the in-sandbox workflow definition instead of outside-of-sandbox one
* Pre-initialize OpenTelemetry context at import time to prevent it lazily calling `open()` at runtime
* Use the proper `MetricsConfig` type in bridge runtime telemetry

## Checklist

1. Closes #201
1. Closes #200
1. Closes #199
1. Closes #198