### PR TITLE
Support raising cancellation in sync multithreaded activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,8 +850,8 @@ activities no special worker parameters are needed.
 
 Cancellation for asynchronous activities is done via
 [`asyncio.Task.cancel`](https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.cancel). This means that
-`asyncio.CancelledError` will be raised (and can be caught, but it is not recommended). An activity must heartbeat to
-receive cancellation and there are other ways to be notified about cancellation (see "Activity Context" and
+`asyncio.CancelledError` will be raised (and can be caught, but it is not recommended). A non-local activity must
+heartbeat to receive cancellation and there are other ways to be notified about cancellation (see "Activity Context" and
 "Heartbeating and Cancellation" later).
 
 ##### Synchronous Activities
@@ -860,9 +860,9 @@ Synchronous activities, i.e. functions that do not have `async def`, can be used
 `activity_executor` worker parameter must be set with a `concurrent.futures.Executor` instance to use for executing the
 activities.
 
-All long running activities should heartbeat so they can be cancelled. Cancellation in threaded activities throws but
-multiprocess/other activities does not. The sections below on each synchronous type explain further. There are also
-calls on the context that can check for cancellation. For more information, see "Activity Context" and
+All long running, non-local activities should heartbeat so they can be cancelled. Cancellation in threaded activities
+throws but multiprocess/other activities does not. The sections below on each synchronous type explain further. There
+are also calls on the context that can check for cancellation. For more information, see "Activity Context" and
 "Heartbeating and Cancellation" sections later.
 
 Note, all calls from an activity to functions in the `temporalio.activity` package are powered by
@@ -923,14 +923,16 @@ occurs. Synchronous activities cannot call any of the `async` functions.
 
 ##### Heartbeating and Cancellation
 
-In order for an activity to be notified of cancellation requests, they must invoke `temporalio.activity.heartbeat()`.
-It is strongly recommended that all but the fastest executing activities call this function regularly. "Types of
-Activities" has specifics on cancellation for asynchronous and synchronous activities.
+In order for a non-local activity to be notified of cancellation requests, it must invoke
+`temporalio.activity.heartbeat()`. It is strongly recommended that all but the fastest executing activities call this
+function regularly. "Types of Activities" has specifics on cancellation for asynchronous and synchronous activities.
 
 In addition to obtaining cancellation information, heartbeats also support detail data that is persisted on the server
 for retrieval during activity retry. If an activity calls `temporalio.activity.heartbeat(123, 456)` and then fails and
 is retried, `temporalio.activity.info().heartbeat_details` will return an iterable containing `123` and `456` on the
 next run.
+
+Heartbeating has no effect on local activities.
 
 ##### Worker Shutdown
 

--- a/temporalio/activity.py
+++ b/temporalio/activity.py
@@ -236,13 +236,13 @@ def shield_thread_cancel_exception() -> Iterator[None]:
     """Context manager for synchronous multithreaded activities to delay
     cancellation exceptions.
 
-    By default, heartbeating synchronous multithreaded activities have an
-    exception thrown inside when cancellation occurs. Code within a "with" block
-    of this context manager will delay that throwing until the end. Even if the
-    block returns a value or throws its own exception, if a cancellation
-    exception is pending, it is thrown instead. Therefore users are encouraged
-    to not throw out of this block and can surround this with a try/except if
-    they wish to catch a cancellation.
+    By default, synchronous multithreaded activities have an exception thrown
+    inside when cancellation occurs. Code within a "with" block of this context
+    manager will delay that throwing until the end. Even if the block returns a
+    value or throws its own exception, if a cancellation exception is pending,
+    it is thrown instead. Therefore users are encouraged to not throw out of
+    this block and can surround this with a try/except if they wish to catch a
+    cancellation.
 
     This properly supports nested calls and will only throw after the last one.
 

--- a/temporalio/bridge/runtime.py
+++ b/temporalio/bridge/runtime.py
@@ -6,7 +6,7 @@ Nothing in this module should be considered stable. The API may change.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import ClassVar, Mapping, Optional
+from typing import ClassVar, Mapping, Optional, Type
 
 import temporalio.bridge.temporal_sdk_bridge
 
@@ -53,6 +53,13 @@ class Runtime:
         if _default_runtime and error_if_already_set:
             raise RuntimeError("Runtime default already set")
         _default_runtime = runtime
+
+    @staticmethod
+    def _raise_in_thread(thread_id: int, exc_type: Type[BaseException]) -> bool:
+        """Internal helper for raising an exception in thread."""
+        return temporalio.bridge.temporal_sdk_bridge.raise_in_thread(
+            thread_id, exc_type
+        )
 
     def __init__(self, *, telemetry: TelemetryConfig) -> None:
         """Create a default runtime with the given telemetry config.

--- a/temporalio/bridge/src/lib.rs
+++ b/temporalio/bridge/src/lib.rs
@@ -50,7 +50,7 @@ fn init_runtime(telemetry_config: runtime::TelemetryConfig) -> PyResult<runtime:
 }
 
 #[pyfunction]
-fn raise_in_thread<'a>(py: Python<'a>, thread_id: i32, exc: &PyAny) -> bool {
+fn raise_in_thread<'a>(py: Python<'a>, thread_id: std::os::raw::c_long, exc: &PyAny) -> bool {
     runtime::raise_in_thread(py, thread_id, exc)
 }
 

--- a/temporalio/bridge/src/lib.rs
+++ b/temporalio/bridge/src/lib.rs
@@ -16,6 +16,7 @@ fn temporal_sdk_bridge(py: Python, m: &PyModule) -> PyResult<()> {
     // Runtime stuff
     m.add_class::<runtime::RuntimeRef>()?;
     m.add_function(wrap_pyfunction!(init_runtime, m)?)?;
+    m.add_function(wrap_pyfunction!(raise_in_thread, m)?)?;
 
     // Testing stuff
     m.add_class::<testing::EphemeralServerRef>()?;
@@ -46,6 +47,11 @@ fn connect_client<'a>(
 #[pyfunction]
 fn init_runtime(telemetry_config: runtime::TelemetryConfig) -> PyResult<runtime::RuntimeRef> {
     runtime::init_runtime(telemetry_config)
+}
+
+#[pyfunction]
+fn raise_in_thread<'a>(py: Python<'a>, thread_id: i32, exc: &PyAny) -> bool {
+    runtime::raise_in_thread(py, thread_id, exc)
 }
 
 #[pyfunction]

--- a/temporalio/bridge/src/runtime.rs
+++ b/temporalio/bridge/src/runtime.rs
@@ -76,7 +76,7 @@ pub fn init_runtime(telemetry_config: TelemetryConfig) -> PyResult<RuntimeRef> {
     })
 }
 
-pub fn raise_in_thread<'a>(_py: Python<'a>, thread_id: i32, exc: &PyAny) -> bool {
+pub fn raise_in_thread<'a>(_py: Python<'a>, thread_id: std::os::raw::c_long, exc: &PyAny) -> bool {
     unsafe { pyo3::ffi::PyThreadState_SetAsyncExc(thread_id, exc.as_ptr()) == 1 }
 }
 

--- a/temporalio/bridge/src/runtime.rs
+++ b/temporalio/bridge/src/runtime.rs
@@ -1,5 +1,6 @@
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
+use pyo3::AsPyPointer;
 use std::collections::HashMap;
 use std::future::Future;
 use std::net::SocketAddr;
@@ -73,6 +74,10 @@ pub fn init_runtime(telemetry_config: TelemetryConfig) -> PyResult<RuntimeRef> {
             ),
         },
     })
+}
+
+pub fn raise_in_thread<'a>(_py: Python<'a>, thread_id: i32, exc: &PyAny) -> bool {
+    unsafe { pyo3::ffi::PyThreadState_SetAsyncExc(thread_id, exc.as_ptr()) == 1 }
 }
 
 impl Runtime {

--- a/temporalio/exceptions.py
+++ b/temporalio/exceptions.py
@@ -97,7 +97,7 @@ class ApplicationError(FailureError):
 class CancelledError(FailureError):
     """Error raised on workflow/activity cancellation."""
 
-    def __init__(self, message: str, *details: Any) -> None:
+    def __init__(self, message: str = "Cancelled", *details: Any) -> None:
         """Initialize a cancelled error."""
         super().__init__(message)
         self._details = details

--- a/temporalio/worker/_interceptor.py
+++ b/temporalio/worker/_interceptor.py
@@ -87,7 +87,6 @@ class ExecuteActivityInput:
     args: Sequence[Any]
     executor: Optional[concurrent.futures.Executor]
     headers: Mapping[str, temporalio.api.common.v1.Payload]
-    _cancelled_event: temporalio.activity._CompositeEvent
 
 
 class ActivityInboundInterceptor:

--- a/tests/bridge/test_runtime.py
+++ b/tests/bridge/test_runtime.py
@@ -1,0 +1,40 @@
+from threading import Event, Thread
+from time import sleep
+from typing import Optional
+
+from temporalio.bridge.runtime import Runtime
+
+
+class SomeException(Exception):
+    pass
+
+
+def test_bridge_runtime_raise_in_thread():
+    waiting = Event()
+    exc_in_thread: Optional[Exception] = None
+
+    def wait_forever():
+        try:
+            waiting.set()
+            while True:
+                sleep(0.1)
+        except BaseException as err:
+            nonlocal exc_in_thread
+            exc_in_thread = err
+
+    # Start thread
+    thread = Thread(target=wait_forever, daemon=True)
+    thread.start()
+
+    # Wait until sleeping
+    waiting.wait(5)
+
+    # Raise exception
+    assert thread.ident
+    assert thread.is_alive()
+    assert Runtime._raise_in_thread(thread.ident, SomeException)
+
+    # Make sure thread completes
+    thread.join(5)
+    assert not thread.is_alive()
+    assert type(exc_in_thread) is SomeException


### PR DESCRIPTION
## What was changed

* Throw inside sync threaded activities on cancellation using https://docs.python.org/3/c-api/init.html#c.PyThreadState_SetAsyncExc in test env and regular env
* Add ability in `@activity.defn` decorator to avoid this
* Add `activity.shield_thread_cancel_exception` context manager to have blocks shielded from this exception
* Docs and tests

## Checklist

1. Closes #146