### PR TITLE
Sandbox Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The Python SDK is under development. There are no compatibility guarantees at th
         - [Sandbox is not Secure](#sandbox-is-not-secure)
         - [Sandbox Performance](#sandbox-performance)
         - [Extending Restricted Classes](#extending-restricted-classes)
+        - [Certain Standard Library Calls on Restricted Objects](#certain-standard-library-calls-on-restricted-objects)
         - [is_subclass of ABC-based Restricted Classes](#is_subclass-of-abc-based-restricted-classes)
   - [Activities](#activities)
     - [Definition](#definition-1)
@@ -802,9 +803,22 @@ To mitigate this, users should:
 
 ###### Extending Restricted Classes
 
-Currently, extending classes marked as restricted causes an issue with their `__init__` parameters. This does not affect
-most users, but if there is a dependency that is, say, extending `zipfile.ZipFile` an error may occur and the module
-will have to be marked as pass through.
+Extending a restricted class causes Python to instantiate the restricted metaclass which is unsupported. Therefore if
+you attempt to use a class in the sandbox that extends a restricted class, it will fail. For example, if you have a
+`class MyZipFile(zipfile.ZipFile)` and try to use that class inside a workflow, it will fail.
+
+Classes used inside the workflow should not extend restricted classes. For situations where third-party modules need to
+at import time, they should be marked as pass through modules.
+
+###### Certain Standard Library Calls on Restricted Objects
+
+If an object is restricted, internal C Python validation may fail in some cases. For example, running
+`dict.items(os.__dict__)` will fail with:
+
+> descriptor 'items' for 'dict' objects doesn't apply to a '_RestrictedProxy' object
+
+This is a low-level check that cannot be subverted. The solution is to not use restricted objects inside the sandbox.
+For situations where third-party modules need to at import time, they should be marked as pass through modules.
 
 ###### is_subclass of ABC-based Restricted Classes
 

--- a/README.md
+++ b/README.md
@@ -731,7 +731,7 @@ my_restrictions = dataclasses.replace(
     SandboxRestrictions.default,
     passthrough_modules=SandboxRestrictions.passthrough_modules_default | SandboxMatcher(access={"pydantic"}),
 )
-my_worker = Worker(..., runner=SandboxedWorkflowRunner(restrictions=my_restrictions))
+my_worker = Worker(..., workflow_runner=SandboxedWorkflowRunner(restrictions=my_restrictions))
 ```
 
 If an "access" match succeeds for an import, it will simply be forwarded from outside of the sandbox. See the API for
@@ -750,7 +750,7 @@ my_restrictions = dataclasses.replace(
       "datetime", "date", "today",
     ),
 )
-my_worker = Worker(..., runner=SandboxedWorkflowRunner(restrictions=my_restrictions))
+my_worker = Worker(..., workflow_runner=SandboxedWorkflowRunner(restrictions=my_restrictions))
 ```
 
 Restrictions can also be added by `|`'ing together matchers, for example to restrict the `datetime.date` class from
@@ -763,7 +763,7 @@ my_restrictions = dataclasses.replace(
       children={"datetime": SandboxMatcher(use={"date"})},
     ),
 )
-my_worker = Worker(..., runner=SandboxedWorkflowRunner(restrictions=my_restrictions))
+my_worker = Worker(..., workflow_runner=SandboxedWorkflowRunner(restrictions=my_restrictions))
 ```
 
 See the API for more details on exact fields and their meaning.

--- a/README.md
+++ b/README.md
@@ -853,6 +853,16 @@ Due to [https://bugs.python.org/issue44847](https://bugs.python.org/issue44847),
 checked to see if they are subclasses of another via `is_subclass` may fail (see also
 [this wrapt issue](https://github.com/GrahamDumpleton/wrapt/issues/130)).
 
+###### Compiled Pydantic Sometimes Using Wrong Types
+
+If the Pydantic dependency is in compiled form (the default) and you are using a Pydantic model inside a workflow
+sandbox that uses a `datetime` type, it will grab the wrong validator and use `date` instead. This is because our
+patched form of `issubclass` is bypassed by compiled Pydantic.
+
+To work around, either don't use `datetime`-based Pydantic model fields in workflows, or mark `datetime` library as
+passthrough (means you lose protection against calling the non-deterministic `now()`), or use non-compiled Pydantic
+dependency.
+
 ### Activities
 
 #### Definition

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The Python SDK is under development. There are no compatibility guarantees at th
         - [Extending Restricted Classes](#extending-restricted-classes)
         - [Certain Standard Library Calls on Restricted Objects](#certain-standard-library-calls-on-restricted-objects)
         - [is_subclass of ABC-based Restricted Classes](#is_subclass-of-abc-based-restricted-classes)
+        - [Compiled Pydantic Sometimes Using Wrong Types](#compiled-pydantic-sometimes-using-wrong-types)
   - [Activities](#activities)
     - [Definition](#definition-1)
     - [Types of Activities](#types-of-activities)

--- a/temporalio/worker/workflow_sandbox/_importer.py
+++ b/temporalio/worker/workflow_sandbox/_importer.py
@@ -14,6 +14,7 @@ import logging
 import sys
 import threading
 import types
+import warnings
 from contextlib import ExitStack, contextmanager
 from typing import (
     Any,
@@ -29,6 +30,7 @@ from typing import (
     Set,
     Tuple,
     TypeVar,
+    no_type_check,
 )
 
 from typing_extensions import ParamSpec
@@ -107,6 +109,33 @@ class Importer:
                         )
                     )
 
+            # Need to unwrap params for isinstance and issubclass. We have
+            # chosen to do it this way instead of customize __instancecheck__
+            # and __subclasscheck__ because we may have proxied the second
+            # parameter which does not have a way to override. It is unfortunate
+            # we have to change these globals for everybody.
+            def unwrap_second_param(orig: Any, a: Any, b: Any) -> Any:
+                a = RestrictionContext.unwrap_if_proxied(a)
+                b = RestrictionContext.unwrap_if_proxied(b)
+                return orig(a, b)
+
+            thread_local_is_inst = _get_thread_local_builtin("isinstance")
+            self.restricted_builtins.append(
+                (
+                    "isinstance",
+                    thread_local_is_inst,
+                    functools.partial(unwrap_second_param, thread_local_is_inst.orig),
+                )
+            )
+            thread_local_is_sub = _get_thread_local_builtin("issubclass")
+            self.restricted_builtins.append(
+                (
+                    "issubclass",
+                    thread_local_is_sub,
+                    functools.partial(unwrap_second_param, thread_local_is_sub.orig),
+                )
+            )
+
     @contextmanager
     def applied(self) -> Iterator[None]:
         """Context manager to apply this restrictive import.
@@ -153,17 +182,21 @@ class Importer:
         fromlist: Sequence[str] = (),
         level: int = 0,
     ) -> types.ModuleType:
+        # We have to resolve the full name, it can be relative at different
+        # levels
+        full_name = _resolve_module_name(name, globals, level)
+
         # Check module restrictions and passthrough modules
-        if name not in sys.modules:
+        if full_name not in sys.modules:
             # Make sure not an entirely invalid module
-            self._assert_valid_module(name)
+            self._assert_valid_module(full_name)
 
             # Check if passthrough
-            passthrough_mod = self._maybe_passthrough_module(name)
+            passthrough_mod = self._maybe_passthrough_module(full_name)
             if passthrough_mod:
                 # Load all parents. Usually Python does this for us, but not on
                 # passthrough.
-                parent, _, child = name.rpartition(".")
+                parent, _, child = full_name.rpartition(".")
                 if parent and parent not in sys.modules:
                     _trace(
                         "Importing parent module %s before passing through %s",
@@ -174,17 +207,17 @@ class Importer:
                     # Set the passthrough on the parent
                     setattr(sys.modules[parent], child, passthrough_mod)
                 # Set the passthrough on sys.modules and on the parent
-                sys.modules[name] = passthrough_mod
+                sys.modules[full_name] = passthrough_mod
                 # Put it on the parent
                 if parent:
-                    setattr(sys.modules[parent], child, sys.modules[name])
+                    setattr(sys.modules[parent], child, sys.modules[full_name])
 
             # If the module is __temporal_main__ and not already in sys.modules,
             # we load it from whatever file __main__ was originally in
-            if name == "__temporal_main__":
+            if full_name == "__temporal_main__":
                 orig_mod = _thread_local_sys_modules.orig["__main__"]
                 new_spec = importlib.util.spec_from_file_location(
-                    name, orig_mod.__file__
+                    full_name, orig_mod.__file__
                 )
                 if not new_spec:
                     raise ImportError(
@@ -195,7 +228,7 @@ class Importer:
                         f"Spec for __main__ file at {orig_mod.__file__} has no loader"
                     )
                 new_mod = importlib.util.module_from_spec(new_spec)
-                sys.modules[name] = new_mod
+                sys.modules[full_name] = new_mod
                 new_spec.loader.exec_module(new_mod)
 
         mod = importlib.__import__(name, globals, locals, fromlist, level)
@@ -409,3 +442,50 @@ def _get_thread_local_builtin(name: str) -> _ThreadLocalCallable:
         ret = _ThreadLocalCallable(getattr(builtins, name))
         _thread_local_builtins[name] = ret
     return ret
+
+
+def _resolve_module_name(
+    name: str, globals: Optional[Mapping[str, object]], level: int
+) -> str:
+    if level == 0:
+        return name
+    # Calc the package from globals
+    package = _calc___package__(globals or {})
+    # Logic taken from importlib._resolve_name
+    bits = package.rsplit(".", level - 1)
+    if len(bits) < level:
+        raise ImportError("Attempted relative import beyond top-level package")
+    base = bits[0]
+    return f"{base}.{name}" if name else base
+
+
+# Copied from importlib._calc__package__
+@no_type_check
+def _calc___package__(globals: Mapping[str, object]) -> str:
+    """Calculate what __package__ should be.
+    __package__ is not guaranteed to be defined or could be set to None
+    to represent that its proper value is unknown.
+    """
+    package = globals.get("__package__")
+    spec = globals.get("__spec__")
+    if package is not None:
+        if spec is not None and package != spec.parent:
+            warnings.warn(
+                "__package__ != __spec__.parent " f"({package!r} != {spec.parent!r})",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+        return package
+    elif spec is not None:
+        return spec.parent
+    else:
+        warnings.warn(
+            "can't resolve package from __spec__ or __package__, "
+            "falling back on __name__ and __path__",
+            ImportWarning,
+            stacklevel=3,
+        )
+        package = globals["__name__"]
+        if "__path__" not in globals:
+            package = package.rpartition(".")[0]
+    return package

--- a/temporalio/worker/workflow_sandbox/_restrictions.py
+++ b/temporalio/worker/workflow_sandbox/_restrictions.py
@@ -640,6 +640,13 @@ class RestrictionContext:
             if we're just importing it.
     """
 
+    @staticmethod
+    def unwrap_if_proxied(v: Any) -> Any:
+        """Unwrap a proxy object if proxied."""
+        if type(v) is _RestrictedProxy:
+            v = _RestrictionState.from_proxy(v).obj
+        return v
+
     def __init__(self) -> None:
         """Create a restriction context."""
         self.is_runtime = False
@@ -897,7 +904,6 @@ class _RestrictedProxy:
     # __slots__ used by proxy itself
     # __dict__ (__getattr__)
     # __weakref__ (__getattr__)
-    # __init_subclass__ (proxying metaclass not supported)
     # __prepare__ (metaclass)
     __class__ = _RestrictedProxyLookup(  # type: ignore
         fallback_func=lambda self: type(self), is_attr=True

--- a/temporalio/worker/workflow_sandbox/_restrictions.py
+++ b/temporalio/worker/workflow_sandbox/_restrictions.py
@@ -358,6 +358,9 @@ SandboxRestrictions.passthrough_modules_with_temporal = SandboxRestrictions.pass
     # Due to pkg_resources use of base classes caused by the ABC issue
     # above, and Otel's use of pkg_resources, we pass it through
     "pkg_resources",
+    # Due to how Pydantic is importing lazily inside of some classes, we choose
+    # to always pass it through
+    "pydantic",
 }
 
 # sys.stdlib_module_names is only available on 3.10+, so we hardcode here. A

--- a/tests/worker/workflow_sandbox/test_importer.py
+++ b/tests/worker/workflow_sandbox/test_importer.py
@@ -33,15 +33,20 @@ def test_workflow_sandbox_importer_passthrough_module():
     assert outside1.module_state == ["module orig"]
     assert outside2.module_state == ["module orig"]
 
-    # Now import both via importer
+    # Now import via importer
     with Importer(restrictions, RestrictionContext()).applied():
         import tests.worker.workflow_sandbox.testmodules.passthrough_module as inside1
         import tests.worker.workflow_sandbox.testmodules.stateful_module as inside2
+
+        from .testmodules import stateful_module as inside_relative2
 
     # Now if we alter inside1, it's passthrough so it affects outside1
     inside1.module_state = ["another val"]
     assert outside1.module_state == ["another val"]
     assert id(inside1) == id(outside1)
+
+    # Confirm relative is same as non-relative
+    assert id(inside2) == id(inside_relative2)
 
     # But if we alter non-passthrough inside2 it does not affect outside2
     inside2.module_state = ["another val"]

--- a/tests/worker/workflow_sandbox/test_importer.py
+++ b/tests/worker/workflow_sandbox/test_importer.py
@@ -2,6 +2,7 @@ import sys
 
 import pytest
 
+from temporalio import workflow
 from temporalio.worker.workflow_sandbox._importer import (
     Importer,
     _thread_local_sys_modules,
@@ -52,6 +53,15 @@ def test_workflow_sandbox_importer_passthrough_module():
     inside2.module_state = ["another val"]
     assert outside2.module_state != ["another val"]
     assert id(inside2) != id(outside2)
+
+
+def test_workflow_sandbox_importer_passthough_context_manager():
+    import tests.worker.workflow_sandbox.testmodules.stateful_module as outside
+
+    with Importer(restrictions, RestrictionContext()).applied():
+        with workflow.unsafe.imports_passed_through():
+            import tests.worker.workflow_sandbox.testmodules.stateful_module as inside
+    assert id(outside) == id(inside)
 
 
 def test_workflow_sandbox_importer_invalid_module_members():

--- a/tests/worker/workflow_sandbox/test_restrictions.py
+++ b/tests/worker/workflow_sandbox/test_restrictions.py
@@ -10,6 +10,7 @@ from temporalio.worker.workflow_sandbox._restrictions import (
     RestrictedWorkflowAccessError,
     RestrictionContext,
     SandboxMatcher,
+    SandboxRestrictions,
     _RestrictedProxy,
     _stdlib_module_names,
 )
@@ -32,6 +33,14 @@ def test_workflow_sandbox_stdlib_module_names():
     assert (
         actual_names == _stdlib_module_names
     ), f"Expecting names as {actual_names}. In code as:\n{code}"
+
+
+def test_workflow_sandbox_restrictions_add_passthrough_modules():
+    updated = SandboxRestrictions.default.with_passthrough_modules("module1", "module2")
+    assert (
+        "module1" in updated.passthrough_modules
+        and "module2" in updated.passthrough_modules
+    )
 
 
 @dataclass

--- a/tests/worker/workflow_sandbox/test_runner.py
+++ b/tests/worker/workflow_sandbox/test_runner.py
@@ -9,7 +9,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from enum import IntEnum
-from typing import Callable, Dict, List, Optional, Sequence, Type
+from typing import Callable, Dict, List, Optional, Sequence, Set, Type
 
 import pytest
 from pydantic import BaseModel
@@ -90,7 +90,7 @@ class GlobalStateWorkflow:
 )
 async def test_workflow_sandbox_global_state(
     client: Client,
-    sandboxed_passthrough_modules: SandboxMatcher,
+    sandboxed_passthrough_modules: Set[str],
 ):
     global global_state
     async with new_worker(
@@ -445,7 +445,7 @@ def new_worker(
     *workflows: Type,
     activities: Sequence[Callable] = [],
     task_queue: Optional[str] = None,
-    sandboxed_passthrough_modules: Optional[SandboxMatcher] = None,
+    sandboxed_passthrough_modules: Set[str] = set(),
     sandboxed_invalid_module_members: Optional[SandboxMatcher] = None,
 ) -> Worker:
     restrictions = SandboxRestrictions.default

--- a/tests/worker/workflow_sandbox/test_runner.py
+++ b/tests/worker/workflow_sandbox/test_runner.py
@@ -11,7 +11,6 @@ from datetime import date, datetime, timedelta
 from enum import IntEnum
 from typing import Callable, Dict, List, Optional, Sequence, Set, Type
 
-import pydantic
 import pytest
 
 import temporalio.worker.workflow_sandbox._restrictions
@@ -387,6 +386,10 @@ async def test_workflow_sandbox_with_proto(client: Client):
             task_queue=worker.task_queue,
         )
         assert result is not param and result == param
+
+
+with workflow.unsafe.imports_passed_through():
+    import pydantic
 
 
 class PydanticMessage(pydantic.BaseModel):

--- a/tests/worker/workflow_sandbox/test_runner.py
+++ b/tests/worker/workflow_sandbox/test_runner.py
@@ -11,6 +11,7 @@ from datetime import date, datetime, timedelta
 from enum import IntEnum
 from typing import Callable, Dict, List, Optional, Sequence, Set, Type
 
+import pydantic
 import pytest
 
 import temporalio.worker.workflow_sandbox._restrictions
@@ -386,10 +387,6 @@ async def test_workflow_sandbox_with_proto(client: Client):
             task_queue=worker.task_queue,
         )
         assert result is not param and result == param
-
-
-with workflow.unsafe.imports_passed_through():
-    import pydantic
 
 
 class PydanticMessage(pydantic.BaseModel):

--- a/tests/worker/workflow_sandbox/testmodules/__init__.py
+++ b/tests/worker/workflow_sandbox/testmodules/__init__.py
@@ -5,10 +5,7 @@ from temporalio.worker.workflow_sandbox._restrictions import (
 
 restrictions = SandboxRestrictions(
     passthrough_modules=SandboxRestrictions.passthrough_modules_minimum
-    | SandboxMatcher.nested_child(
-        "tests.worker.workflow_sandbox.testmodules".split("."),
-        SandboxMatcher(access={"passthrough_module"}),
-    ),
+    | {"tests.worker.workflow_sandbox.testmodules.passthrough_module"},
     invalid_modules=SandboxMatcher.nested_child(
         "tests.worker.workflow_sandbox.testmodules".split("."),
         SandboxMatcher(access={"invalid_module"}),


### PR DESCRIPTION
## What was changed

* Fix issue with `isinstance` and `issubclass` in sandbox
  * Made them be thread-local during sandbox run and if in sandbox, make sure to unwrap their parameters before running
* Properly resolve relative imports to their full names for checking against passthrough/restrictions
* Add `with workflow.unsafe.imports_passed_through():` context manager for easier passthrough
* Change `SandboxRestrictions.passthrough_modules` to be a simple set of strings instead of the unnecessary full sandbox matcher used by other restrictions (💥 technically a breaking change in a marked-unstable API area)
* Added `SandboxRestrictions.with_passthrough_modules` helper to add passthrough modules to the immutable restriction set
* Did hack to make subclasses of restricted/proxy types at lease load. They still don't work if used though.
* Mark Pydantic datetime issue as a known issue
* Clarified passthrough module customization in README

## Checklist

1. Closes #203
2. Closes #204
2. Relates to #207
2. Closes #208
2. Closes #210
2. Closes #216