### PR TITLE
Minor type improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,9 @@ The default data converter supports converting multiple types including:
 
 This notably doesn't include any `date`, `time`, or `datetime` objects as they may not work across SDKs.
 
+Classes with generics may not have the generics properly resolved. The current implementation, similar to Pydantic, does
+not have generic type resolution. Users should use concrete types.
+
 For converting from JSON, the workflow/activity type hint is taken into account to convert to the proper type. Care has
 been taken to support all common typings including `Optional`, `Union`, all forms of iterables and mappings, `NewType`,
 etc in addition to the regular JSON values mentioned before.

--- a/README.md
+++ b/README.md
@@ -360,7 +360,10 @@ class GreetingWorkflow:
             # Wait for salutation update or complete signal (this can be
             # cancelled)
             await asyncio.wait(
-                [self._greeting_info_update.wait(), self._complete.wait()],
+                [
+                    asyncio.create_task(self._greeting_info_update.wait()),
+                    asyncio.create_task(self._complete.wait()),
+                ],
                 return_when=asyncio.FIRST_COMPLETED,
             )
             if self._complete.is_set():

--- a/temporalio/client.py
+++ b/temporalio/client.py
@@ -320,6 +320,7 @@ class Client:
         args: Sequence[Any] = [],
         id: str,
         task_queue: str,
+        result_type: Optional[Type] = None,
         execution_timeout: Optional[timedelta] = None,
         run_timeout: Optional[timedelta] = None,
         task_timeout: Optional[timedelta] = None,
@@ -343,6 +344,7 @@ class Client:
         args: Sequence[Any] = [],
         id: str,
         task_queue: str,
+        result_type: Optional[Type] = None,
         execution_timeout: Optional[timedelta] = None,
         run_timeout: Optional[timedelta] = None,
         task_timeout: Optional[timedelta] = None,
@@ -365,6 +367,8 @@ class Client:
             args: Multiple arguments to the workflow. Cannot be set if arg is.
             id: Unique identifier for the workflow execution.
             task_queue: Task queue to run the workflow on.
+            result_type: For string workflows, this can set the specific result
+                type hint to deserialize into.
             execution_timeout: Total workflow execution timeout including
                 retries and continue as new.
             run_timeout: Timeout of a single workflow run.
@@ -390,13 +394,13 @@ class Client:
         """
         # Use definition if callable
         name: str
-        ret_type: Optional[Type] = None
         if isinstance(workflow, str):
             name = workflow
         elif callable(workflow):
             defn = temporalio.workflow._Definition.must_from_run_fn(workflow)
             name = defn.name
-            ret_type = defn.ret_type
+            if result_type is None:
+                result_type = defn.ret_type
         else:
             raise TypeError("Workflow must be a string or callable")
 
@@ -417,7 +421,7 @@ class Client:
                 headers={},
                 start_signal=start_signal,
                 start_signal_args=start_signal_args,
-                ret_type=ret_type,
+                ret_type=result_type,
                 rpc_metadata=rpc_metadata,
                 rpc_timeout=rpc_timeout,
             )
@@ -506,6 +510,7 @@ class Client:
         args: Sequence[Any] = [],
         id: str,
         task_queue: str,
+        result_type: Optional[Type] = None,
         execution_timeout: Optional[timedelta] = None,
         run_timeout: Optional[timedelta] = None,
         task_timeout: Optional[timedelta] = None,
@@ -529,6 +534,7 @@ class Client:
         args: Sequence[Any] = [],
         id: str,
         task_queue: str,
+        result_type: Optional[Type] = None,
         execution_timeout: Optional[timedelta] = None,
         run_timeout: Optional[timedelta] = None,
         task_timeout: Optional[timedelta] = None,
@@ -555,6 +561,7 @@ class Client:
                 arg,
                 args=args,
                 task_queue=task_queue,
+                result_type=result_type,
                 id=id,
                 execution_timeout=execution_timeout,
                 run_timeout=run_timeout,

--- a/temporalio/common.py
+++ b/temporalio/common.py
@@ -222,11 +222,7 @@ def _type_hints_from_func(
     sig = inspect.signature(func)
     hints = get_type_hints(func)
     ret_hint = hints.get("return")
-    ret = (
-        ret_hint
-        if inspect.isclass(ret_hint) and ret_hint is not inspect.Signature.empty
-        else None
-    )
+    ret = ret_hint if ret_hint is not inspect.Signature.empty else None
     args: List[Type] = []
     for index, value in enumerate(sig.parameters.values()):
         # Ignore self on methods
@@ -244,7 +240,9 @@ def _type_hints_from_func(
             return (None, ret)
         # All params must have annotations or we consider none to have them
         arg_hint = hints.get(value.name)
-        if not inspect.isclass(arg_hint) or arg_hint is inspect.Parameter.empty:
+        if arg_hint is inspect.Parameter.empty:
             return (None, ret)
-        args.append(arg_hint)
+        # Ignoring type here because union/optional isn't really a type
+        # necessarily
+        args.append(arg_hint)  # type: ignore
     return args, ret

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -34,7 +34,7 @@ async def assert_eq_eventually(
     expected: T,
     fn: Callable[[], Awaitable[T]],
     *,
-    timeout: timedelta = timedelta(seconds=3),
+    timeout: timedelta = timedelta(seconds=10),
     interval: timedelta = timedelta(milliseconds=200),
 ) -> None:
     start_sec = time.monotonic()


### PR DESCRIPTION
## What was changed

* Properly support `Optional` params in workflows/activities
* Make sure that we don't try to send cancelled error to server on worker shutdown (was only caused by the recent #217)
* Updated README to note that generic types are not resolved for purposes of deserialization
* Updated README to properly use `asyncio.create_task` for calls to `asyncio.wait` since 3.11 requires that now

## Checklist

1. Closes #232
2. Closes #234
3. Closes #236
4. Closes #237