### PR TITLE
Fail activity worker on broken executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,6 +938,9 @@ Note, all calls from an activity to functions in the `temporalio.activity` packa
 activities must `copy_context()` and then `.run()` manually to ensure `temporalio.activity` calls like `heartbeat` still
 function in the new threads.
 
+If any activity ever throws a `concurrent.futures.BrokenExecutor`, the failure is consisted unrecoverable and the worker
+will fail and shutdown.
+
 ###### Synchronous Multithreaded Activities
 
 If `activity_executor` is set to an instance of `concurrent.futures.ThreadPoolExecutor` then the synchronous activities

--- a/temporalio/worker/_worker.py
+++ b/temporalio/worker/_worker.py
@@ -93,7 +93,9 @@ class Worker:
             activity_executor: Concurrent executor to use for non-async
                 activities. This is required if any activities are non-async. If
                 this is a :py:class:`concurrent.futures.ProcessPoolExecutor`,
-                all non-async activities must be picklable.
+                all non-async activities must be picklable. Note, a broken
+                executor failure from this executor will cause the worker to
+                fail and shutdown.
             workflow_task_executor: Thread pool executor for workflow tasks. If
                 this is not present, a new
                 :py:class:`concurrent.futures.ThreadPoolExecutor` will be


### PR DESCRIPTION
## What was changed

When using sync activities, if the thread pool or process pool executor breaks irrecoverably, we now fail the entire worker.

## Checklist

1. Closes #245