### PR TITLE
Add missing option to `WorkflowIDReusePolicy` enum

### DIFF
--- a/temporalio/common.py
+++ b/temporalio/common.py
@@ -118,6 +118,9 @@ class WorkflowIDReusePolicy(IntEnum):
     REJECT_DUPLICATE = int(
         temporalio.api.enums.v1.WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE
     )
+    TERMINATE_IF_RUNNING = int(
+        temporalio.api.enums.v1.WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING
+    )
 
 
 class QueryRejectCondition(IntEnum):


### PR DESCRIPTION
## What was changed

This PR adds the missing `TERMINATE_IF_RUNNING` option to the existing `WorkflowIDReusePolicy` enum.

## Why?

So that users of the SDK can use the easily accessible enum value, instead of hardcoding the value `4` or reaching for the longer import `temporalio.api.enums.v1.WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING`.

## Checklist

1. How was this tested:

No special tests, that is an enum.

2. Any docs updates needed?

I haven't found any documentation to update.