### PR TITLE
Support string subtypes as function arguments in workflows

### DIFF
--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -1277,6 +1277,14 @@ def value_to_type(hint: Type, value: Any) -> Any:
                 )
             return hint(value)
 
+    # String Subtype
+    if inspect.isclass(hint) and issubclass(hint, str):
+        if not isinstance(value, str):
+            raise TypeError(
+                f"Cannot convert to {hint}, value not a string, value is {type(value)}"
+            )
+        return hint(value)
+
     # UUID
     if inspect.isclass(hint) and issubclass(hint, uuid.UUID):
         return hint(value)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -363,6 +363,9 @@ def test_json_type_hints():
             [SerializableStrEnum.FOO, SerializableStrEnum.FOO],
         )
 
+    # String Subtype
+    ok(StringSubtype, StringSubtype("abc"))
+
     # 3.10+ checks
     if sys.version_info >= (3, 10):
         ok(list[int], [1, 2])

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -64,6 +64,9 @@ if sys.version_info >= (3, 11):
 class StringSubtype(str):
   pass
 
+class StringEnumOldStyle(str, Enum):
+    FOO = "foo"
+
 
 @dataclass
 class MyDataClass:
@@ -369,6 +372,7 @@ def test_json_type_hints():
 
     # String Subtype
     ok(StringSubtype, StringSubtype("abc"))
+    ok(StringEnumOldStyle, StringEnumOldStyle.FOO)
 
     # 3.10+ checks
     if sys.version_info >= (3, 10):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -61,6 +61,10 @@ if sys.version_info >= (3, 11):
         FOO = "foo"
 
 
+class StringSubtype(str):
+  pass
+
+
 @dataclass
 class MyDataClass:
     foo: str


### PR DESCRIPTION
## What was changed
[Regression fix] Support string subtypes as function arguments in workflows, by handling explicitly in `converter.value_to_type`

## Why?
When we upgraded from b0.1 to v1.0, we experienced a regression in the deserialization of string subtypes. Not sure exactly which diff introduced the bug. As a result, String subtypes were being deserialized as lists of characters, rather than strings.

## Checklist

1. Closes: N/A

2. How was this tested: Unit test

3. Any docs updates needed? Not sure
