### PR TITLE
Pass through global telemetry tags

### DIFF
--- a/temporalio/bridge/runtime.py
+++ b/temporalio/bridge/runtime.py
@@ -73,3 +73,4 @@ class TelemetryConfig:
     tracing: Optional[TracingConfig]
     logging: Optional[LoggingConfig]
     metrics: Optional[MetricsConfig]
+    global_tags: Mapping[str, str]

--- a/temporalio/bridge/src/runtime.rs
+++ b/temporalio/bridge/src/runtime.rs
@@ -30,6 +30,7 @@ pub struct TelemetryConfig {
     tracing: Option<TracingConfig>,
     logging: Option<LoggingConfig>,
     metrics: Option<MetricsConfig>,
+    global_tags: Option<HashMap<String, String>>
 }
 
 #[derive(FromPyObject)]
@@ -128,6 +129,9 @@ impl TryFrom<TelemetryConfig> for TelemetryOptions {
                     "Either OpenTelemetry or Prometheus config must be provided",
                 ));
             });
+        }
+        if let Some(v) = conf.global_tags {
+            build.global_tags(v);
         }
         build
             .build()

--- a/temporalio/runtime.py
+++ b/temporalio/runtime.py
@@ -5,7 +5,7 @@ This module is currently experimental. The API may change.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import ClassVar, Mapping, Optional, Union
 
@@ -175,6 +175,8 @@ class TelemetryConfig:
     metrics: Optional[Union[OpenTelemetryConfig, PrometheusConfig]] = None
     """Metrics configuration."""
 
+    global_tags: Mapping[str, str] = field(default_factory=dict)
+
     def _to_bridge_config(self) -> temporalio.bridge.runtime.TelemetryConfig:
         return temporalio.bridge.runtime.TelemetryConfig(
             tracing=None if not self.tracing else self.tracing._to_bridge_config(),
@@ -189,4 +191,5 @@ class TelemetryConfig:
                 if not isinstance(self.metrics, PrometheusConfig)
                 else self.metrics._to_bridge_config(),
             ),
+            global_tags=self.global_tags,
         )

--- a/temporalio/runtime.py
+++ b/temporalio/runtime.py
@@ -176,6 +176,7 @@ class TelemetryConfig:
     """Metrics configuration."""
 
     global_tags: Mapping[str, str] = field(default_factory=dict)
+    """OTel resource tags to be applied to all metrics and traces"""
 
     def _to_bridge_config(self) -> temporalio.bridge.runtime.TelemetryConfig:
         return temporalio.bridge.runtime.TelemetryConfig(


### PR DESCRIPTION
## What was changed
This PR adds python representation of `global_tags` and passes them through to rust version

## Why?
See https://github.com/temporalio/sdk-core/pull/518 for the base PR in the core SDK. This PR just adds means to set the new parameter from Python

The result should allow us to identify resources reporting metrics (i.e. service name, host ID, environment, etc)

## Checklist
<!--- add/delete as needed --->

1. Closes (closed the issue in sdk-core. Doesn't seem to be one here)

2. How was this tested:
Tested in the original PR

3. Any docs updates needed?
Unlikely (unless we document telemetry fields somewhere)

**Note:** I bumped the `sdk-core` submodule to current `master`. The project does not build with that version (and did not seem to build even before I touched it). I did my tests with my work applied on top of the commit referenced in the _current_ submodule.
My current understanding is that this is not caused by me and needs to be addressed by the maintainers at some point.