### PR TITLE
Remove github context data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
       - name: Print build information
-        run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, os: ${{ matrix.os }}, python: ${{ matrix.python }}"
+        run: "echo os: ${{ matrix.os }}, python: ${{ matrix.python }}"
       - uses: actions/checkout@v2
         with:
           submodules: recursive


### PR DESCRIPTION
## What was changed
Remove references to github context data.

## Why?
Address an injection in the runner because this is user-manipulatable information.

## Checklist

1. How was this tested:
poe test
