### PR TITLE
Dynamic workflows, activities, signals, and queries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ jobs:
           - os: ubuntu-arm
             runsOn: buildjet-4vcpu-ubuntu-2204-arm
     runs-on: ${{ matrix.runsOn || matrix.os }}
+    # For Windows there is currently a bug with Windows + pytest + warnings +
+    # importlib + Python < 3.12. Based on others' investigations, disabling
+    # bytecode fixes it.
+    # See https://github.com/temporalio/sdk-python/pull/346#issuecomment-1636108747
+    env:
+      PYTHONDONTWRITEBYTECODE: "${{ matrix.os == 'windows-latest' && '1' || '' }}"
     steps:
       - uses: actions/checkout@v2
         with:

--- a/README.md
+++ b/README.md
@@ -539,6 +539,9 @@ Here are the decorators that can be applied:
 * `@workflow.defn` - Defines a workflow class
   * Must be defined on the class given to the worker (ignored if present on a base class)
   * Can have a `name` param to customize the workflow name, otherwise it defaults to the unqualified class name
+  * Can have `dynamic=True` which means all otherwise unhandled workflows fall through to this. If present, cannot have
+    `name` argument, and run method must accept a single parameter of `Sequence[temporalio.common.RawValue]` type. The
+    payload of the raw value can be converted via `workflow.payload_converter().from_payload`.
 * `@workflow.run` - Defines the primary workflow run method
   * Must be defined on the same class as `@workflow.defn`, not a base class (but can _also_ be defined on the same
     method of a base class)
@@ -553,7 +556,8 @@ Here are the decorators that can be applied:
   * The method's arguments are the signal's arguments
   * Can have a `name` param to customize the signal name, otherwise it defaults to the unqualified method name
   * Can have `dynamic=True` which means all otherwise unhandled signals fall through to this. If present, cannot have
-    `name` argument, and method parameters must be `self`, a string signal name, and a `*args` varargs param.
+    `name` argument, and method parameters must be `self`, a string signal name, and a
+    `Sequence[temporalio.common.RawValue]`.
   * Non-dynamic method can only have positional arguments. Best practice is to only take a single argument that is an
     object/dataclass of fields that can be added to as needed.
   * Return value is ignored
@@ -1051,6 +1055,10 @@ Some things to note about activity definitions:
   activity may need (e.g. a DB connection). The instance method should be what is registered with the worker.
 * Activities can also be defined on callable classes (i.e. classes with `__call__`). An instance of the class should be
   what is registered with the worker.
+* The `@activity.defn` can have `dynamic=True` set which means all otherwise unhandled activities fall through to this.
+  If present, cannot have `name` argument, and the activity function must accept a single parameter of
+  `Sequence[temporalio.common.RawValue]`. The payload of the raw value can be converted via
+  `activity.payload_converter().from_payload`.
 
 #### Types of Activities
 

--- a/temporalio/client.py
+++ b/temporalio/client.py
@@ -408,6 +408,8 @@ class Client:
             name = workflow
         elif callable(workflow):
             defn = temporalio.workflow._Definition.must_from_run_fn(workflow)
+            if not defn.name:
+                raise TypeError("Cannot invoke dynamic workflow explicitly")
             name = defn.name
             if result_type is None:
                 result_type = defn.ret_type
@@ -2827,6 +2829,8 @@ class ScheduleActionStartWorkflow(ScheduleAction):
             # Use definition if callable
             if callable(workflow):
                 defn = temporalio.workflow._Definition.must_from_run_fn(workflow)
+                if not defn.name:
+                    raise TypeError("Cannot schedule dynamic workflow explicitly")
                 workflow = defn.name
             elif not isinstance(workflow, str):
                 raise TypeError("Workflow must be a string or callable")

--- a/temporalio/client.py
+++ b/temporalio/client.py
@@ -409,7 +409,7 @@ class Client:
         elif callable(workflow):
             defn = temporalio.workflow._Definition.must_from_run_fn(workflow)
             if not defn.name:
-                raise TypeError("Cannot invoke dynamic workflow explicitly")
+                raise ValueError("Cannot invoke dynamic workflow explicitly")
             name = defn.name
             if result_type is None:
                 result_type = defn.ret_type
@@ -2830,7 +2830,7 @@ class ScheduleActionStartWorkflow(ScheduleAction):
             if callable(workflow):
                 defn = temporalio.workflow._Definition.must_from_run_fn(workflow)
                 if not defn.name:
-                    raise TypeError("Cannot schedule dynamic workflow explicitly")
+                    raise ValueError("Cannot schedule dynamic workflow explicitly")
                 workflow = defn.name
             elif not isinstance(workflow, str):
                 raise TypeError("Workflow must be a string or callable")

--- a/temporalio/common.py
+++ b/temporalio/common.py
@@ -160,7 +160,7 @@ class RawValue:
         if not isinstance(state, bytes):
             raise TypeError(f"Expected bytes state, got {type(state)}")
         if not state[:1] == b"1":
-            raise TypeError("Bad version prefix")
+            raise ValueError("Bad version prefix")
         object.__setattr__(
             self, "payload", temporalio.api.common.v1.Payload.FromString(state[1:])
         )

--- a/temporalio/common.py
+++ b/temporalio/common.py
@@ -138,6 +138,34 @@ class QueryRejectCondition(IntEnum):
     )
 
 
+@dataclass(frozen=True)
+class RawValue:
+    """Representation of an unconverted, raw payload.
+
+    This type can be used as a parameter or return type in workflows,
+    activities, signals, and queries to pass through a raw payload.
+    Encoding/decoding of the payload is still done by the system.
+    """
+
+    payload: temporalio.api.common.v1.Payload
+
+    def __getstate__(self) -> object:
+        """Pickle support."""
+        # We'll convert payload to bytes and prepend a version number just in
+        # case we want to extend in the future
+        return b"1" + self.payload.SerializeToString()
+
+    def __setstate__(self, state: object) -> None:
+        """Pickle support."""
+        if not isinstance(state, bytes):
+            raise TypeError(f"Expected bytes state, got {type(state)}")
+        if not state[:1] == b"1":
+            raise TypeError("Bad version prefix")
+        object.__setattr__(
+            self, "payload", temporalio.api.common.v1.Payload.FromString(state[1:])
+        )
+
+
 # We choose to make this a list instead of an sequence so we can catch if people
 # are not sending lists each time but maybe accidentally sending a string (which
 # is a sequence)

--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -293,7 +293,7 @@ class CompositePayloadConverter(PayloadConverter):
         values = []
         for index, payload in enumerate(payloads):
             type_hint = None
-            if type_hints is not None:
+            if type_hints and len(type_hints) > index:
                 type_hint = type_hints[index]
             # Raw value should just wrap
             if type_hint == temporalio.common.RawValue:

--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -31,6 +31,7 @@ from typing import (
     TypeVar,
     Union,
     get_type_hints,
+    overload,
 )
 
 import google.protobuf.json_format
@@ -43,6 +44,7 @@ import temporalio.api.enums.v1
 import temporalio.api.failure.v1
 import temporalio.common
 import temporalio.exceptions
+import temporalio.types
 
 if sys.version_info < (3, 11):
     # Python's datetime.fromisoformat doesn't support certain formats pre-3.11
@@ -67,6 +69,9 @@ class PayloadConverter(ABC):
     ) -> List[temporalio.api.common.v1.Payload]:
         """Encode values into payloads.
 
+        Implementers are expected to just return the payload for
+        :py:class:`temporalio.common.RawValue`.
+
         Args:
             values: Values to be converted.
 
@@ -87,6 +92,9 @@ class PayloadConverter(ABC):
         type_hints: Optional[List[Type]] = None,
     ) -> List[Any]:
         """Decode payloads into values.
+
+        Implementers are expected to treat a type hint of
+        :py:class:`temporalio.common.RawValue` as just the raw value.
 
         Args:
             payloads: Payloads to convert to Python values.
@@ -121,6 +129,51 @@ class PayloadConverter(ABC):
         if not payloads or not payloads.payloads:
             return []
         return self.from_payloads(payloads.payloads)
+
+    def to_payload(self, value: Any) -> temporalio.api.common.v1.Payload:
+        """Convert a single value to a payload.
+
+        This is a shortcut for :py:meth:`to_payloads` with a single-item list
+        and result.
+
+        Args:
+            value: Value to convert to a single payload.
+
+        Returns:
+            Single converted payload.
+        """
+        return self.to_payloads([value])[0]
+
+    @overload
+    def from_payload(self, payload: temporalio.api.common.v1.Payload) -> Any:
+        ...
+
+    @overload
+    def from_payload(
+        self,
+        payload: temporalio.api.common.v1.Payload,
+        type_hint: Type[temporalio.types.AnyType],
+    ) -> temporalio.types.AnyType:
+        ...
+
+    def from_payload(
+        self,
+        payload: temporalio.api.common.v1.Payload,
+        type_hint: Optional[Type] = None,
+    ) -> Any:
+        """Convert a single payload to a value.
+
+        This is a shortcut for :py:meth:`from_payloads` with a single-item list
+        and result.
+
+        Args:
+            payload: Payload to convert to value.
+            type_hint: Optional type hint to say which type to convert to.
+
+        Returns:
+            Single converted value.
+        """
+        return self.from_payloads([payload], [type_hint] if type_hint else None)[0]
 
 
 class EncodingPayloadConverter(ABC):
@@ -209,10 +262,14 @@ class CompositePayloadConverter(PayloadConverter):
             # We intentionally attempt these serially just in case a stateful
             # converter may rely on the previous values
             payload = None
-            for converter in self.converters.values():
-                payload = converter.to_payload(value)
-                if payload is not None:
-                    break
+            # RawValue should just pass through
+            if isinstance(value, temporalio.common.RawValue):
+                payload = value.payload
+            else:
+                for converter in self.converters.values():
+                    payload = converter.to_payload(value)
+                    if payload is not None:
+                        break
             if payload is None:
                 raise RuntimeError(
                     f"Value at index {index} of type {type(value)} has no known converter"
@@ -235,13 +292,17 @@ class CompositePayloadConverter(PayloadConverter):
         """
         values = []
         for index, payload in enumerate(payloads):
+            type_hint = None
+            if type_hints is not None:
+                type_hint = type_hints[index]
+            # Raw value should just wrap
+            if type_hint == temporalio.common.RawValue:
+                values.append(temporalio.common.RawValue(payload))
+                continue
             encoding = payload.metadata.get("encoding", b"<unknown>")
             converter = self.converters.get(encoding)
             if converter is None:
                 raise KeyError(f"Unknown payload encoding {encoding.decode()}")
-            type_hint = None
-            if type_hints is not None:
-                type_hint = type_hints[index]
             try:
                 values.append(converter.from_payload(payload, type_hint))
             except RuntimeError as err:

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -864,7 +864,7 @@ class _WorkflowInstanceImpl(
         elif callable(activity):
             defn = temporalio.activity._Definition.must_from_callable(activity)
             if not defn.name:
-                raise TypeError("Cannot invoke dynamic activity explicitly")
+                raise ValueError("Cannot invoke dynamic activity explicitly")
             name = defn.name
             arg_types = defn.arg_types
             ret_type = defn.ret_type
@@ -971,7 +971,7 @@ class _WorkflowInstanceImpl(
         elif callable(activity):
             defn = temporalio.activity._Definition.must_from_callable(activity)
             if not defn.name:
-                raise TypeError("Cannot invoke dynamic activity explicitly")
+                raise ValueError("Cannot invoke dynamic activity explicitly")
             name = defn.name
             arg_types = defn.arg_types
             ret_type = defn.ret_type

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -10,6 +10,7 @@ import logging
 import random
 import sys
 import traceback
+import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import timedelta
@@ -222,7 +223,9 @@ class _WorkflowInstanceImpl(
         )
 
         # Maintain buffered signals for later-added dynamic handlers
-        self._buffered_signals: Dict[str, List[HandleSignalInput]] = {}
+        self._buffered_signals: Dict[
+            str, List[temporalio.bridge.proto.workflow_activation.SignalWorkflow]
+        ] = {}
 
         # Create interceptors. We do this with our runtime on the loop just in
         # case they want to access info() during init().
@@ -413,11 +416,34 @@ class _WorkflowInstanceImpl(
     def _apply_query_workflow(
         self, job: temporalio.bridge.proto.workflow_activation.QueryWorkflow
     ) -> None:
-        # Async call to run on the scheduler thread
-        async def run_query(input: HandleQueryInput) -> None:
+        # Wrap entire bunch of work in a task
+        async def run_query() -> None:
             command = self._add_command()
             command.respond_to_query.query_id = job.query_id
             try:
+                # Named query or dynamic
+                defn = self._queries.get(job.query_type) or self._queries.get(None)
+                if not defn:
+                    known_queries = sorted([k for k in self._queries.keys() if k])
+                    raise RuntimeError(
+                        f"Query handler for '{job.query_type}' expected but not found, "
+                        f"known queries: [{' '.join(known_queries)}]"
+                    )
+
+                # Create input
+                args = self._process_handler_args(
+                    job.query_type,
+                    job.arguments,
+                    defn.name,
+                    defn.arg_types,
+                    defn.dynamic_vararg,
+                )
+                input = HandleQueryInput(
+                    id=job.query_id,
+                    query=job.query_type,
+                    args=args,
+                    headers=job.headers,
+                )
                 success = await self._inbound.handle_query(input)
                 result_payloads = self._payload_converter.to_payloads([success])
                 if len(result_payloads) != 1:
@@ -437,26 +463,8 @@ class _WorkflowInstanceImpl(
                         "Failed converting application error"
                     ) from inner_err
 
-        # Just find the arg types for now. The interceptor will be responsible
-        # for checking whether the query definition actually exists.
-        arg_types: Optional[List[Type]] = None
-        query_defn = self._queries.get(job.query_type)
-        if query_defn:
-            arg_types = query_defn.arg_types
-        args = self._convert_payloads(job.arguments, arg_types)
-
         # Schedule it
-        self.create_task(
-            run_query(
-                HandleQueryInput(
-                    id=job.query_id,
-                    query=job.query_type,
-                    args=args,
-                    headers=job.headers,
-                )
-            ),
-            name=f"query: {job.query_type}",
-        )
+        self.create_task(run_query(), name=f"query: {job.query_type}")
 
     def _apply_notify_has_patch(
         self, job: temporalio.bridge.proto.workflow_activation.NotifyHasPatch
@@ -610,28 +618,12 @@ class _WorkflowInstanceImpl(
     def _apply_signal_workflow(
         self, job: temporalio.bridge.proto.workflow_activation.SignalWorkflow
     ) -> None:
-        # Just find the arg types for now. The interceptor will be responsible
-        # for checking whether the signal definition actually exists.
-        arg_types: Optional[List[Type]] = None
-        signal_defn = self._signals.get(job.signal_name)
-        if signal_defn:
-            arg_types = signal_defn.arg_types
-        input = HandleSignalInput(
-            signal=job.signal_name,
-            args=self._convert_payloads(job.input, arg_types),
-            headers=job.headers,
-        )
-
-        # If there is no definition or dynamic, we buffer and ignore
-        if not signal_defn and None not in self._signals:
-            self._buffered_signals.setdefault(job.signal_name, []).append(input)
+        # Apply to named or to dynamic or buffer
+        signal_defn = self._signals.get(job.signal_name) or self._signals.get(None)
+        if not signal_defn:
+            self._buffered_signals.setdefault(job.signal_name, []).append(job)
             return
-
-        # Schedule the handler
-        self.create_task(
-            self._run_top_level_workflow_function(self._inbound.handle_signal(input)),
-            name=f"signal: {job.signal_name}",
-        )
+        self._process_signal_job(signal_defn, job)
 
     def _apply_start_workflow(
         self, job: temporalio.bridge.proto.workflow_activation.StartWorkflow
@@ -660,12 +652,22 @@ class _WorkflowInstanceImpl(
                         "Ignoring exception while deleting workflow", exc_info=True
                     )
 
+        # Set arg types, using raw values for dynamic
+        arg_types = self._defn.arg_types
+        if not self._defn.name:
+            # Dynamic is just the raw value for each input value
+            arg_types = [temporalio.common.RawValue] * len(job.arguments)
+        args = self._convert_payloads(job.arguments, arg_types)
+        # Put args in a list if dynamic
+        if not self._defn.name:
+            args = [args]
+
         # Schedule it
         input = ExecuteWorkflowInput(
             type=self._defn.cls,
             # TODO(cretz): Remove cast when https://github.com/python/mypy/issues/5485 fixed
             run_fn=cast(Callable[..., Awaitable[Any]], self._defn.run_fn),
-            args=self._convert_payloads(job.arguments, self._defn.arg_types),
+            args=args,
             headers=job.headers,
         )
         self._primary_task = self.create_task(
@@ -789,6 +791,9 @@ class _WorkflowInstanceImpl(
             command.set_patch_marker.deprecated = deprecated
         return use_patch
 
+    def workflow_payload_converter(self) -> temporalio.converter.PayloadConverter:
+        return self._payload_converter
+
     def workflow_random(self) -> random.Random:
         return self._random
 
@@ -796,9 +801,16 @@ class _WorkflowInstanceImpl(
         self, name: Optional[str], handler: Optional[Callable]
     ) -> None:
         if handler:
-            self._queries[name] = temporalio.workflow._QueryDefinition(
+            defn = temporalio.workflow._QueryDefinition(
                 name=name, fn=handler, is_method=False
             )
+            self._queries[name] = defn
+            if defn.dynamic_vararg:
+                warnings.warn(
+                    "Dynamic queries with vararg third param is deprecated, use Sequence[RawValue]",
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
         else:
             self._queries.pop(name, None)
 
@@ -806,27 +818,24 @@ class _WorkflowInstanceImpl(
         self, name: Optional[str], handler: Optional[Callable]
     ) -> None:
         if handler:
-            self._signals[name] = temporalio.workflow._SignalDefinition(
+            defn = temporalio.workflow._SignalDefinition(
                 name=name, fn=handler, is_method=False
             )
+            self._signals[name] = defn
+            if defn.dynamic_vararg:
+                warnings.warn(
+                    "Dynamic signals with vararg third param is deprecated, use Sequence[RawValue]",
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
             # We have to send buffered signals to the handler if they apply
             if name:
-                for input in self._buffered_signals.pop(name, []):
-                    self.create_task(
-                        self._run_top_level_workflow_function(
-                            self._inbound.handle_signal(input)
-                        ),
-                        name=f"signal: {input.signal} (buffered)",
-                    )
+                for job in self._buffered_signals.pop(name, []):
+                    self._process_signal_job(defn, job)
             else:
-                for inputs in self._buffered_signals.values():
-                    for input in inputs:
-                        self.create_task(
-                            self._run_top_level_workflow_function(
-                                self._inbound.handle_signal(input)
-                            ),
-                            name=f"signal: {input.signal} (buffered)",
-                        )
+                for jobs in self._buffered_signals.values():
+                    for job in jobs:
+                        self._process_signal_job(defn, job)
                 self._buffered_signals.clear()
         else:
             self._signals.pop(name, None)
@@ -854,6 +863,8 @@ class _WorkflowInstanceImpl(
             name = activity
         elif callable(activity):
             defn = temporalio.activity._Definition.must_from_callable(activity)
+            if not defn.name:
+                raise TypeError("Cannot invoke dynamic activity explicitly")
             name = defn.name
             arg_types = defn.arg_types
             ret_type = defn.ret_type
@@ -907,6 +918,8 @@ class _WorkflowInstanceImpl(
             name = workflow
         elif callable(workflow):
             defn = temporalio.workflow._Definition.must_from_run_fn(workflow)
+            if not defn.name:
+                raise TypeError("Cannot invoke dynamic workflow explicitly")
             name = defn.name
             arg_types = defn.arg_types
             ret_type = defn.ret_type
@@ -957,6 +970,8 @@ class _WorkflowInstanceImpl(
             name = activity
         elif callable(activity):
             defn = temporalio.activity._Definition.must_from_callable(activity)
+            if not defn.name:
+                raise TypeError("Cannot invoke dynamic activity explicitly")
             name = defn.name
             arg_types = defn.arg_types
             ret_type = defn.ret_type
@@ -1186,6 +1201,46 @@ class _WorkflowInstanceImpl(
         seq = self._curr_seqs.get(type, 0) + 1
         self._curr_seqs[type] = seq
         return seq
+
+    def _process_handler_args(
+        self,
+        job_name: str,
+        job_input: Sequence[temporalio.api.common.v1.Payload],
+        defn_name: Optional[str],
+        defn_arg_types: Optional[List[Type]],
+        defn_dynamic_vararg: bool,
+    ) -> List[Any]:
+        # If dynamic old-style vararg, args become name + varargs of given arg
+        # types. If dynamic new-style raw value sequence, args become name +
+        # seq of raw values.
+        if not defn_name and defn_dynamic_vararg:
+            # Take off the string type hint for conversion
+            arg_types = defn_arg_types[1:] if defn_arg_types else None
+            return [job_name] + self._convert_payloads(job_input, arg_types)
+        if not defn_name:
+            return [
+                job_name,
+                self._convert_payloads(
+                    job_input, [temporalio.common.RawValue] * len(job_input)
+                ),
+            ]
+        return self._convert_payloads(job_input, defn_arg_types)
+
+    def _process_signal_job(
+        self,
+        defn: temporalio.workflow._SignalDefinition,
+        job: temporalio.bridge.proto.workflow_activation.SignalWorkflow,
+    ) -> None:
+        args = self._process_handler_args(
+            job.signal_name, job.input, defn.name, defn.arg_types, defn.dynamic_vararg
+        )
+        input = HandleSignalInput(
+            signal=job.signal_name, args=args, headers=job.headers
+        )
+        self.create_task(
+            self._run_top_level_workflow_function(self._inbound.handle_signal(input)),
+            name=f"signal: {job.signal_name}",
+        )
 
     def _register_task(
         self,
@@ -1501,46 +1556,26 @@ class _WorkflowInboundImpl(WorkflowInboundInterceptor):
         return await input.run_fn(*args)
 
     async def handle_signal(self, input: HandleSignalInput) -> None:
-        # Get the definition or fall through to dynamic
-        handler = self._instance.workflow_get_signal_handler(input.signal)
-        dynamic = False
-        if not handler:
-            handler = self._instance.workflow_get_signal_handler(None)
-            dynamic = True
-            # Technically this is checked before the interceptor is invoked, but
-            # an interceptor could have changed the name
-            if not handler:
-                raise RuntimeError(
-                    f"Signal handler for {input.signal} expected but not found"
-                )
-        # Put name first if dynamic
-        args = list(input.args) if not dynamic else [input.signal] + list(input.args)
+        handler = self._instance.workflow_get_signal_handler(
+            input.signal
+        ) or self._instance.workflow_get_signal_handler(None)
+        # Handler should always be present at this point
+        assert handler
         if inspect.iscoroutinefunction(handler):
-            await handler(*args)
+            await handler(*input.args)
         else:
-            handler(*args)
+            handler(*input.args)
 
     async def handle_query(self, input: HandleQueryInput) -> Any:
-        # Get the definition or fall through to dynamic
-        handler = self._instance.workflow_get_query_handler(input.query)
-        dynamic = False
-        if not handler:
-            handler = self._instance.workflow_get_query_handler(None)
-            dynamic = True
-            # Technically this is checked before the interceptor is invoked, but
-            # an interceptor could have changed the name
-            if not handler:
-                known_queries = sorted([k for k in self._instance._queries.keys() if k])
-                raise RuntimeError(
-                    f"Query handler for '{input.query}' expected but not found, "
-                    f"known queries: [{' '.join(known_queries)}]"
-                )
-        # Put name first if dynamic
-        args = list(input.args) if not dynamic else [input.query] + list(input.args)
+        handler = self._instance.workflow_get_query_handler(
+            input.query
+        ) or self._instance.workflow_get_query_handler(None)
+        # Handler should always be present at this point
+        assert handler
         if inspect.iscoroutinefunction(handler):
-            return await handler(*args)
+            return await handler(*input.args)
         else:
-            return handler(*args)
+            return handler(*input.args)
 
 
 class _WorkflowOutboundImpl(WorkflowOutboundInterceptor):

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -75,7 +75,14 @@ def defn(cls: ClassType) -> ClassType:
 
 @overload
 def defn(
-    *, name: Optional[str] = None, sandboxed: bool = True, dynamic: bool = False
+    *, name: Optional[str] = None, sandboxed: bool = True
+) -> Callable[[ClassType], ClassType]:
+    ...
+
+
+@overload
+def defn(
+    *, sandboxed: bool = True, dynamic: bool = False
 ) -> Callable[[ClassType], ClassType]:
     ...
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+import pickle
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
 import pytest
 
-from temporalio.common import RetryPolicy, _type_hints_from_func
+from temporalio.api.common.v1 import Payload
+from temporalio.common import RawValue, RetryPolicy, _type_hints_from_func
 
 
 def test_retry_policy_validate():
@@ -61,3 +63,14 @@ def test_type_hints_from_func():
     assert_hints(MyCallableClass)
     assert_hints(MyCallableClass.some_method)
     assert_hints(MyCallableClass().some_method)
+
+
+def test_raw_value_pickle():
+    pickled = pickle.dumps(
+        RawValue(Payload(metadata={"meta-key": b"meta-val"}, data=b"data-val"))
+    )
+    unpickled = pickle.loads(pickled)
+    assert isinstance(unpickled, RawValue)
+    assert isinstance(unpickled.payload, Payload)
+    assert unpickled.payload.metadata == {"meta-key": b"meta-val"}
+    assert unpickled.payload.data == b"data-val"

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -39,6 +39,7 @@ from temporalio.api.common.v1 import Payload
 from temporalio.api.common.v1 import Payload as AnotherNameForPayload
 from temporalio.api.common.v1 import Payloads
 from temporalio.api.failure.v1 import Failure
+from temporalio.common import RawValue
 from temporalio.converter import (
     AdvancedJSONEncoder,
     BinaryProtoPayloadConverter,
@@ -167,6 +168,14 @@ async def test_converter_default():
         "json/plain",
         '{"bar":123,"baz":1,"foo":"somestr"}',
         type_hint=MyDataClass,
+    )
+
+    # Raw value
+    await assert_payload(
+        RawValue(Payload(metadata={"encoding": b"my-encoding"}, data=b"blah blah")),
+        "my-encoding",
+        "blah blah",
+        type_hint=RawValue,
     )
 
 


### PR DESCRIPTION
## What was changed

* Add a `temporalio.common.RawValue` class which represents a raw payload that is never converted (but still encoded/decoded)
* Update composite/default payload converter to pass through that type by default
* Add `dynamic=True` for `@workflow.defn` which requires the run method to accept a single `Sequence[RawValue]` param
* Add `dynamic=True` for `@activity.defn` which requires the function to accept a single `Sequence[RawValue]` param
* Updated `@workflow.signal` to work with `Sequence[RawValue]` args and deprecate/warn when using the existing style (which was varargs of already-converted values which makes little sense)
* Updated `@workflow.update` to work with `Sequence[RawValue]` args and deprecate/warn when using the existing style (which was varargs of already-converted values which makes little sense)
* 💥 Interceptor behavior change! We now resolve signal and query handlers _before_ invoking interceptors like all other SDKs. If a user had some advanced use case where they had a custom interceptor and expected it to be called even for unknown signals/queries, it now will not. This should be rare.

## Checklist

1. Closes #242