### PR TITLE
Link to Python SDK launch blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ The workflow implementation basically turns `async def` functions into workflows
 event loop. This means task management, sleep, cancellation, etc have all been developed to seamlessly integrate with
 `asyncio` concepts.
 
+See the [blog post](https://temporal.io/blog/durable-distributed-asyncio-event-loop) introducing the Python SDK for an
+informal introduction to the features and their implementation.
+
 ---
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->


### PR DESCRIPTION
The blog post is essential reading for anyone interested in understanding the codebase, so I think a link from the repo README makes sense. But if it is confusing to have more links up at the top then it could also go lower down, in the "Development" section.