### PR TITLE
Provide Span.Kind for TracingInterceptor

### DIFF
--- a/temporalio/contrib/opentelemetry.py
+++ b/temporalio/contrib/opentelemetry.py
@@ -158,13 +158,9 @@ class TracingInterceptor(temporalio.client.Interceptor, temporalio.worker.Interc
         *,
         attributes: opentelemetry.util.types.Attributes,
         input: Optional[_InputWithHeaders] = None,
-        kind: opentelemetry.trace.SpanKind = opentelemetry.trace.SpanKind.INTERNAL
+        kind: opentelemetry.trace.SpanKind,
     ) -> Iterator[None]:
-        with self.tracer.start_as_current_span(
-            name,
-            attributes=attributes,
-            kind=kind
-        ):
+        with self.tracer.start_as_current_span(name, attributes=attributes, kind=kind):
             if input:
                 input.headers = self._context_to_headers(input.headers)
             yield None
@@ -195,7 +191,7 @@ class TracingInterceptor(temporalio.client.Interceptor, temporalio.worker.Interc
             attributes=params.attributes,
             links=links,
             start_time=params.time_ns,
-            kind=params.kind
+            kind=params.kind,
         )
         context = opentelemetry.trace.set_span_in_context(span, context)
         if params.exception:
@@ -224,7 +220,7 @@ class _TracingClientOutboundInterceptor(temporalio.client.OutboundInterceptor):
             f"{prefix}:{input.workflow}",
             attributes={"temporalWorkflowID": input.id},
             input=input,
-            kind=opentelemetry.trace.SpanKind.CLIENT
+            kind=opentelemetry.trace.SpanKind.CLIENT,
         ):
             return await super().start_workflow(input)
 
@@ -233,7 +229,7 @@ class _TracingClientOutboundInterceptor(temporalio.client.OutboundInterceptor):
             f"QueryWorkflow:{input.query}",
             attributes={"temporalWorkflowID": input.id},
             input=input,
-            kind=opentelemetry.trace.SpanKind.INTERNAL
+            kind=opentelemetry.trace.SpanKind.CLIENT,
         ):
             return await super().query_workflow(input)
 
@@ -244,7 +240,7 @@ class _TracingClientOutboundInterceptor(temporalio.client.OutboundInterceptor):
             f"SignalWorkflow:{input.signal}",
             attributes={"temporalWorkflowID": input.id},
             input=input,
-            kind=opentelemetry.trace.SpanKind.INTERNAL
+            kind=opentelemetry.trace.SpanKind.CLIENT,
         ):
             return await super().signal_workflow(input)
 
@@ -270,7 +266,7 @@ class _TracingActivityInboundInterceptor(temporalio.worker.ActivityInboundInterc
                 "temporalRunID": info.workflow_run_id,
                 "temporalActivityID": info.activity_id,
             },
-            kind=opentelemetry.trace.SpanKind.SERVER
+            kind=opentelemetry.trace.SpanKind.SERVER,
         ):
             return await super().execute_activity(input)
 
@@ -293,7 +289,7 @@ class _CompletedWorkflowSpanParams:
     time_ns: int
     link_context: Optional[_CarrierDict]
     exception: Optional[Exception]
-    kind: opentelemetry.trace.SpanKind = opentelemetry.trace.SpanKind.INTERNAL
+    kind: opentelemetry.trace.SpanKind
 
 
 _interceptor_context_key = opentelemetry.context.create_key(
@@ -348,7 +344,7 @@ class TracingWorkflowInboundInterceptor(temporalio.worker.WorkflowInboundInterce
             # Entrypoint of workflow should be `server` in OTel
             self._completed_span(
                 f"RunWorkflow:{temporalio.workflow.info().workflow_type}",
-                kind=opentelemetry.trace.SpanKind.SERVER
+                kind=opentelemetry.trace.SpanKind.SERVER,
             )
             return await super().execute_workflow(input)
 
@@ -368,7 +364,7 @@ class TracingWorkflowInboundInterceptor(temporalio.worker.WorkflowInboundInterce
             self._completed_span(
                 f"HandleSignal:{input.signal}",
                 link_context_carrier=link_context_carrier,
-                kind=opentelemetry.trace.SpanKind.INTERNAL
+                kind=opentelemetry.trace.SpanKind.SERVER,
             )
             await super().handle_signal(input)
 
@@ -402,7 +398,7 @@ class TracingWorkflowInboundInterceptor(temporalio.worker.WorkflowInboundInterce
                 link_context_carrier=link_context_carrier,
                 # Create even on replay for queries
                 new_span_even_on_replay=True,
-                kind=opentelemetry.trace.SpanKind.INTERNAL
+                kind=opentelemetry.trace.SpanKind.SERVER,
             )
             return await super().handle_query(input)
         finally:
@@ -452,7 +448,7 @@ class TracingWorkflowInboundInterceptor(temporalio.worker.WorkflowInboundInterce
                 self._completed_span(
                     f"CompleteWorkflow:{temporalio.workflow.info().workflow_type}",
                     exception=exception,
-                    kind=opentelemetry.trace.SpanKind.INTERNAL
+                    kind=opentelemetry.trace.SpanKind.INTERNAL,
                 )
             opentelemetry.context.detach(token)
 
@@ -484,7 +480,7 @@ class TracingWorkflowInboundInterceptor(temporalio.worker.WorkflowInboundInterce
         new_span_even_on_replay: bool = False,
         additional_attributes: opentelemetry.util.types.Attributes = None,
         exception: Optional[Exception] = None,
-        kind: opentelemetry.trace.SpanKind = opentelemetry.trace.SpanKind.INTERNAL
+        kind: opentelemetry.trace.SpanKind = opentelemetry.trace.SpanKind.INTERNAL,
     ) -> None:
         # If there is no span on the context, we do not create a span
         if opentelemetry.trace.get_current_span() is opentelemetry.trace.INVALID_SPAN:
@@ -501,7 +497,7 @@ class TracingWorkflowInboundInterceptor(temporalio.worker.WorkflowInboundInterce
         info = temporalio.workflow.info()
         attributes: Dict[str, opentelemetry.util.types.AttributeValue] = {
             "temporalWorkflowID": info.workflow_id,
-            "temporalRunID": info.run_id
+            "temporalRunID": info.run_id,
         }
         if additional_attributes:
             attributes.update(additional_attributes)
@@ -516,7 +512,7 @@ class TracingWorkflowInboundInterceptor(temporalio.worker.WorkflowInboundInterce
                 time_ns=temporalio.workflow.time_ns(),
                 link_context=link_context_carrier,
                 exception=exception,
-                kind=kind
+                kind=kind,
             )
         )
 
@@ -555,7 +551,7 @@ class _TracingWorkflowOutboundInterceptor(
         self.root._completed_span(
             f"SignalChildWorkflow:{input.signal}",
             add_to_outbound=input,
-            kind=opentelemetry.trace.SpanKind.INTERNAL
+            kind=opentelemetry.trace.SpanKind.SERVER,
         )
         await super().signal_child_workflow(input)
 
@@ -566,7 +562,7 @@ class _TracingWorkflowOutboundInterceptor(
         self.root._completed_span(
             f"SignalExternalWorkflow:{input.signal}",
             add_to_outbound=input,
-            kind=opentelemetry.trace.SpanKind.INTERNAL
+            kind=opentelemetry.trace.SpanKind.CLIENT,
         )
         await super().signal_external_workflow(input)
 
@@ -577,7 +573,7 @@ class _TracingWorkflowOutboundInterceptor(
         self.root._completed_span(
             f"StartActivity:{input.activity}",
             add_to_outbound=input,
-            kind=opentelemetry.trace.SpanKind.CLIENT
+            kind=opentelemetry.trace.SpanKind.CLIENT,
         )
         return super().start_activity(input)
 
@@ -588,7 +584,7 @@ class _TracingWorkflowOutboundInterceptor(
         self.root._completed_span(
             f"StartChildWorkflow:{input.workflow}",
             add_to_outbound=input,
-            kind=opentelemetry.trace.SpanKind.CLIENT
+            kind=opentelemetry.trace.SpanKind.CLIENT,
         )
         return await super().start_child_workflow(input)
 
@@ -599,7 +595,7 @@ class _TracingWorkflowOutboundInterceptor(
         self.root._completed_span(
             f"StartActivity:{input.activity}",
             add_to_outbound=input,
-            kind=opentelemetry.trace.SpanKind.CLIENT
+            kind=opentelemetry.trace.SpanKind.CLIENT,
         )
         return super().start_local_activity(input)
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Added span kinds for TracingInterceptor

Now, all **START** actions are **opentelemetry.trace.SpanKind.CLIENT**
and all **RUN** actions are **opentelemetry.trace.SpanKind.SERVER**

For other actions kind=INTERNAL 

## Why?
<!-- Tell your future self why have you made these changes -->
Before this changes all spans was **INTERNAL**, so it was unavailable to build service graphs for APM (ex.: Grafana Tempo)

For example, this is the service graph with INTERNAL spans:
![bad_sg](https://github.com/temporalio/sdk-python/assets/95244614/6c53d4b4-bd1f-415c-bd45-dfb9ba334733)

And this is for CLIENT/SERVER:
![good_sg](https://github.com/temporalio/sdk-python/assets/95244614/c6a1ed26-8888-4113-8dab-4485d8caad0a)

Spans attributes now look like this:
![span_ex1](https://github.com/temporalio/sdk-python/assets/95244614/e82d0386-820f-4d08-9e89-65ebd20b85d8)
![span_ex2](https://github.com/temporalio/sdk-python/assets/95244614/9e8a2f0a-f9d3-489f-9217-1c8eb24bf6c6)

All experiments located [here](https://github.com/northpowered/temporal-otlp)
This repo is a bit raw now, and hasn\`t good README, but it`ll be fixed soon



## Checklist
<!--- add/delete as needed --->

1. Closes #357 

2. How was this tested:
SDK developers reccomended testing, Integration tests were made [here](https://github.com/northpowered/temporal-otlp)

3. Any docs updates needed?
No docs updated needed
