### PR TITLE
Expose history size and continue-as-new-suggested

### DIFF
--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -175,6 +175,8 @@ class _WorkflowInstanceImpl(
         self._time_ns = 0
         self._cancel_requested = False
         self._current_history_length = 0
+        self._current_history_size = 0
+        self._continue_as_new_suggested = False
         # Lazily loaded
         self._memo: Optional[Mapping[str, Any]] = None
         # Handles which are ready to run on the next event loop iteration
@@ -272,6 +274,8 @@ class _WorkflowInstanceImpl(
         self._current_completion.successful.SetInParent()
         self._current_activation_error: Optional[Exception] = None
         self._current_history_length = act.history_length
+        self._current_history_size = act.history_size_bytes
+        self._continue_as_new_suggested = act.continue_as_new_suggested
         self._time_ns = act.timestamp.ToNanoseconds()
         self._is_replaying = act.is_replaying
 
@@ -738,6 +742,9 @@ class _WorkflowInstanceImpl(
     def workflow_get_current_history_length(self) -> int:
         return self._current_history_length
 
+    def workflow_get_current_history_size(self) -> int:
+        return self._current_history_size
+
     def workflow_get_external_workflow_handle(
         self, id: str, *, run_id: Optional[str]
     ) -> temporalio.workflow.ExternalWorkflowHandle[Any]:
@@ -759,6 +766,9 @@ class _WorkflowInstanceImpl(
 
     def workflow_info(self) -> temporalio.workflow.Info:
         return self._outbound.info()
+
+    def workflow_is_continue_as_new_suggested(self) -> bool:
+        return self._continue_as_new_suggested
 
     def workflow_is_replaying(self) -> bool:
         return self._is_replaying

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -336,10 +336,33 @@ class Info:
     def get_current_history_length(self) -> int:
         """Get the current number of events in history.
 
+        Note, this value may not be up to date if accessed inside a query.
+
         Returns:
             Current number of events in history (up until the current task).
         """
         return _Runtime.current().workflow_get_current_history_length()
+
+    def get_current_history_size(self) -> int:
+        """Get the current byte size of history.
+
+        Note, this value may not be up to date if accessed inside a query.
+
+        Returns:
+            Current byte-size of history (up until the current task).
+        """
+        return _Runtime.current().workflow_get_current_history_size()
+
+    def is_continue_as_new_suggested(self) -> bool:
+        """Get whether or not continue as new is suggested.
+
+        Note, this value may not be up to date if accessed inside a query.
+
+        Returns:
+            True if the server is configured to suggest continue as new and it
+            is suggested.
+        """
+        return _Runtime.current().workflow_is_continue_as_new_suggested()
 
 
 @dataclass(frozen=True)
@@ -406,6 +429,10 @@ class _Runtime(ABC):
         ...
 
     @abstractmethod
+    def workflow_get_current_history_size(self) -> int:
+        ...
+
+    @abstractmethod
     def workflow_get_external_workflow_handle(
         self, id: str, *, run_id: Optional[str]
     ) -> ExternalWorkflowHandle[Any]:
@@ -421,6 +448,10 @@ class _Runtime(ABC):
 
     @abstractmethod
     def workflow_info(self) -> Info:
+        ...
+
+    @abstractmethod
+    def workflow_is_continue_as_new_suggested(self) -> bool:
         ...
 
     @abstractmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,8 @@ async def env(env_type: str) -> AsyncGenerator[WorkflowEnvironment, None]:
             dev_server_extra_args=[
                 "--dynamic-config-value",
                 "system.forceSearchAttributesCacheRefreshOnRead=true",
+                "--dynamic-config-value",
+                f"limit.historyCount.suggestContinueAsNew={CONTINUE_AS_NEW_SUGGEST_HISTORY_COUNT}",
             ]
         )
     elif env_type == "time-skipping":
@@ -101,3 +103,11 @@ async def worker(
     worker = ExternalPythonWorker(env)
     yield worker
     await worker.close()
+
+
+CONTINUE_AS_NEW_SUGGEST_HISTORY_COUNT = 50
+
+
+@pytest.fixture
+def continue_as_new_suggest_history_count() -> int:
+    return CONTINUE_AS_NEW_SUGGEST_HISTORY_COUNT


### PR DESCRIPTION
## What was changed

* Added `get_history_size()` and `is_continue_as_new_suggested()` to `workflow.info()`
* Added test to confirm behavior