### PR TITLE
Fix interceptors in testing environment

### DIFF
--- a/temporalio/testing/_workflow.py
+++ b/temporalio/testing/_workflow.py
@@ -562,5 +562,5 @@ def _client_with_interceptors(
     config = client.config()
     config_interceptors = list(config["interceptors"])
     config_interceptors.extend(interceptors)
-    config["interceptors"] = interceptors
+    config["interceptors"] = config_interceptors
     return temporalio.client.Client(**config)


### PR DESCRIPTION
## What was changed

Stop overriding user interceptors in testing environment (was using wrong variable)

## Checklist

1. Closes #363