### PR TITLE
Custom metric support

### DIFF
--- a/temporalio/bridge/metric.py
+++ b/temporalio/bridge/metric.py
@@ -1,0 +1,111 @@
+"""Metrics using SDK Core. (unstable)
+
+Nothing in this module should be considered stable. The API may change.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional, Union
+
+import temporalio.bridge.runtime
+import temporalio.bridge.temporal_sdk_bridge
+
+
+class MetricMeter:
+    """Metric meter using SDK Core."""
+
+    @staticmethod
+    def create(runtime: temporalio.bridge.runtime.Runtime) -> Optional[MetricMeter]:
+        """Create optional metric meter."""
+        ref = temporalio.bridge.temporal_sdk_bridge.new_metric_meter(runtime._ref)
+        if not ref:
+            return None
+        return MetricMeter(ref)
+
+    def __init__(
+        self, ref: temporalio.bridge.temporal_sdk_bridge.MetricMeterRef
+    ) -> None:
+        """Initialize metric meter."""
+        self._ref = ref
+        self._default_attributes = MetricAttributes(ref.default_attributes)
+
+    @property
+    def default_attributes(self) -> MetricAttributes:
+        """Default attributes for the metric meter."""
+        return self._default_attributes
+
+
+class MetricCounter:
+    """Metric counter using SDK Core."""
+
+    def __init__(
+        self,
+        meter: MetricMeter,
+        name: str,
+        description: Optional[str],
+        unit: Optional[str],
+    ) -> None:
+        """Initialize counter metric."""
+        self._ref = meter._ref.new_counter(name, description, unit)
+
+    def add(self, value: int, attrs: MetricAttributes) -> None:
+        """Add value to counter."""
+        if value < 0:
+            raise ValueError("Metric value must be non-negative value")
+        self._ref.add(value, attrs._ref)
+
+
+class MetricHistogram:
+    """Metric histogram using SDK Core."""
+
+    def __init__(
+        self,
+        meter: MetricMeter,
+        name: str,
+        description: Optional[str],
+        unit: Optional[str],
+    ) -> None:
+        """Initialize histogram."""
+        self._ref = meter._ref.new_histogram(name, description, unit)
+
+    def record(self, value: int, attrs: MetricAttributes) -> None:
+        """Record value on histogram."""
+        if value < 0:
+            raise ValueError("Metric value must be non-negative value")
+        self._ref.record(value, attrs._ref)
+
+
+class MetricGauge:
+    """Metric gauge using SDK Core."""
+
+    def __init__(
+        self,
+        meter: MetricMeter,
+        name: str,
+        description: Optional[str],
+        unit: Optional[str],
+    ) -> None:
+        """Initialize gauge."""
+        self._ref = meter._ref.new_gauge(name, description, unit)
+
+    def set(self, value: int, attrs: MetricAttributes) -> None:
+        """Set value on gauge."""
+        if value < 0:
+            raise ValueError("Metric value must be non-negative value")
+        self._ref.set(value, attrs._ref)
+
+
+class MetricAttributes:
+    """Metric attributes using SDK Core."""
+
+    def __init__(
+        self, ref: temporalio.bridge.temporal_sdk_bridge.MetricAttributesRef
+    ) -> None:
+        """Initialize attributes."""
+        self._ref = ref
+
+    def with_additional_attributes(
+        self, new_attrs: Mapping[str, Union[str, int, float, bool]]
+    ) -> MetricAttributes:
+        """Create new attributes with new attributes appended."""
+        return MetricAttributes(self._ref.with_additional_attributes(new_attrs))

--- a/temporalio/bridge/src/lib.rs
+++ b/temporalio/bridge/src/lib.rs
@@ -2,6 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyTuple;
 
 mod client;
+mod metric;
 mod runtime;
 mod testing;
 mod worker;
@@ -12,6 +13,14 @@ fn temporal_sdk_bridge(py: Python, m: &PyModule) -> PyResult<()> {
     m.add("RPCError", py.get_type::<client::RPCError>())?;
     m.add_class::<client::ClientRef>()?;
     m.add_function(wrap_pyfunction!(connect_client, m)?)?;
+
+    // Metric stuff
+    m.add_class::<metric::MetricMeterRef>()?;
+    m.add_class::<metric::MetricAttributesRef>()?;
+    m.add_class::<metric::MetricCounterRef>()?;
+    m.add_class::<metric::MetricHistogramRef>()?;
+    m.add_class::<metric::MetricGaugeRef>()?;
+    m.add_function(wrap_pyfunction!(new_metric_meter, m)?)?;
 
     // Runtime stuff
     m.add_class::<runtime::RuntimeRef>()?;
@@ -42,6 +51,11 @@ fn connect_client<'a>(
     config: client::ClientConfig,
 ) -> PyResult<&'a PyAny> {
     client::connect_client(py, &runtime_ref, config)
+}
+
+#[pyfunction]
+fn new_metric_meter(runtime_ref: &runtime::RuntimeRef) -> Option<metric::MetricMeterRef> {
+    metric::new_metric_meter(&runtime_ref)
 }
 
 #[pyfunction]

--- a/temporalio/bridge/src/metric.rs
+++ b/temporalio/bridge/src/metric.rs
@@ -1,0 +1,175 @@
+use std::{collections::HashMap, sync::Arc};
+
+use pyo3::exceptions::PyTypeError;
+use pyo3::prelude::*;
+use temporal_sdk_core_api::telemetry::metrics;
+
+use crate::runtime;
+
+#[pyclass]
+pub struct MetricMeterRef {
+    meter: metrics::TemporalMeter,
+    #[pyo3(get)]
+    default_attributes: MetricAttributesRef,
+}
+
+#[pyclass]
+#[derive(Clone)]
+pub struct MetricAttributesRef {
+    attrs: metrics::MetricAttributes,
+}
+
+#[pyclass]
+pub struct MetricCounterRef {
+    counter: Arc<dyn metrics::Counter>,
+}
+
+#[pyclass]
+pub struct MetricHistogramRef {
+    histogram: Arc<dyn metrics::Histogram>,
+}
+
+#[pyclass]
+pub struct MetricGaugeRef {
+    gauge: Arc<dyn metrics::Gauge>,
+}
+
+pub fn new_metric_meter(runtime_ref: &runtime::RuntimeRef) -> Option<MetricMeterRef> {
+    runtime_ref
+        .runtime
+        .core
+        .telemetry()
+        .get_metric_meter()
+        .map(|meter| {
+            let default_attributes = MetricAttributesRef {
+                attrs: meter.inner.new_attributes(meter.default_attribs.clone()),
+            };
+            MetricMeterRef {
+                meter,
+                default_attributes,
+            }
+        })
+}
+
+#[pymethods]
+impl MetricMeterRef {
+    fn new_counter(
+        &self,
+        name: String,
+        description: Option<String>,
+        unit: Option<String>,
+    ) -> MetricCounterRef {
+        MetricCounterRef {
+            counter: self
+                .meter
+                .inner
+                .counter(build_metric_parameters(name, description, unit)),
+        }
+    }
+
+    fn new_histogram(
+        &self,
+        name: String,
+        description: Option<String>,
+        unit: Option<String>,
+    ) -> MetricHistogramRef {
+        MetricHistogramRef {
+            histogram: self
+                .meter
+                .inner
+                .histogram(build_metric_parameters(name, description, unit)),
+        }
+    }
+
+    fn new_gauge(
+        &self,
+        name: String,
+        description: Option<String>,
+        unit: Option<String>,
+    ) -> MetricGaugeRef {
+        MetricGaugeRef {
+            gauge: self
+                .meter
+                .inner
+                .gauge(build_metric_parameters(name, description, unit)),
+        }
+    }
+}
+
+#[pymethods]
+impl MetricCounterRef {
+    fn add(&self, value: u64, attrs_ref: &MetricAttributesRef) {
+        self.counter.add(value, &attrs_ref.attrs);
+    }
+}
+
+#[pymethods]
+impl MetricHistogramRef {
+    fn record(&self, value: u64, attrs_ref: &MetricAttributesRef) {
+        self.histogram.record(value, &attrs_ref.attrs);
+    }
+}
+
+#[pymethods]
+impl MetricGaugeRef {
+    fn set(&self, value: u64, attrs_ref: &MetricAttributesRef) {
+        self.gauge.record(value, &attrs_ref.attrs);
+    }
+}
+
+fn build_metric_parameters(
+    name: String,
+    description: Option<String>,
+    unit: Option<String>,
+) -> metrics::MetricParameters {
+    let mut build = metrics::MetricParametersBuilder::default();
+    build.name(name);
+    if let Some(description) = description {
+        build.description(description);
+    }
+    if let Some(unit) = unit {
+        build.unit(unit);
+    }
+    // Should be nothing that would fail validation here
+    build.build().unwrap()
+}
+
+#[pymethods]
+impl MetricAttributesRef {
+    fn with_additional_attributes<'p>(
+        &self,
+        py: Python<'p>,
+        new_attrs: HashMap<String, PyObject>,
+    ) -> PyResult<Self> {
+        let mut attrs = self.attrs.clone();
+        attrs.add_new_attrs(
+            new_attrs
+                .into_iter()
+                .map(|(k, obj)| metric_key_value_from_py(py, k, obj))
+                .collect::<PyResult<Vec<metrics::MetricKeyValue>>>()?,
+        );
+        Ok(MetricAttributesRef { attrs })
+    }
+}
+
+fn metric_key_value_from_py<'p>(
+    py: Python<'p>,
+    k: String,
+    obj: PyObject,
+) -> PyResult<metrics::MetricKeyValue> {
+    let val = if let Ok(v) = obj.extract::<String>(py) {
+        metrics::MetricValue::String(v)
+    } else if let Ok(v) = obj.extract::<bool>(py) {
+        metrics::MetricValue::Bool(v)
+    } else if let Ok(v) = obj.extract::<i64>(py) {
+        metrics::MetricValue::Int(v)
+    } else if let Ok(v) = obj.extract::<f64>(py) {
+        metrics::MetricValue::Float(v)
+    } else {
+        return Err(PyTypeError::new_err(format!(
+            "Invalid value type for key {}, must be str, int, float, or bool",
+            k
+        )));
+    };
+    Ok(metrics::MetricKeyValue::new(k, val))
+}

--- a/temporalio/common.py
+++ b/temporalio/common.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import types
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import IntEnum
@@ -22,7 +23,7 @@ from typing import (
 )
 
 import google.protobuf.internal.containers
-from typing_extensions import TypeAlias
+from typing_extensions import ClassVar, TypeAlias
 
 import temporalio.api.common.v1
 import temporalio.api.enums.v1
@@ -175,6 +176,337 @@ SearchAttributeValues: TypeAlias = Union[
 
 SearchAttributes: TypeAlias = Mapping[str, SearchAttributeValues]
 
+MetricAttributes: TypeAlias = Mapping[str, Union[str, int, float, bool]]
+
+
+class MetricMeter(ABC):
+    """Metric meter for recording metrics."""
+
+    noop: ClassVar[MetricMeter]
+    """Metric meter implementation that does nothing."""
+
+    @abstractmethod
+    def create_counter(
+        self, name: str, description: Optional[str] = None, unit: Optional[str] = None
+    ) -> MetricCounter:
+        """Create a counter metric for adding values.
+
+        Args:
+            name: Name for the metric.
+            description: Optional description for the metric.
+            unit: Optional unit for the metric.
+
+        Returns:
+            Counter metric.
+        """
+        ...
+
+    @abstractmethod
+    def create_histogram(
+        self, name: str, description: Optional[str] = None, unit: Optional[str] = None
+    ) -> MetricHistogram:
+        """Create a histogram metric for recording values.
+
+        Args:
+            name: Name for the metric.
+            description: Optional description for the metric.
+            unit: Optional unit for the metric.
+
+        Returns:
+            Histogram metric.
+        """
+        ...
+
+    @abstractmethod
+    def create_gauge(
+        self, name: str, description: Optional[str] = None, unit: Optional[str] = None
+    ) -> MetricGauge:
+        """Create a gauge metric for setting values.
+
+        Args:
+            name: Name for the metric.
+            description: Optional description for the metric.
+            unit: Optional unit for the metric.
+
+        Returns:
+            Gauge metric.
+        """
+        ...
+
+    @abstractmethod
+    def with_additional_attributes(
+        self, additional_attributes: MetricAttributes
+    ) -> MetricMeter:
+        """Create a new metric meter with the given attributes appended to the
+        current set.
+
+        Args:
+            additional_attributes: Additional attributes to append to the
+                current set.
+
+        Returns:
+            New metric meter.
+
+        Raises:
+            TypeError: Attribute values are not the expected type.
+        """
+        ...
+
+
+class MetricCounter(ABC):
+    """Counter metric created by a metric meter."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Name for the metric."""
+        ...
+
+    @property
+    @abstractmethod
+    def description(self) -> Optional[str]:
+        """Description for the metric if any."""
+        ...
+
+    @property
+    @abstractmethod
+    def unit(self) -> Optional[str]:
+        """Unit for the metric if any."""
+        ...
+
+    @abstractmethod
+    def add(
+        self, value: int, additional_attributes: Optional[MetricAttributes] = None
+    ) -> None:
+        """Add a value to the counter.
+
+        Args:
+            value: A non-negative integer to add.
+            additional_attributes: Additional attributes to append to the
+                current set.
+
+        Raises:
+            ValueError: Value is negative.
+            TypeError: Attribute values are not the expected type.
+        """
+        ...
+
+    @abstractmethod
+    def with_additional_attributes(
+        self, additional_attributes: MetricAttributes
+    ) -> MetricCounter:
+        """Create a new counter with the given attributes appended to the
+        current set.
+
+        Args:
+            additional_attributes: Additional attributes to append to the
+                current set.
+
+        Returns:
+            New counter.
+
+        Raises:
+            TypeError: Attribute values are not the expected type.
+        """
+        ...
+
+
+class MetricHistogram(ABC):
+    """Histogram metric created by a metric meter."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Name for the metric."""
+        ...
+
+    @property
+    @abstractmethod
+    def description(self) -> Optional[str]:
+        """Description for the metric if any."""
+        ...
+
+    @property
+    @abstractmethod
+    def unit(self) -> Optional[str]:
+        """Unit for the metric if any."""
+        ...
+
+    @abstractmethod
+    def record(
+        self, value: int, additional_attributes: Optional[MetricAttributes] = None
+    ) -> None:
+        """Record a value on the histogram.
+
+        Args:
+            value: A non-negative integer to record.
+            additional_attributes: Additional attributes to append to the
+                current set.
+
+        Raises:
+            ValueError: Value is negative.
+            TypeError: Attribute values are not the expected type.
+        """
+        ...
+
+    @abstractmethod
+    def with_additional_attributes(
+        self, additional_attributes: MetricAttributes
+    ) -> MetricHistogram:
+        """Create a new histogram with the given attributes appended to the
+        current set.
+
+        Args:
+            additional_attributes: Additional attributes to append to the
+                current set.
+
+        Returns:
+            New histogram.
+
+        Raises:
+            TypeError: Attribute values are not the expected type.
+        """
+        ...
+
+
+class MetricGauge(ABC):
+    """Gauge metric created by a metric meter."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Name for the metric."""
+        ...
+
+    @property
+    @abstractmethod
+    def description(self) -> Optional[str]:
+        """Description for the metric if any."""
+        ...
+
+    @property
+    @abstractmethod
+    def unit(self) -> Optional[str]:
+        """Unit for the metric if any."""
+        ...
+
+    @abstractmethod
+    def set(
+        self, value: int, additional_attributes: Optional[MetricAttributes] = None
+    ) -> None:
+        """Set a value on the gauge.
+
+        Args:
+            value: A non-negative integer to set.
+            additional_attributes: Additional attributes to append to the
+                current set.
+
+        Raises:
+            ValueError: Value is negative.
+            TypeError: Attribute values are not the expected type.
+        """
+        ...
+
+    @abstractmethod
+    def with_additional_attributes(
+        self, additional_attributes: MetricAttributes
+    ) -> MetricGauge:
+        """Create a new gauge with the given attributes appended to the
+        current set.
+
+        Args:
+            additional_attributes: Additional attributes to append to the
+                current set.
+
+        Returns:
+            New gauge.
+
+        Raises:
+            TypeError: Attribute values are not the expected type.
+        """
+        ...
+
+
+class _NoopMetricMeter(MetricMeter):
+    def create_counter(
+        self, name: str, description: Optional[str] = None, unit: Optional[str] = None
+    ) -> MetricCounter:
+        return _NoopMetricCounter(name, description, unit)
+
+    def create_histogram(
+        self, name: str, description: Optional[str] = None, unit: Optional[str] = None
+    ) -> MetricHistogram:
+        return _NoopMetricHistogram(name, description, unit)
+
+    def create_gauge(
+        self, name: str, description: Optional[str] = None, unit: Optional[str] = None
+    ) -> MetricGauge:
+        return _NoopMetricGauge(name, description, unit)
+
+    def with_additional_attributes(
+        self, additional_attributes: MetricAttributes
+    ) -> MetricMeter:
+        return self
+
+
+class _NoopMetric:
+    def __init__(
+        self, name: str, description: Optional[str], unit: Optional[str]
+    ) -> None:
+        self._name = name
+        self._description = description
+        self._unit = unit
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> Optional[str]:
+        return self._description
+
+    @property
+    def unit(self) -> Optional[str]:
+        return self._unit
+
+
+class _NoopMetricCounter(_NoopMetric, MetricCounter):
+    def add(
+        self, value: int, additional_attributes: Optional[MetricAttributes] = None
+    ) -> None:
+        pass
+
+    def with_additional_attributes(
+        self, additional_attributes: MetricAttributes
+    ) -> MetricCounter:
+        return self
+
+
+class _NoopMetricHistogram(_NoopMetric, MetricHistogram):
+    def record(
+        self, value: int, additional_attributes: Optional[MetricAttributes] = None
+    ) -> None:
+        pass
+
+    def with_additional_attributes(
+        self, additional_attributes: MetricAttributes
+    ) -> MetricHistogram:
+        return self
+
+
+class _NoopMetricGauge(_NoopMetric, MetricGauge):
+    def set(
+        self, value: int, additional_attributes: Optional[MetricAttributes] = None
+    ) -> None:
+        pass
+
+    def with_additional_attributes(
+        self, additional_attributes: MetricAttributes
+    ) -> MetricGauge:
+        return self
+
+
+MetricMeter.noop = _NoopMetricMeter()
 
 # Should be set as the "arg" argument for _arg_or_args checks where the argument
 # is unset. This is different than None which is a legitimate argument.

--- a/temporalio/runtime.py
+++ b/temporalio/runtime.py
@@ -10,7 +10,9 @@ from datetime import timedelta
 from enum import Enum
 from typing import ClassVar, Mapping, Optional, Union
 
+import temporalio.bridge.metric
 import temporalio.bridge.runtime
+import temporalio.common
 
 _default_runtime: Optional[Runtime] = None
 
@@ -64,6 +66,18 @@ class Runtime:
         self._core_runtime = temporalio.bridge.runtime.Runtime(
             telemetry=telemetry._to_bridge_config()
         )
+        core_meter = temporalio.bridge.metric.MetricMeter.create(self._core_runtime)
+        if not core_meter:
+            self._metric_meter = temporalio.common.MetricMeter.noop
+        else:
+            self._metric_meter = _MetricMeter(core_meter, core_meter.default_attributes)
+
+    @property
+    def metric_meter(self) -> temporalio.common.MetricMeter:
+        """Metric meter for this runtime. This is a no-op metric meter if no
+        metrics were configured.
+        """
+        return self._metric_meter
 
 
 @dataclass
@@ -196,4 +210,214 @@ class TelemetryConfig:
                 global_tags=self.global_tags or None,
                 metric_prefix=self.metric_prefix,
             ),
+        )
+
+
+class _MetricMeter(temporalio.common.MetricMeter):
+    def __init__(
+        self,
+        core_meter: temporalio.bridge.metric.MetricMeter,
+        core_attrs: temporalio.bridge.metric.MetricAttributes,
+    ) -> None:
+        self._core_meter = core_meter
+        self._core_attrs = core_attrs
+
+    def create_counter(
+        self, name: str, description: Optional[str] = None, unit: Optional[str] = None
+    ) -> temporalio.common.MetricCounter:
+        return _MetricCounter(
+            name,
+            description,
+            unit,
+            temporalio.bridge.metric.MetricCounter(
+                self._core_meter, name, description, unit
+            ),
+            self._core_attrs,
+        )
+
+    def create_histogram(
+        self, name: str, description: Optional[str] = None, unit: Optional[str] = None
+    ) -> temporalio.common.MetricHistogram:
+        return _MetricHistogram(
+            name,
+            description,
+            unit,
+            temporalio.bridge.metric.MetricHistogram(
+                self._core_meter, name, description, unit
+            ),
+            self._core_attrs,
+        )
+
+    def create_gauge(
+        self, name: str, description: Optional[str] = None, unit: Optional[str] = None
+    ) -> temporalio.common.MetricGauge:
+        return _MetricGauge(
+            name,
+            description,
+            unit,
+            temporalio.bridge.metric.MetricGauge(
+                self._core_meter, name, description, unit
+            ),
+            self._core_attrs,
+        )
+
+    def with_additional_attributes(
+        self, additional_attributes: temporalio.common.MetricAttributes
+    ) -> temporalio.common.MetricMeter:
+        return _MetricMeter(
+            self._core_meter,
+            self._core_attrs.with_additional_attributes(additional_attributes),
+        )
+
+
+class _MetricCounter(temporalio.common.MetricCounter):
+    def __init__(
+        self,
+        name: str,
+        description: Optional[str],
+        unit: Optional[str],
+        core_metric: temporalio.bridge.metric.MetricCounter,
+        core_attrs: temporalio.bridge.metric.MetricAttributes,
+    ) -> None:
+        self._name = name
+        self._description = description
+        self._unit = unit
+        self._core_metric = core_metric
+        self._core_attrs = core_attrs
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> Optional[str]:
+        return self._description
+
+    @property
+    def unit(self) -> Optional[str]:
+        return self._unit
+
+    def add(
+        self,
+        value: int,
+        additional_attributes: Optional[temporalio.common.MetricAttributes] = None,
+    ) -> None:
+        if value < 0:
+            raise ValueError("Metric value cannot be negative")
+        core_attrs = self._core_attrs
+        if additional_attributes:
+            core_attrs = core_attrs.with_additional_attributes(additional_attributes)
+        self._core_metric.add(value, core_attrs)
+
+    def with_additional_attributes(
+        self, additional_attributes: temporalio.common.MetricAttributes
+    ) -> temporalio.common.MetricCounter:
+        return _MetricCounter(
+            self._name,
+            self._description,
+            self._unit,
+            self._core_metric,
+            self._core_attrs.with_additional_attributes(additional_attributes),
+        )
+
+
+class _MetricHistogram(temporalio.common.MetricHistogram):
+    def __init__(
+        self,
+        name: str,
+        description: Optional[str],
+        unit: Optional[str],
+        core_metric: temporalio.bridge.metric.MetricHistogram,
+        core_attrs: temporalio.bridge.metric.MetricAttributes,
+    ) -> None:
+        self._name = name
+        self._description = description
+        self._unit = unit
+        self._core_metric = core_metric
+        self._core_attrs = core_attrs
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> Optional[str]:
+        return self._description
+
+    @property
+    def unit(self) -> Optional[str]:
+        return self._unit
+
+    def record(
+        self,
+        value: int,
+        additional_attributes: Optional[temporalio.common.MetricAttributes] = None,
+    ) -> None:
+        if value < 0:
+            raise ValueError("Metric value cannot be negative")
+        core_attrs = self._core_attrs
+        if additional_attributes:
+            core_attrs = core_attrs.with_additional_attributes(additional_attributes)
+        self._core_metric.record(value, core_attrs)
+
+    def with_additional_attributes(
+        self, additional_attributes: temporalio.common.MetricAttributes
+    ) -> temporalio.common.MetricHistogram:
+        return _MetricHistogram(
+            self._name,
+            self._description,
+            self._unit,
+            self._core_metric,
+            self._core_attrs.with_additional_attributes(additional_attributes),
+        )
+
+
+class _MetricGauge(temporalio.common.MetricGauge):
+    def __init__(
+        self,
+        name: str,
+        description: Optional[str],
+        unit: Optional[str],
+        core_metric: temporalio.bridge.metric.MetricGauge,
+        core_attrs: temporalio.bridge.metric.MetricAttributes,
+    ) -> None:
+        self._name = name
+        self._description = description
+        self._unit = unit
+        self._core_metric = core_metric
+        self._core_attrs = core_attrs
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> Optional[str]:
+        return self._description
+
+    @property
+    def unit(self) -> Optional[str]:
+        return self._unit
+
+    def set(
+        self,
+        value: int,
+        additional_attributes: Optional[temporalio.common.MetricAttributes] = None,
+    ) -> None:
+        if value < 0:
+            raise ValueError("Metric value cannot be negative")
+        core_attrs = self._core_attrs
+        if additional_attributes:
+            core_attrs = core_attrs.with_additional_attributes(additional_attributes)
+        self._core_metric.set(value, core_attrs)
+
+    def with_additional_attributes(
+        self, additional_attributes: temporalio.common.MetricAttributes
+    ) -> temporalio.common.MetricGauge:
+        return _MetricGauge(
+            self._name,
+            self._description,
+            self._unit,
+            self._core_metric,
+            self._core_attrs.with_additional_attributes(additional_attributes),
         )

--- a/temporalio/testing/_activity.py
+++ b/temporalio/testing/_activity.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Optional, Set, TypeVar
 from typing_extensions import ParamSpec
 
 import temporalio.activity
+import temporalio.common
 import temporalio.converter
 import temporalio.exceptions
 import temporalio.worker._activity
@@ -56,6 +57,9 @@ class ActivityEnvironment:
         payload_converter: Payload converter set on the activity context. This
             must be set before :py:meth:`run`. Changes after the activity has
             started do not take effect.
+        metric_meter: Metric meter set on the activity context. This must be set
+            before :py:meth:`run`. Changes after the activity has started do not
+            take effect. Default is noop.
     """
 
     def __init__(self) -> None:
@@ -65,6 +69,7 @@ class ActivityEnvironment:
         self.payload_converter = (
             temporalio.converter.DataConverter.default.payload_converter
         )
+        self.metric_meter = temporalio.common.MetricMeter.noop
         self._cancelled = False
         self._worker_shutdown = False
         self._activities: Set[_Activity] = set()
@@ -147,6 +152,7 @@ class _Activity:
             if not self.cancel_thread_raiser
             else self.cancel_thread_raiser.shielded,
             payload_converter_class_or_instance=env.payload_converter,
+            runtime_metric_meter=env.metric_meter,
         )
         self.task: Optional[asyncio.Task] = None
 

--- a/temporalio/worker/_replayer.py
+++ b/temporalio/worker/_replayer.py
@@ -225,6 +225,7 @@ class Replayer:
                     data_converter=self._config["data_converter"],
                     interceptors=self._config["interceptors"],
                     debug_mode=self._config["debug_mode"],
+                    metric_meter=runtime.metric_meter,
                     on_eviction_hook=on_eviction_hook,
                     disable_eager_activity_execution=False,
                 ).run()

--- a/temporalio/worker/_worker.py
+++ b/temporalio/worker/_worker.py
@@ -23,6 +23,7 @@ import temporalio.bridge.worker
 import temporalio.client
 import temporalio.converter
 import temporalio.exceptions
+import temporalio.runtime
 import temporalio.service
 
 from ._activity import SharedStateManager, _ActivityWorker
@@ -259,6 +260,7 @@ class Worker:
 
         # Create activity and workflow worker
         self._activity_worker: Optional[_ActivityWorker] = None
+        runtime = bridge_client.config.runtime or temporalio.runtime.Runtime.default()
         if activities:
             self._activity_worker = _ActivityWorker(
                 bridge_worker=lambda: self._bridge_worker,
@@ -268,6 +270,7 @@ class Worker:
                 shared_state_manager=shared_state_manager,
                 data_converter=client_config["data_converter"],
                 interceptors=interceptors,
+                metric_meter=runtime.metric_meter,
             )
         self._workflow_worker: Optional[_WorkflowWorker] = None
         if workflows:
@@ -283,6 +286,7 @@ class Worker:
                 interceptors=interceptors,
                 debug_mode=debug_mode,
                 disable_eager_activity_execution=disable_eager_activity_execution,
+                metric_meter=runtime.metric_meter,
                 on_eviction_hook=None,
             )
 

--- a/temporalio/worker/_workflow.py
+++ b/temporalio/worker/_workflow.py
@@ -30,6 +30,7 @@ from ._workflow_instance import (
     WorkflowInstance,
     WorkflowInstanceDetails,
     WorkflowRunner,
+    _WorkflowExternFunctions,
 )
 
 logger = logging.getLogger(__name__)
@@ -53,6 +54,7 @@ class _WorkflowWorker:
         interceptors: Sequence[Interceptor],
         debug_mode: bool,
         disable_eager_activity_execution: bool,
+        metric_meter: temporalio.common.MetricMeter,
         on_eviction_hook: Optional[
             Callable[
                 [str, temporalio.bridge.proto.workflow_activation.RemoveFromCache], None
@@ -83,6 +85,9 @@ class _WorkflowWorker:
             interceptor_class = i.workflow_interceptor_class(interceptor_class_input)
             if interceptor_class:
                 self._interceptor_classes.append(interceptor_class)
+        self._extern_functions.update(
+            **_WorkflowExternFunctions(__temporal_get_metric_meter=lambda: metric_meter)
+        )
         self._running_workflows: Dict[str, WorkflowInstance] = {}
         self._disable_eager_activity_execution = disable_eager_activity_execution
         self._on_eviction_hook = on_eviction_hook

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -32,13 +32,12 @@ from typing import (
     Set,
     Tuple,
     Type,
-    TypedDict,
     TypeVar,
     Union,
     cast,
 )
 
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, TypedDict
 
 import temporalio.activity
 import temporalio.api.common.v1

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -32,6 +32,7 @@ from typing import (
     Set,
     Tuple,
     Type,
+    TypedDict,
     TypeVar,
     Union,
     cast,
@@ -94,7 +95,7 @@ class WorkflowRunner(ABC):
         """Create a workflow instance that can handle activations.
 
         Args:
-            det: Serializable details that can be used to create the instance.
+            det: Details that can be used to create the instance.
 
         Returns:
             Workflow instance that can handle activations.
@@ -104,7 +105,7 @@ class WorkflowRunner(ABC):
 
 @dataclass(frozen=True)
 class WorkflowInstanceDetails:
-    """Immutable, serializable details for creating a workflow instance."""
+    """Immutable details for creating a workflow instance."""
 
     payload_converter_class: Type[temporalio.converter.PayloadConverter]
     failure_converter_class: Type[temporalio.converter.FailureConverter]
@@ -255,6 +256,9 @@ class _WorkflowInstanceImpl(
         # these causing even more issues. We will set ourselves as deleted so we
         # can check in some places to swallow these errors on tear down.
         self._deleting = False
+
+        # We only create the metric meter lazily
+        self._metric_meter: Optional[_ReplaySafeMetricMeter] = None
 
     def __del__(self) -> None:
         # We have confirmed there are no super() versions of __del__
@@ -792,6 +796,22 @@ class _WorkflowInstanceImpl(
         return self._payload_converter.from_payloads(
             [payload], [type_hint] if type_hint else None
         )[0]
+
+    def workflow_metric_meter(self) -> temporalio.common.MetricMeter:
+        # Create if not present, which means using an extern function
+        if not self._metric_meter:
+            metric_meter = cast(_WorkflowExternFunctions, self._extern_functions)[
+                "__temporal_get_metric_meter"
+            ]()
+            metric_meter = metric_meter.with_additional_attributes(
+                {
+                    "namespace": self._info.namespace,
+                    "task_queue": self._info.task_queue,
+                    "workflow_type": self._info.workflow_type,
+                }
+            )
+            self._metric_meter = _ReplaySafeMetricMeter(metric_meter)
+        return self._metric_meter
 
     def workflow_patch(self, id: str, *, deprecated: bool) -> bool:
         self._assert_not_read_only("patch")
@@ -2059,3 +2079,136 @@ def _encode_search_attributes(
     """Encode search attributes as bridge payloads."""
     for k, vals in attributes.items():
         payloads[k].CopyFrom(temporalio.converter.encode_search_attribute_values(vals))
+
+
+class _WorkflowExternFunctions(TypedDict):
+    __temporal_get_metric_meter: Callable[[], temporalio.common.MetricMeter]
+
+
+class _ReplaySafeMetricMeter(temporalio.common.MetricMeter):
+    def __init__(self, underlying: temporalio.common.MetricMeter) -> None:
+        self._underlying = underlying
+
+    def create_counter(
+        self, name: str, description: Optional[str] = None, unit: Optional[str] = None
+    ) -> temporalio.common.MetricCounter:
+        return _ReplaySafeMetricCounter(
+            self._underlying.create_counter(name, description, unit)
+        )
+
+    def create_histogram(
+        self, name: str, description: Optional[str] = None, unit: Optional[str] = None
+    ) -> temporalio.common.MetricHistogram:
+        return _ReplaySafeMetricHistogram(
+            self._underlying.create_histogram(name, description, unit)
+        )
+
+    def create_gauge(
+        self, name: str, description: Optional[str] = None, unit: Optional[str] = None
+    ) -> temporalio.common.MetricGauge:
+        return _ReplaySafeMetricGauge(
+            self._underlying.create_gauge(name, description, unit)
+        )
+
+    def with_additional_attributes(
+        self, additional_attributes: temporalio.common.MetricAttributes
+    ) -> temporalio.common.MetricMeter:
+        return _ReplaySafeMetricMeter(
+            self._underlying.with_additional_attributes(additional_attributes)
+        )
+
+
+class _ReplaySafeMetricCounter(temporalio.common.MetricCounter):
+    def __init__(self, underlying: temporalio.common.MetricCounter) -> None:
+        self._underlying = underlying
+
+    @property
+    def name(self) -> str:
+        return self._underlying.name
+
+    @property
+    def description(self) -> Optional[str]:
+        return self._underlying.description
+
+    @property
+    def unit(self) -> Optional[str]:
+        return self._underlying.unit
+
+    def add(
+        self,
+        value: int,
+        additional_attributes: Optional[temporalio.common.MetricAttributes] = None,
+    ) -> None:
+        if not temporalio.workflow.unsafe.is_replaying():
+            self._underlying.add(value, additional_attributes)
+
+    def with_additional_attributes(
+        self, additional_attributes: temporalio.common.MetricAttributes
+    ) -> temporalio.common.MetricCounter:
+        return _ReplaySafeMetricCounter(
+            self._underlying.with_additional_attributes(additional_attributes)
+        )
+
+
+class _ReplaySafeMetricHistogram(temporalio.common.MetricHistogram):
+    def __init__(self, underlying: temporalio.common.MetricHistogram) -> None:
+        self._underlying = underlying
+
+    @property
+    def name(self) -> str:
+        return self._underlying.name
+
+    @property
+    def description(self) -> Optional[str]:
+        return self._underlying.description
+
+    @property
+    def unit(self) -> Optional[str]:
+        return self._underlying.unit
+
+    def record(
+        self,
+        value: int,
+        additional_attributes: Optional[temporalio.common.MetricAttributes] = None,
+    ) -> None:
+        if not temporalio.workflow.unsafe.is_replaying():
+            self._underlying.record(value, additional_attributes)
+
+    def with_additional_attributes(
+        self, additional_attributes: temporalio.common.MetricAttributes
+    ) -> temporalio.common.MetricHistogram:
+        return _ReplaySafeMetricHistogram(
+            self._underlying.with_additional_attributes(additional_attributes)
+        )
+
+
+class _ReplaySafeMetricGauge(temporalio.common.MetricGauge):
+    def __init__(self, underlying: temporalio.common.MetricGauge) -> None:
+        self._underlying = underlying
+
+    @property
+    def name(self) -> str:
+        return self._underlying.name
+
+    @property
+    def description(self) -> Optional[str]:
+        return self._underlying.description
+
+    @property
+    def unit(self) -> Optional[str]:
+        return self._underlying.unit
+
+    def set(
+        self,
+        value: int,
+        additional_attributes: Optional[temporalio.common.MetricAttributes] = None,
+    ) -> None:
+        if not temporalio.workflow.unsafe.is_replaying():
+            self._underlying.set(value, additional_attributes)
+
+    def with_additional_attributes(
+        self, additional_attributes: temporalio.common.MetricAttributes
+    ) -> temporalio.common.MetricGauge:
+        return _ReplaySafeMetricGauge(
+            self._underlying.with_additional_attributes(additional_attributes)
+        )

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -469,6 +469,10 @@ class _Runtime(ABC):
         ...
 
     @abstractmethod
+    def workflow_metric_meter(self) -> temporalio.common.MetricMeter:
+        ...
+
+    @abstractmethod
     def workflow_patch(self, id: str, *, deprecated: bool) -> bool:
         ...
 
@@ -651,6 +655,18 @@ def memo_value(
         KeyError: Key not present and default not set.
     """
     return _Runtime.current().workflow_memo_value(key, default, type_hint=type_hint)
+
+
+def metric_meter() -> temporalio.common.MetricMeter:
+    """Get the metric meter for the current workflow.
+
+    This meter is replay safe which means that metrics will not be recorded
+    during replay.
+
+    Returns:
+        Current metric meter for this workflow for recording metrics.
+    """
+    return _Runtime.current().workflow_metric_meter()
 
 
 def now() -> datetime:

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,6 +1,8 @@
 import asyncio
+import socket
 import time
 import uuid
+from contextlib import closing
 from datetime import timedelta
 from typing import Awaitable, Callable, Optional, Sequence, Type, TypeVar
 
@@ -63,3 +65,10 @@ async def worker_versioning_enabled(client: Client) -> bool:
         if e.status in [RPCStatusCode.PERMISSION_DENIED, RPCStatusCode.UNIMPLEMENTED]:
             return False
         raise
+
+
+def find_free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,19 +1,11 @@
-import socket
 import uuid
-from contextlib import closing
 from urllib.request import urlopen
 
 from temporalio import workflow
 from temporalio.client import Client
 from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
 from temporalio.worker import Worker
-
-
-def find_free_port() -> int:
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-        s.bind(("", 0))
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        return s.getsockname()[1]
+from tests.helpers import find_free_port
 
 
 @workflow.defn


### PR DESCRIPTION
## What was changed

* Added `MetricMeter`, `MetricCounter`, `MetricHistogram`, and `MetricGauge` as (abstract) classes to `temporalio.common`
* Added `metric_meter` property to `temporalio.runtime.Runtime`
* Added `temporalio.workflow.metric_meter()` function to get replay-safe metric meter
* Added `temporalio.activity.metric_meter()` function to get optional metric meter
  * NOTE: This does not return a metric meter for sync activities that are non-threaded (i.e. multiprocess) because a meter cannot be shared across processes and it's a large effort to support metric shipping across processes for this rarely used activity type
* Added `metric_meter` attribute to `temporalio.testing.ActivityEnvironment` that defaults to noop impl
* API docs and tests

Handles part of #369 