### PR TITLE
Fix logging of error on activation failure

### DIFF
--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -324,7 +324,7 @@ class _WorkflowInstanceImpl(
         if activation_err:
             logger.warning(
                 f"Failed activation on workflow {self._info.workflow_type} with ID {self._info.workflow_id} and run ID {self._info.run_id}",
-                exc_info=True,
+                exc_info=activation_err,
             )
             # Set completion failure
             self._current_completion.failed.failure.SetInParent()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Explicitly include the error object in the `logger.warning` call after failure to activate on a workflow.

## Why?
<!-- Tell your future self why have you made these changes -->

If the log call happens outside any `except` block and `exc_info` is just set to `True` no error information is included in the log (making it difficult to understand what caused the error).
