### PR TITLE
Buffered metrics

### DIFF
--- a/temporalio/bridge/Cargo.lock
+++ b/temporalio/bridge/Cargo.lock
@@ -1162,15 +1162,6 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
@@ -1248,16 +1239,13 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nix"
-version = "0.26.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cfg-if",
  "libc",
- "memoffset 0.7.1",
- "pin-utils",
- "static_assertions",
 ]
 
 [[package]]
@@ -2221,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "54ac45299ccbd390721be55b412d41931911f654fa99e2cb8bfb57184b2061fe"
 
 [[package]]
 name = "slab"
@@ -2274,12 +2262,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/temporalio/bridge/metric.py
+++ b/temporalio/bridge/metric.py
@@ -27,7 +27,7 @@ class MetricMeter:
     ) -> None:
         """Initialize metric meter."""
         self._ref = ref
-        self._default_attributes = MetricAttributes(ref.default_attributes)
+        self._default_attributes = MetricAttributes(self, ref.default_attributes)
 
     @property
     def default_attributes(self) -> MetricAttributes:
@@ -99,13 +99,19 @@ class MetricAttributes:
     """Metric attributes using SDK Core."""
 
     def __init__(
-        self, ref: temporalio.bridge.temporal_sdk_bridge.MetricAttributesRef
+        self,
+        meter: MetricMeter,
+        ref: temporalio.bridge.temporal_sdk_bridge.MetricAttributesRef,
     ) -> None:
         """Initialize attributes."""
+        self._meter = meter
         self._ref = ref
 
     def with_additional_attributes(
         self, new_attrs: Mapping[str, Union[str, int, float, bool]]
     ) -> MetricAttributes:
         """Create new attributes with new attributes appended."""
-        return MetricAttributes(self._ref.with_additional_attributes(new_attrs))
+        return MetricAttributes(
+            self._meter,
+            self._ref.with_additional_attributes(self._meter._ref, new_attrs),
+        )

--- a/temporalio/bridge/runtime.py
+++ b/temporalio/bridge/runtime.py
@@ -6,7 +6,7 @@ Nothing in this module should be considered stable. The API may change.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Mapping, Optional, Type
+from typing import Any, Mapping, Optional, Sequence, Type
 
 import temporalio.bridge.temporal_sdk_bridge
 
@@ -25,6 +25,10 @@ class Runtime:
         """Create SDK Core runtime."""
         self._ref = temporalio.bridge.temporal_sdk_bridge.init_runtime(telemetry)
 
+    def retrieve_buffered_metrics(self) -> Sequence[Any]:
+        """Get buffered metrics."""
+        return self._ref.retrieve_buffered_metrics()
+
 
 @dataclass(frozen=True)
 class LoggingConfig:
@@ -40,6 +44,7 @@ class MetricsConfig:
 
     opentelemetry: Optional[OpenTelemetryConfig]
     prometheus: Optional[PrometheusConfig]
+    buffered_with_size: int
     attach_service_name: bool
     global_tags: Optional[Mapping[str, str]]
     metric_prefix: Optional[str]

--- a/temporalio/bridge/src/lib.rs
+++ b/temporalio/bridge/src/lib.rs
@@ -20,6 +20,8 @@ fn temporal_sdk_bridge(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<metric::MetricCounterRef>()?;
     m.add_class::<metric::MetricHistogramRef>()?;
     m.add_class::<metric::MetricGaugeRef>()?;
+    m.add_class::<metric::BufferedMetricUpdate>()?;
+    m.add_class::<metric::BufferedMetric>()?;
     m.add_function(wrap_pyfunction!(new_metric_meter, m)?)?;
 
     // Runtime stuff

--- a/temporalio/bridge/src/metric.rs
+++ b/temporalio/bridge/src/metric.rs
@@ -257,7 +257,7 @@ fn convert_metric_event<'p>(
                         },
                     },
                 )
-                .unwrap(),
+                .expect("Unable to create buffered metric"),
             );
             populate_into.set(Arc::new(buffered_ref)).unwrap();
             None
@@ -275,11 +275,11 @@ fn convert_metric_event<'p>(
                     .clone()
                     .as_any()
                     .downcast::<BufferedMetricAttributes>()
-                    .unwrap()
+                    .expect("Unable to downcast to expected buffered metric attributes")
                     .0
                     .as_ref(py)
                     .copy()
-                    .unwrap()
+                    .expect("Failed to copy metric attribute dictionary")
                     .into(),
                 None => PyDict::new(py).into(),
             };
@@ -292,12 +292,12 @@ fn convert_metric_event<'p>(
                     metrics::MetricValue::Float(v) => new_attrs.set_item(kv.key, v),
                     metrics::MetricValue::Bool(v) => new_attrs.set_item(kv.key, v),
                 }
-                .unwrap();
+                .expect("Unable to set metric key/value on dictionary");
             }
             // Put on lazy ref
             populate_into
                 .set(Arc::new(BufferedMetricAttributes(new_attrs_ref)))
-                .unwrap();
+                .expect("Unable to set buffered metric attributes on reference");
             None
         }
         // Convert to Python metric event
@@ -316,7 +316,7 @@ fn convert_metric_event<'p>(
                 .clone()
                 .as_any()
                 .downcast::<BufferedMetricAttributes>()
-                .unwrap()
+                .expect("Unable to downcast to expected buffered metric attributes")
                 .0
                 .clone(),
         }),

--- a/temporalio/bridge/src/runtime.rs
+++ b/temporalio/bridge/src/runtime.rs
@@ -134,7 +134,7 @@ impl RuntimeRef {
             self.runtime
                 .metrics_call_buffer
                 .as_ref()
-                .unwrap()
+                .expect("Attempting to retrieve buffered metrics without buffer")
                 .retrieve(),
         )
     }

--- a/temporalio/bridge/src/runtime.rs
+++ b/temporalio/bridge/src/runtime.rs
@@ -8,14 +8,18 @@ use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
-use temporal_sdk_core::telemetry::{build_otlp_metric_exporter, start_prometheus_metric_exporter};
+use temporal_sdk_core::telemetry::{
+    build_otlp_metric_exporter, start_prometheus_metric_exporter, MetricsCallBuffer,
+};
 use temporal_sdk_core::CoreRuntime;
-use temporal_sdk_core_api::telemetry::metrics::CoreMeter;
+use temporal_sdk_core_api::telemetry::metrics::{CoreMeter, MetricCallBufferer};
 use temporal_sdk_core_api::telemetry::{
     Logger, MetricTemporality, OtelCollectorOptionsBuilder, PrometheusExporterOptionsBuilder,
     TelemetryOptions, TelemetryOptionsBuilder,
 };
 use url::Url;
+
+use crate::metric::{convert_metric_events, BufferedMetricRef, BufferedMetricUpdate};
 
 #[pyclass]
 pub struct RuntimeRef {
@@ -25,6 +29,7 @@ pub struct RuntimeRef {
 #[derive(Clone)]
 pub(crate) struct Runtime {
     pub(crate) core: Arc<CoreRuntime>,
+    metrics_call_buffer: Option<Arc<MetricsCallBuffer<BufferedMetricRef>>>,
 }
 
 #[derive(FromPyObject)]
@@ -41,8 +46,11 @@ pub struct LoggingConfig {
 
 #[derive(FromPyObject)]
 pub struct MetricsConfig {
+    // These fields are mutually exclusive
     opentelemetry: Option<OpenTelemetryConfig>,
     prometheus: Option<PrometheusConfig>,
+    buffered_with_size: usize,
+
     attach_service_name: bool,
     global_tags: Option<HashMap<String, String>>,
     metric_prefix: Option<String>,
@@ -71,16 +79,34 @@ pub fn init_runtime(telemetry_config: TelemetryConfig) -> PyResult<RuntimeRef> {
         tokio::runtime::Builder::new_multi_thread(),
     )
     .map_err(|err| PyRuntimeError::new_err(format!("Failed initializing telemetry: {}", err)))?;
+
     // We late-bind the metrics after core runtime is created since it needs
     // the Tokio handle
+    let mut maybe_metrics_call_buffer: Option<Arc<MetricsCallBuffer<BufferedMetricRef>>> = None;
     if let Some(metrics_conf) = telemetry_config.metrics {
         let _guard = core.tokio_handle().enter();
-        core.telemetry_mut()
-            .attach_late_init_metrics(metrics_conf.try_into()?);
+        // If they want buffered, cannot have Prom/OTel and we make buffered
+        if metrics_conf.buffered_with_size > 0 {
+            if metrics_conf.opentelemetry.is_some() || metrics_conf.prometheus.is_some() {
+                return Err(PyValueError::new_err(
+                    "Cannot have buffer size with OpenTelemetry or Prometheus metric config",
+                ));
+            }
+            let metrics_call_buffer =
+                Arc::new(MetricsCallBuffer::new(metrics_conf.buffered_with_size));
+            core.telemetry_mut()
+                .attach_late_init_metrics(metrics_call_buffer.clone());
+            maybe_metrics_call_buffer = Some(metrics_call_buffer);
+        } else {
+            core.telemetry_mut()
+                .attach_late_init_metrics(metrics_conf.try_into()?);
+        }
     }
+
     Ok(RuntimeRef {
         runtime: Runtime {
             core: Arc::new(core),
+            metrics_call_buffer: maybe_metrics_call_buffer,
         },
     })
 }
@@ -97,6 +123,20 @@ impl Runtime {
     {
         let _guard = self.core.tokio_handle().enter();
         pyo3_asyncio::generic::future_into_py::<TokioRuntime, _, T>(py, fut)
+    }
+}
+
+#[pymethods]
+impl RuntimeRef {
+    fn retrieve_buffered_metrics<'p>(&self, py: Python<'p>) -> Vec<BufferedMetricUpdate> {
+        convert_metric_events(
+            py,
+            self.runtime
+                .metrics_call_buffer
+                .as_ref()
+                .unwrap()
+                .retrieve(),
+        )
     }
 }
 

--- a/temporalio/bridge/src/worker.rs
+++ b/temporalio/bridge/src/worker.rs
@@ -49,9 +49,9 @@ pub struct WorkerConfig {
 
 macro_rules! enter_sync {
     ($runtime:expr) => {
-        temporal_sdk_core::telemetry::set_trace_subscriber_for_current_thread(
-            $runtime.core.telemetry().trace_subscriber(),
-        );
+        if let Some(subscriber) = $runtime.core.telemetry().trace_subscriber() {
+            temporal_sdk_core::telemetry::set_trace_subscriber_for_current_thread(subscriber);
+        }
         let _guard = $runtime.core.tokio_handle().enter();
     };
 }

--- a/temporalio/runtime.py
+++ b/temporalio/runtime.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
-from typing import ClassVar, Mapping, Optional, Union
+from typing import ClassVar, Mapping, NewType, Optional, Sequence, Union
+
+from typing_extensions import Literal, Protocol
 
 import temporalio.bridge.metric
 import temporalio.bridge.runtime
@@ -66,6 +68,8 @@ class Runtime:
         self._core_runtime = temporalio.bridge.runtime.Runtime(
             telemetry=telemetry._to_bridge_config()
         )
+        if isinstance(telemetry.metrics, MetricBuffer):
+            telemetry.metrics._runtime = self
         core_meter = temporalio.bridge.metric.MetricMeter.create(self._core_runtime)
         if not core_meter:
             self._metric_meter = temporalio.common.MetricMeter.noop
@@ -174,6 +178,45 @@ class PrometheusConfig:
         )
 
 
+class MetricBuffer:
+    """A buffer that can be set on :py:class:`TelemetryConfig` to record
+    metrics instead of ignoring/exporting them.
+
+    .. warning::
+        It is very important that the buffer size is set to a high number and
+        that :py:meth:`retrieve_updates` is called regularly. Metric updates
+        will not be lost, so they can cause the system to halt if there is not
+        enough room in the buffer.
+    """
+
+    def __init__(self, buffer_size: int) -> None:
+        """Create a buffer with the given size.
+
+        .. warning::
+            It is very important that the buffer size is set to a high number
+            and is drained regularly. See :py:class:`MetricBuffer` warning.
+
+        Args:
+            buffer_size: Size of the buffer. Set this to a large value.
+        """
+        self._buffer_size = buffer_size
+        self._runtime: Optional[Runtime] = None
+
+    def retrieve_updates(self) -> Sequence[BufferedMetricUpdate]:
+        """Drain the buffer and return all metric updates.
+
+        .. warning::
+            It is very important that this is called regularly. See
+            :py:class:`MetricBuffer` warning.
+
+        Returns:
+            A sequence of metric updates.
+        """
+        if not self._runtime:
+            raise RuntimeError("Attempting to retrieve updates before runtime created")
+        return self._runtime._core_runtime.retrieve_buffered_metrics()
+
+
 @dataclass(frozen=True)
 class TelemetryConfig:
     """Configuration for Core telemetry."""
@@ -181,8 +224,8 @@ class TelemetryConfig:
     logging: Optional[LoggingConfig] = LoggingConfig.default
     """Logging configuration."""
 
-    metrics: Optional[Union[OpenTelemetryConfig, PrometheusConfig]] = None
-    """Metrics configuration."""
+    metrics: Optional[Union[OpenTelemetryConfig, PrometheusConfig, MetricBuffer]] = None
+    """Metrics configuration or buffer."""
 
     global_tags: Mapping[str, str] = field(default_factory=dict)
     """OTel resource tags to be applied to all metrics."""
@@ -206,11 +249,100 @@ class TelemetryConfig:
                 prometheus=None
                 if not isinstance(self.metrics, PrometheusConfig)
                 else self.metrics._to_bridge_config(),
+                buffered_with_size=0
+                if not isinstance(self.metrics, MetricBuffer)
+                else self.metrics._buffer_size,
                 attach_service_name=self.attach_service_name,
                 global_tags=self.global_tags or None,
                 metric_prefix=self.metric_prefix,
             ),
         )
+
+
+BufferedMetricKind = NewType("BufferedMetricKind", int)
+"""Representation of a buffered metric kind."""
+
+BUFFERED_METRIC_KIND_COUNTER = BufferedMetricKind(0)
+"""Buffered metric is a counter which means values are deltas."""
+
+BUFFERED_METRIC_KIND_GAUGE = BufferedMetricKind(1)
+"""Buffered metric is a gauge."""
+
+BUFFERED_METRIC_KIND_HISTOGRAM = BufferedMetricKind(2)
+"""Buffered metric is a histogram."""
+
+
+# WARNING: This must match Rust metric::BufferedMetric
+class BufferedMetric(Protocol):
+    """A metric for a buffered update.
+
+    The same metric for the same name and runtime is guaranteed to be the exact
+    same object for performance reasons. This means py:func:`id` will be the
+    same for the same metric across updates.
+    """
+
+    @property
+    def name(self) -> str:
+        """Get the name of the metric."""
+        ...
+
+    @property
+    def description(self) -> Optional[str]:
+        """Get the description of the metric if any."""
+        ...
+
+    @property
+    def unit(self) -> Optional[str]:
+        """Get the unit of the metric if any."""
+        ...
+
+    @property
+    def kind(self) -> BufferedMetricKind:
+        """Get the metric kind.
+
+        This is one of :py:const:`BUFFERED_METRIC_KIND_COUNTER`,
+        :py:const:`BUFFERED_METRIC_KIND_GAUGE`, or
+        :py:const:`BUFFERED_METRIC_KIND_HISTOGRAM`.
+        """
+        ...
+
+
+# WARNING: This must match Rust metric::BufferedMetricUpdate
+class BufferedMetricUpdate(Protocol):
+    """A single metric value update."""
+
+    @property
+    def metric(self) -> BufferedMetric:
+        """Metric being updated.
+
+        For performance reasons, this is the same object across updates for the
+        same metric. This means py:func:`id` will be the same for the same
+        metric across updates.
+        """
+        ...
+
+    @property
+    def value(self) -> Union[int, float]:
+        """Value for the update.
+
+        For counters this is a delta, for gauges and histograms this is just the
+        value.
+        """
+        ...
+
+    @property
+    def attributes(self) -> temporalio.common.MetricAttributes:
+        """Attributes for the update.
+
+        For performance reasons, this is the same object across updates for the
+        same attribute set. This means py:func:`id` will be the same for the
+        same attribute set across updates. Note this is for same "attribute set"
+        as created by the metric creator, but different attribute sets may have
+        the same values.
+
+        Do not mutate this.
+        """
+        ...
 
 
 class _MetricMeter(temporalio.common.MetricMeter):

--- a/temporalio/runtime.py
+++ b/temporalio/runtime.py
@@ -183,18 +183,18 @@ class MetricBuffer:
     metrics instead of ignoring/exporting them.
 
     .. warning::
-        It is very important that the buffer size is set to a high number and
-        that :py:meth:`retrieve_updates` is called regularly. Metric updates
-        will not be lost, so they can cause the system to halt if there is not
-        enough room in the buffer.
+        It is important that the buffer size is set to a high number and that
+        :py:meth:`retrieve_updates` is called regularly to drain the buffer. If
+        the buffer is full, metric updates will be dropped and an error will be
+        logged.
     """
 
     def __init__(self, buffer_size: int) -> None:
         """Create a buffer with the given size.
 
         .. warning::
-            It is very important that the buffer size is set to a high number
-            and is drained regularly. See :py:class:`MetricBuffer` warning.
+            It is important that the buffer size is set to a high number and is
+            drained regularly. See :py:class:`MetricBuffer` warning.
 
         Args:
             buffer_size: Size of the buffer. Set this to a large value. A value
@@ -207,7 +207,7 @@ class MetricBuffer:
         """Drain the buffer and return all metric updates.
 
         .. warning::
-            It is very important that this is called regularly. See
+            It is important that this is called regularly. See
             :py:class:`MetricBuffer` warning.
 
         Returns:

--- a/temporalio/runtime.py
+++ b/temporalio/runtime.py
@@ -197,7 +197,8 @@ class MetricBuffer:
             and is drained regularly. See :py:class:`MetricBuffer` warning.
 
         Args:
-            buffer_size: Size of the buffer. Set this to a large value.
+            buffer_size: Size of the buffer. Set this to a large value. A value
+                in the tens of thousands or higher is plenty reasonable.
         """
         self._buffer_size = buffer_size
         self._runtime: Optional[Runtime] = None


### PR DESCRIPTION
## What was changed

Support for user-retrieved metrics via a buffer

* Added Rust code to support metric buffer including ensuring the same Python metric/attribute objects are reused
* Added `MetricBuffer`, `BufferedMetric`, and `BufferedMetricUpdate` to `temporalio.runtime`

## Checklist

1. Closes #369