### PR TITLE
Fix line number in workflow.logger

### DIFF
--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -1104,10 +1104,11 @@ class LoggerAdapter(logging.LoggerAdapter):
                     kwargs["extra"] = extra
         return (msg, kwargs)
 
-    def log(self, *args, **kwargs) -> None:
+    def isEnabledFor(self, level: int) -> bool:
         """Override to ignore replay logs."""
-        if self.log_during_replay or not unsafe.is_replaying():
-            super().log(*args, **kwargs)
+        if not self.log_during_replay and unsafe.is_replaying():
+            return False
+        return super().isEnabledFor(level)
 
     @property
     def base_logger(self) -> logging.Logger:

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -1907,11 +1907,12 @@ async def test_workflow_logging(client: Client, env: WorkflowEnvironment):
         assert find_log("Signal: signal 1 ({'attempt':")
         assert find_log("Signal: signal 2")
         assert not find_log("Signal: signal 3")
-        # Also make sure it has some workflow info
+        # Also make sure it has some workflow info and correct funcName
         record = find_log("Signal: signal 1")
         assert (
             record
             and record.__dict__["workflow_info"].workflow_type == "LoggingWorkflow"
+            and record.funcName == "my_signal"
         )
 
         # Clear queue and start a new one with more signals


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Now, `workflow.LoggingAdapter` overrides `isEnabledFor`, which does not add additional stack frame during logging, instead of `log`.

## Why?
To have correct line numbers in logs.

## Checklist
<!--- add/delete as needed --->

1. Closes #447

2. How was this tested:
Unit test

3. Any docs updates needed?
No