### PR TITLE
Fix typing of methods for pyright

### DIFF
--- a/temporalio/types.py
+++ b/temporalio/types.py
@@ -82,7 +82,7 @@ class MethodAsyncSingleParam(
     """Generic callable type."""
 
     def __call__(
-        __self, self: ProtocolSelfType, __arg: ProtocolParamType
+        self, __self: ProtocolSelfType, __arg: ProtocolParamType
     ) -> Awaitable[ProtocolReturnType]:
         """Generic callable type callback."""
         ...
@@ -94,7 +94,7 @@ class MethodSyncSingleParam(
     """Generic callable type."""
 
     def __call__(
-        __self, self: ProtocolSelfType, __arg: ProtocolParamType
+        self, __self: ProtocolSelfType, __arg: ProtocolParamType
     ) -> ProtocolReturnType:
         """Generic callable type callback."""
         ...
@@ -104,7 +104,7 @@ class MethodSyncOrAsyncNoParam(Protocol[ProtocolSelfType, ProtocolReturnType]):
     """Generic callable type."""
 
     def __call__(
-        __self, self: ProtocolSelfType
+        self, __self: ProtocolSelfType
     ) -> Union[ProtocolReturnType, Awaitable[ProtocolReturnType]]:
         """Generic callable type callback."""
         ...
@@ -116,7 +116,7 @@ class MethodSyncOrAsyncSingleParam(
     """Generic callable type."""
 
     def __call__(
-        __self, self: ProtocolSelfType, __param: ProtocolParamType
+        self, __self: ProtocolSelfType, __param: ProtocolParamType
     ) -> Union[ProtocolReturnType, Awaitable[ProtocolReturnType]]:
         """Generic callable type callback."""
         ...


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Since pyright 1.1.344, my code stated to fail with errors such as the following:
```bash
webapp.py:46:22 - error: No overloads for "execute_workflow" match the provided arguments (reportGeneralTypeIssues)
webapp.py:47:22 - error: Argument of type "(self: HelloWorkflow, name: str) -> Coroutine[Any, Any, str]" cannot be assigned to parameter "workflow" of type "str" in function "execute_workflow"
    "function" is incompatible with "str" (reportGeneralTypeIssues)
```

The code being something like:
```python
@workflow.defn(name="HelloWorkflow")
class HelloWorkflow:
    @workflow.run
    async def run(self, name: str) -> str:
        return await workflow.execute_activity(
            hello_activity,
            HelloParams("Hello", name),
            start_to_close_timeout=timedelta(seconds=10),
        )

# and later in webapp.py:
return await env.temporal.execute_workflow(
    workflow=HelloWorkflow.run,
    arg="your name",
    id="workflow-id",
    task_queue="task-queue",
)
```

Despite looking legit, pyright did not like it. The issue is explained in https://github.com/microsoft/pyright/issues/6875 and has to do with how the typing for methods is declared. I am attempting a fix here that I only tested with pyright for my use case, hoping that this will not break mypy.

## Why?
To be able to use pyright with temporal.

## Checklist
1. How was this tested:
Only a typing change, relying on CI to fully verify it.

2. Any docs updates needed?
No