### PR TITLE
Apply eviction before completing activation

### DIFF
--- a/temporalio/worker/_workflow.py
+++ b/temporalio/worker/_workflow.py
@@ -267,7 +267,7 @@ class _WorkflowWorker:
                 )
                 del self._running_workflows[act.run_id]
             else:
-                logger.debug(
+                logger.warn(
                     "Eviction request on unknown workflow with run ID %s, message: %s",
                     act.run_id,
                     cache_remove_job.message,


### PR DESCRIPTION
## What was changed

Today if we receive an activation with a cache-remove job, we complete the activation in core and _then_ remove the workflow from cache. That's bad. There is the potential for a rare bug where:

* Python receives activation
* Activation takes too long causing server-side task timeout causing server to send new task which core buffers while current activation is in flight
* Already-timed-out-server-side activation completion is sent to core
* Core sends eviction activation and Python sends activation completion _before_ removing from cache
* Core sends the buffered task to run from beginning, but it reuses cache from old eviction activation because the eviction code wasn't reached just yet

This moves eviction processing to before activation completion. Also, this adds optimizations to not yield to a codec handler on cache-eviction-only activations potentially saving cycles and improving performance for codec users. Also we now log a warning if an activation contains a start-workflow job but it's already in cache (should never happen).

There are no real tests beyond the current suite to confirm no regression since this is a simple order-of-operations change. We have struggled to reliably replicate in an integration sense, and patching/mocking core to inject this bug is too contrived to represent what could really happen.