### PR TITLE
Fix SingleParam types for pyright checking

### DIFF
--- a/temporalio/types.py
+++ b/temporalio/types.py
@@ -82,7 +82,7 @@ class MethodAsyncSingleParam(
     """Generic callable type."""
 
     def __call__(
-        self, __self: ProtocolSelfType, __arg: ProtocolParamType
+        self, __self: ProtocolSelfType, __arg: ProtocolParamType, /
     ) -> Awaitable[ProtocolReturnType]:
         """Generic callable type callback."""
         ...
@@ -94,7 +94,7 @@ class MethodSyncSingleParam(
     """Generic callable type."""
 
     def __call__(
-        self, __self: ProtocolSelfType, __arg: ProtocolParamType
+        self, __self: ProtocolSelfType, __arg: ProtocolParamType, /
     ) -> ProtocolReturnType:
         """Generic callable type callback."""
         ...
@@ -116,7 +116,7 @@ class MethodSyncOrAsyncSingleParam(
     """Generic callable type."""
 
     def __call__(
-        self, __self: ProtocolSelfType, __param: ProtocolParamType
+        self, __self: ProtocolSelfType, __param: ProtocolParamType, /
     ) -> Union[ProtocolReturnType, Awaitable[ProtocolReturnType]]:
         """Generic callable type callback."""
         ...


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Explicitly specify `__arg` is a position argument in `Method*SingleParam` types.

## Why?
<!-- Tell your future self why have you made these changes -->

After updating pyright from 1.1.338 to 1.1.348 (following pylance release cycle), type check and inference related to `client.execute_workflow` and `workflow.execute_activity` are failing because of parameter name mismatch with `__arg`. Causing pyright rejecting the correct overloads.

This can be reproduced with the code sample in the collapsed block. Trying to guide pyright with type hinting on `MethodAsyncSingleParam` shows why the overload got rejected. The problem is "Parameter name mismatch"

<img width="1208" alt="image" src="https://github.com/temporalio/sdk-python/assets/6838982/6d6e4d53-154a-4dd1-97a4-278478aeb94e">

I guess python sdk won't use the method types by keyword but only use them with position argument. So this change signal the sdk's intent to type checker.

After adding the last `/` in the type pyright is passing.

<img width="1440" alt="image" src="https://github.com/temporalio/sdk-python/assets/6838982/bed55478-4806-4bf1-ba42-d87fb797fc6b">

<details>

<summary>Sample</summary>

```py
import os
import time
from dataclasses import dataclass
from datetime import timedelta

from temporalio import activity, workflow
from temporalio.client import Client
from temporalio.types import MethodAsyncSingleParam


@dataclass
class ComposeGreetingInput:
    greeting: str
    name: str


@activity.defn
def compose_greeting(input: ComposeGreetingInput) -> str:
    # We'll wait for 3 seconds, heartbeating in between (like all long-running
    # activities should do), then return the greeting
    for _ in range(0, 3):
        print(f"Heartbeating activity on PID {os.getpid()}")
        activity.heartbeat()
        time.sleep(1)
    return f"{input.greeting}, {input.name}!"


@workflow.defn
class GreetingWorkflow:
    @workflow.run
    async def run(self, name: str) -> str:
        return await workflow.execute_activity(
            compose_greeting,
            ComposeGreetingInput("Hello", name),
            start_to_close_timeout=timedelta(seconds=10),
            # Always set a heartbeat timeout for long-running activities
            heartbeat_timeout=timedelta(seconds=2),
        )


async def main():
    # Start client
    client = await Client.connect("localhost:7233")

    wf_run: MethodAsyncSingleParam = GreetingWorkflow.run

    # While the worker is running, use the client to run the workflow and
    # print out its result. Note, in many production setups, the client
    # would be in a completely separate process from the worker.
    await client.execute_workflow(
        GreetingWorkflow.run,
        "World",
        id="hello-activity-multiprocess-workflow-id",
        task_queue="hello-activity-multiprocess-task-queue",
    )

```

</details>

## Checklist
<!--- add/delete as needed --->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

I guess testing this within the repo relies on #420? If this passes mypy on CI this PR should be good enough...?