### PR TITLE
Flag MD5 as non-security related usage for FIPS compatibility

### DIFF
--- a/temporalio/worker/_worker.py
+++ b/temporalio/worker/_worker.py
@@ -633,7 +633,10 @@ def load_default_build_id(*, memoize: bool = True) -> str:
     # * Using the loader's get_code in rare cases can cause a compile()
 
     got_temporal_code = False
-    m = hashlib.md5(usedforsecurity=False)
+    if sys.version_info < (3, 9):
+        m = hashlib.md5()
+    else:
+        m = hashlib.md5(usedforsecurity=False)
     for mod_name in sorted(sys.modules):
         # Try to read code
         code = _get_module_code(mod_name)

--- a/temporalio/worker/_worker.py
+++ b/temporalio/worker/_worker.py
@@ -633,7 +633,7 @@ def load_default_build_id(*, memoize: bool = True) -> str:
     # * Using the loader's get_code in rare cases can cause a compile()
 
     got_temporal_code = False
-    m = hashlib.md5()
+    m = hashlib.md5(usedforsecurity=False)
     for mod_name in sorted(sys.modules):
         # Try to read code
         code = _get_module_code(mod_name)


### PR DESCRIPTION
## What was changed
Flagged MD5 as not used for security.

## Why?
MD5 algorithm is not allowed under FIPS requirements due to security concerns. Temporal SDK uses MD5 for non-security related reasons, and so it should be flagged as such.


## Checklist

1. How was this tested:
We've been monkey-patching this (or using sed on python file directly after installation) up till now.
