### PR TITLE
Remove experimental flag from start_delay

### DIFF
--- a/temporalio/client.py
+++ b/temporalio/client.py
@@ -462,8 +462,7 @@ class Client:
                 dictionary form of this is deprecated, use
                 :py:class:`temporalio.common.TypedSearchAttributes`.
             start_delay: Amount of time to wait before starting the workflow.
-                This does not work with ``cron_schedule``. This is currently
-                experimental.
+                This does not work with ``cron_schedule``.
             start_signal: If present, this signal is sent as signal-with-start
                 instead of traditional workflow start.
             start_signal_args: Arguments for start_signal if start_signal


### PR DESCRIPTION
Remove experimental flag from start_delay

## What was changed
Remove experimental flag from start_delay

## Why?
To indicate the current state of start_delay workflow option.