### PR TITLE
HTTP CONNECT proxy support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,3 +94,4 @@ jobs:
       python-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}
       version-is-repo-ref: true
+      features-repo-ref: http-connect-proxy-python

--- a/temporalio/bridge/Cargo.lock
+++ b/temporalio/bridge/Cargo.lock
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79fed4cdb43e993fcdadc7e58a09fd0e3e649c4436fa11da71c9f1f3ee7feb9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64ct"
@@ -2414,11 +2414,13 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backoff",
+ "base64",
  "derive_builder",
  "derive_more",
  "futures",
  "futures-retry",
  "http 0.2.11",
+ "hyper 0.14.28",
  "once_cell",
  "parking_lot",
  "prost-types",

--- a/temporalio/bridge/client.py
+++ b/temporalio/bridge/client.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Mapping, Optional, Type, TypeVar
+from typing import Mapping, Optional, Tuple, Type, TypeVar
 
 import google.protobuf.message
 
@@ -47,6 +47,14 @@ class ClientKeepAliveConfig:
 
 
 @dataclass
+class ClientHttpConnectProxyConfig:
+    """Python representation of the Rust struct for configuring HTTP proxy."""
+
+    target_host: str
+    basic_auth: Optional[Tuple[str, str]]
+
+
+@dataclass
 class ClientConfig:
     """Python representation of the Rust struct for configuring the client."""
 
@@ -59,6 +67,7 @@ class ClientConfig:
     keep_alive_config: Optional[ClientKeepAliveConfig]
     client_name: str
     client_version: str
+    http_connect_proxy_config: Optional[ClientHttpConnectProxyConfig]
 
 
 @dataclass

--- a/temporalio/client.py
+++ b/temporalio/client.py
@@ -54,6 +54,7 @@ import temporalio.runtime
 import temporalio.service
 import temporalio.workflow
 from temporalio.service import (
+    HttpConnectProxyConfig,
     KeepAliveConfig,
     RetryConfig,
     RPCError,
@@ -110,6 +111,7 @@ class Client:
         identity: Optional[str] = None,
         lazy: bool = False,
         runtime: Optional[temporalio.runtime.Runtime] = None,
+        http_connect_proxy_config: Optional[HttpConnectProxyConfig] = None,
     ) -> Client:
         """Connect to a Temporal server.
 
@@ -153,6 +155,7 @@ class Client:
                 attempted or a worker is created with it. Lazy clients cannot be
                 used for workers.
             runtime: The runtime for this client, or the default if unset.
+            http_connect_proxy_config: Configuration for HTTP CONNECT proxy.
         """
         connect_config = temporalio.service.ConnectConfig(
             target_host=target_host,
@@ -164,6 +167,7 @@ class Client:
             identity=identity or "",
             lazy=lazy,
             runtime=runtime,
+            http_connect_proxy_config=http_connect_proxy_config,
         )
         return Client(
             await temporalio.service.ServiceClient.connect(connect_config),

--- a/temporalio/service.py
+++ b/temporalio/service.py
@@ -122,7 +122,7 @@ class HttpConnectProxyConfig:
     target_host: str
     """Target host:port for the HTTP CONNECT proxy."""
     basic_auth: Optional[Tuple[str, str]] = None
-    """Basic auth for the HTTP CONNECT proxy if any."""
+    """Basic auth for the HTTP CONNECT proxy if any as a user/pass tuple."""
 
     def _to_bridge_config(
         self,


### PR DESCRIPTION
## What was changed

* Updated core
* Added `temporalio.service.HttpConnectProxyConfig`
* Updated client to accept that config

Note: This tests against the https://github.com/temporalio/features/tree/http-connect-proxy-python branch of the features repo to ensure it works. That branch contains a not-yet-merged Python feature test for proxy.