### PR TITLE
Ensure extra data on task fail logs

### DIFF
--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -349,6 +349,7 @@ class _WorkflowInstanceImpl(
             logger.warning(
                 f"Failed activation on workflow {self._info.workflow_type} with ID {self._info.workflow_id} and run ID {self._info.run_id}",
                 exc_info=activation_err,
+                extra={"temporal_workflow": self._info._logger_details()},
             )
             # Set completion failure
             self._current_completion.failed.failure.SetInParent()


### PR DESCRIPTION
## What was changed

* Add `temporal_workflow` extra data on workflow task failure logs
* Add test to ensure workflow/activity task failures have extra data

## Checklist

1. Closes #500