### PR TITLE
Ability for certain task failure types to fail workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,7 +722,8 @@ While running in a workflow, in addition to features documented elsewhere, the f
 
 #### Exceptions
 
-* Workflows can raise exceptions to fail the workflow or the "workflow task" (i.e. suspend the workflow retrying).
+* Workflows/updates can raise exceptions to fail the workflow or the "workflow task" (i.e. suspend the workflow
+  retrying).
 * Exceptions that are instances of `temporalio.exceptions.FailureError` will fail the workflow with that exception
   * For failing the workflow explicitly with a user exception, use `temporalio.exceptions.ApplicationError`. This can
     be marked non-retryable or include details as needed.
@@ -731,6 +732,13 @@ While running in a workflow, in addition to features documented elsewhere, the f
 * All other exceptions fail the "workflow task" which means the workflow will continually retry until the workflow is
   fixed. This is helpful for bad code or other non-predictable exceptions. To actually fail the workflow, use an
   `ApplicationError` as mentioned above.
+
+This default can be changed by providing a list of exception types to `workflow_failure_exception_types` when creating a
+`Worker` or `failure_exception_types` on the `@workflow.defn` decorator. If a workflow-thrown exception is an instance
+of any type in either list, it will fail the workflow instead of the task. This means a value of `[Exception]` will
+cause every exception to fail the workflow instead of the task. Also, as a special case, if
+`temporalio.workflow.NondeterminismError` (or any superclass of it) is set, non-deterministic exceptions will fail the
+workflow. WARNING: These settings are experimental.
 
 #### External Workflows
 

--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ While running in a workflow, in addition to features documented elsewhere, the f
 #### Exceptions
 
 * Workflows/updates can raise exceptions to fail the workflow or the "workflow task" (i.e. suspend the workflow
-  retrying).
+  in a retrying state).
 * Exceptions that are instances of `temporalio.exceptions.FailureError` will fail the workflow with that exception
   * For failing the workflow explicitly with a user exception, use `temporalio.exceptions.ApplicationError`. This can
     be marked non-retryable or include details as needed.

--- a/temporalio/bridge/worker.py
+++ b/temporalio/bridge/worker.py
@@ -6,7 +6,16 @@ Nothing in this module should be considered stable. The API may change.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Awaitable, Callable, List, Optional, Sequence, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Awaitable,
+    Callable,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+)
 
 import google.protobuf.internal.containers
 from typing_extensions import TypeAlias
@@ -48,6 +57,8 @@ class WorkerConfig:
     max_task_queue_activities_per_second: Optional[float]
     graceful_shutdown_period_millis: int
     use_worker_versioning: bool
+    nondeterminism_as_workflow_fail: bool
+    nondeterminism_as_workflow_fail_for_types: Set[str]
 
 
 class Worker:

--- a/temporalio/worker/_replayer.py
+++ b/temporalio/worker/_replayer.py
@@ -216,6 +216,11 @@ class Replayer:
                     task_queue=task_queue,
                     build_id=self._config["build_id"] or load_default_build_id(),
                     identity_override=self._config["identity"],
+                    # Need to tell core whether we want to consider all
+                    # non-determinism exceptions as workflow fail, and whether we do
+                    # per workflow type
+                    nondeterminism_as_workflow_fail=workflow_worker.nondeterminism_as_workflow_fail(),
+                    nondeterminism_as_workflow_fail_for_types=workflow_worker.nondeterminism_as_workflow_fail_for_types(),
                     # All values below are ignored but required by Core
                     max_cached_workflows=2,
                     max_outstanding_workflow_tasks=2,
@@ -232,11 +237,6 @@ class Replayer:
                     max_task_queue_activities_per_second=None,
                     graceful_shutdown_period_millis=0,
                     use_worker_versioning=False,
-                    # Need to tell core whether we want to consider all
-                    # non-determinism exceptions as workflow fail, and whether we do
-                    # per workflow type
-                    nondeterminism_as_workflow_fail=workflow_worker.nondeterminism_as_workflow_fail(),
-                    nondeterminism_as_workflow_fail_for_types=workflow_worker.nondeterminism_as_workflow_fail_for_types(),
                 ),
             )
             # Start worker

--- a/temporalio/worker/_replayer.py
+++ b/temporalio/worker/_replayer.py
@@ -43,6 +43,7 @@ class Replayer:
         interceptors: Sequence[Interceptor] = [],
         build_id: Optional[str] = None,
         identity: Optional[str] = None,
+        workflow_failure_exception_types: Sequence[Type[BaseException]] = [],
         debug_mode: bool = False,
         runtime: Optional[temporalio.runtime.Runtime] = None,
         disable_safe_workflow_eviction: bool = False,
@@ -66,6 +67,7 @@ class Replayer:
             interceptors=interceptors,
             build_id=build_id,
             identity=identity,
+            workflow_failure_exception_types=workflow_failure_exception_types,
             debug_mode=debug_mode,
             runtime=runtime,
             disable_safe_workflow_eviction=disable_safe_workflow_eviction,
@@ -153,35 +155,6 @@ class Replayer:
             An async iterator that returns replayed workflow results as they are
             replayed.
         """
-        # Create bridge worker
-        task_queue = f"replay-{self._config['build_id']}"
-        runtime = self._config["runtime"] or temporalio.runtime.Runtime.default()
-        bridge_worker, pusher = temporalio.bridge.worker.Worker.for_replay(
-            runtime._core_runtime,
-            temporalio.bridge.worker.WorkerConfig(
-                namespace=self._config["namespace"],
-                task_queue=task_queue,
-                build_id=self._config["build_id"] or load_default_build_id(),
-                identity_override=self._config["identity"],
-                # All values below are ignored but required by Core
-                max_cached_workflows=2,
-                max_outstanding_workflow_tasks=2,
-                max_outstanding_activities=1,
-                max_outstanding_local_activities=1,
-                max_concurrent_workflow_task_polls=1,
-                nonsticky_to_sticky_poll_ratio=1,
-                max_concurrent_activity_task_polls=1,
-                no_remote_activities=True,
-                sticky_queue_schedule_to_start_timeout_millis=1000,
-                max_heartbeat_throttle_interval_millis=1000,
-                default_heartbeat_throttle_interval_millis=1000,
-                max_activities_per_second=None,
-                max_task_queue_activities_per_second=None,
-                graceful_shutdown_period_millis=0,
-                use_worker_versioning=False,
-            ),
-        )
-
         try:
             last_replay_failure: Optional[Exception]
             last_replay_complete = asyncio.Event()
@@ -212,29 +185,62 @@ class Replayer:
                     last_replay_failure = None
                 last_replay_complete.set()
 
-            # Start the worker
-            workflow_worker_task = asyncio.create_task(
-                _WorkflowWorker(
-                    bridge_worker=lambda: bridge_worker,
+            # Create worker referencing bridge worker
+            bridge_worker: temporalio.bridge.worker.Worker
+            task_queue = f"replay-{self._config['build_id']}"
+            runtime = self._config["runtime"] or temporalio.runtime.Runtime.default()
+            workflow_worker = _WorkflowWorker(
+                bridge_worker=lambda: bridge_worker,
+                namespace=self._config["namespace"],
+                task_queue=task_queue,
+                workflows=self._config["workflows"],
+                workflow_task_executor=self._config["workflow_task_executor"],
+                workflow_runner=self._config["workflow_runner"],
+                unsandboxed_workflow_runner=self._config["unsandboxed_workflow_runner"],
+                data_converter=self._config["data_converter"],
+                interceptors=self._config["interceptors"],
+                workflow_failure_exception_types=self._config[
+                    "workflow_failure_exception_types"
+                ],
+                debug_mode=self._config["debug_mode"],
+                metric_meter=runtime.metric_meter,
+                on_eviction_hook=on_eviction_hook,
+                disable_eager_activity_execution=False,
+                disable_safe_eviction=self._config["disable_safe_workflow_eviction"],
+            )
+            # Create bridge worker
+            bridge_worker, pusher = temporalio.bridge.worker.Worker.for_replay(
+                runtime._core_runtime,
+                temporalio.bridge.worker.WorkerConfig(
                     namespace=self._config["namespace"],
                     task_queue=task_queue,
-                    workflows=self._config["workflows"],
-                    workflow_task_executor=self._config["workflow_task_executor"],
-                    workflow_runner=self._config["workflow_runner"],
-                    unsandboxed_workflow_runner=self._config[
-                        "unsandboxed_workflow_runner"
-                    ],
-                    data_converter=self._config["data_converter"],
-                    interceptors=self._config["interceptors"],
-                    debug_mode=self._config["debug_mode"],
-                    metric_meter=runtime.metric_meter,
-                    on_eviction_hook=on_eviction_hook,
-                    disable_eager_activity_execution=False,
-                    disable_safe_eviction=self._config[
-                        "disable_safe_workflow_eviction"
-                    ],
-                ).run()
+                    build_id=self._config["build_id"] or load_default_build_id(),
+                    identity_override=self._config["identity"],
+                    # All values below are ignored but required by Core
+                    max_cached_workflows=2,
+                    max_outstanding_workflow_tasks=2,
+                    max_outstanding_activities=1,
+                    max_outstanding_local_activities=1,
+                    max_concurrent_workflow_task_polls=1,
+                    nonsticky_to_sticky_poll_ratio=1,
+                    max_concurrent_activity_task_polls=1,
+                    no_remote_activities=True,
+                    sticky_queue_schedule_to_start_timeout_millis=1000,
+                    max_heartbeat_throttle_interval_millis=1000,
+                    default_heartbeat_throttle_interval_millis=1000,
+                    max_activities_per_second=None,
+                    max_task_queue_activities_per_second=None,
+                    graceful_shutdown_period_millis=0,
+                    use_worker_versioning=False,
+                    # Need to tell core whether we want to consider all
+                    # non-determinism exceptions as workflow fail, and whether we do
+                    # per workflow type
+                    nondeterminism_as_workflow_fail=workflow_worker.nondeterminism_as_workflow_fail(),
+                    nondeterminism_as_workflow_fail_for_types=workflow_worker.nondeterminism_as_workflow_fail_for_types(),
+                ),
             )
+            # Start worker
+            workflow_worker_task = asyncio.create_task(workflow_worker.run())
 
             # Yield iterator
             async def replay_iterator() -> AsyncIterator[WorkflowReplayResult]:
@@ -301,6 +307,7 @@ class ReplayerConfig(TypedDict, total=False):
     interceptors: Sequence[Interceptor]
     build_id: Optional[str]
     identity: Optional[str]
+    workflow_failure_exception_types: Sequence[Type[BaseException]]
     debug_mode: bool
     runtime: Optional[temporalio.runtime.Runtime]
     disable_safe_workflow_eviction: bool

--- a/temporalio/worker/workflow_sandbox/_in_sandbox.py
+++ b/temporalio/worker/workflow_sandbox/_in_sandbox.py
@@ -6,7 +6,7 @@
 
 import dataclasses
 import logging
-from typing import Type
+from typing import Any, Type
 
 import temporalio.bridge.proto.workflow_activation
 import temporalio.bridge.proto.workflow_completion
@@ -39,7 +39,37 @@ class InSandbox:
         # class. We can't use the definition that was given to us because it has
         # type hints and references to outside-of-sandbox types.
         new_defn = temporalio.workflow._Definition.must_from_class(workflow_class)
-        new_instance_details = dataclasses.replace(instance_details, defn=new_defn)
+
+        # Also, we have to re-import the worker-level exception types, because
+        # some exceptions are not passthrough and therefore our issubclass fails
+        # because it'll be comparing out-of-sandbox types with in-sandbox types
+        exception_types = instance_details.worker_level_failure_exception_types
+        if exception_types:
+            # Copy first, then add in-sandbox types appended
+            exception_types = list(exception_types)
+            # Try to re-import each
+            for typ in instance_details.worker_level_failure_exception_types:
+                try:
+                    class_hier = typ.__qualname__.split(".")
+                    module = __import__(typ.__module__, fromlist=[class_hier[0]])
+                    reimported_type: Any = module
+                    for name in class_hier:
+                        reimported_type = getattr(reimported_type, name)
+                    if not issubclass(reimported_type, BaseException):
+                        raise TypeError(
+                            f"Final imported type of {reimported_type} does not extend BaseException"
+                        )
+                    exception_types.append(reimported_type)
+                except Exception as err:
+                    raise TypeError(
+                        f"Failed to re-import workflow exception failure type {typ} in sandbox"
+                    ) from err
+
+        new_instance_details = dataclasses.replace(
+            instance_details,
+            defn=new_defn,
+            worker_level_failure_exception_types=exception_types,
+        )
 
         # Instantiate the runner and the instance
         self.instance = runner_class().create_instance(new_instance_details)

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -25,6 +25,7 @@ def new_worker(
     task_queue: Optional[str] = None,
     workflow_runner: WorkflowRunner = SandboxedWorkflowRunner(),
     max_cached_workflows: int = 1000,
+    workflow_failure_exception_types: Sequence[Type[BaseException]] = [],
     **kwargs,
 ) -> Worker:
     return Worker(
@@ -34,6 +35,7 @@ def new_worker(
         activities=activities,
         workflow_runner=workflow_runner,
         max_cached_workflows=max_cached_workflows,
+        workflow_failure_exception_types=workflow_failure_exception_types,
         **kwargs,
     )
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -118,6 +118,7 @@ def test_workflow_defn_good():
             ),
         },
         sandboxed=True,
+        failure_exception_types=[],
     )
 
 


### PR DESCRIPTION
## What was changed

* Added `workflow_failure_exception_types` to `Worker` to allow configuring failure exception types at a worker level
* Added `failure_exception_types` to `@workflow.defn` to allow configuring failure exception types at a workflow level
* Updated bridge code to include worker-level and workflow-type-level non-determinism-as-fail based on the presence of `temporalio.workflow.NondeterminismError` (or super type) in worker/workflow options
* Documented in README, API doc, and marked experimental
* Several tests for several scenarios

It's no coincidence this mimics https://github.com/temporalio/sdk-dotnet/pull/205. Also see the feature issue at https://github.com/temporalio/features/issues/322.

## Checklist

1. Closes #446