### PR TITLE
Worker client replacement

### DIFF
--- a/temporalio/bridge/src/worker.rs
+++ b/temporalio/bridge/src/worker.rs
@@ -187,7 +187,7 @@ impl WorkerRef {
     fn replace_client(&self, client: &client::ClientRef) {
         self.worker
             .as_ref()
-            .unwrap()
+            .expect("missing worker")
             .replace_client(client.retry_client.clone().into_inner());
     }
 

--- a/temporalio/bridge/src/worker.rs
+++ b/temporalio/bridge/src/worker.rs
@@ -184,6 +184,13 @@ impl WorkerRef {
         Ok(())
     }
 
+    fn replace_client(&self, client: &client::ClientRef) {
+        self.worker
+            .as_ref()
+            .unwrap()
+            .replace_client(client.retry_client.clone().into_inner());
+    }
+
     fn initiate_shutdown(&self) -> PyResult<()> {
         let worker = self.worker.as_ref().unwrap().clone();
         worker.initiate_shutdown();

--- a/temporalio/bridge/worker.py
+++ b/temporalio/bridge/worker.py
@@ -132,6 +132,10 @@ class Worker:
         """Request a workflow be evicted."""
         self._ref.request_workflow_eviction(run_id)
 
+    def replace_client(self, client: temporalio.bridge.client.Client) -> None:
+        """Replace the worker client."""
+        self._ref.replace_client(client._ref)
+
     def initiate_shutdown(self) -> None:
         """Start shutdown of the worker."""
         self._ref.initiate_shutdown()

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -4506,8 +4506,68 @@ async def test_workflow_fail_on_bad_input(client: Client):
             await client.execute_workflow(
                 "FailOnBadInputWorkflow",
                 123,
-                id=f"wf-{uuid}",
+                id=f"wf-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
             )
     assert isinstance(err.value.cause, ApplicationError)
     assert "Failed decoding arguments" in err.value.cause.message
+
+
+@workflow.defn
+class TickingWorkflow:
+    @workflow.run
+    async def run(self) -> None:
+        # Just tick every 100ms for 10s
+        for _ in range(100):
+            await asyncio.sleep(0.1)
+
+
+async def test_workflow_replace_worker_client(client: Client, env: WorkflowEnvironment):
+    if env.supports_time_skipping:
+        pytest.skip("Only testing against two real servers")
+    # We are going to start a second ephemeral server and then replace the
+    # client. So we will start a no-cache ticking workflow with the current
+    # client and confirm it has accomplished at least one task. Then we will
+    # start another on the other client, and confirm it gets started too. Then
+    # we will terminate both. We have to use a ticking workflow with only one
+    # poller to force a quick re-poll to recognize our client change quickly (as
+    # opposed to just waiting the minute for poll timeout).
+    async with await WorkflowEnvironment.start_local() as other_env:
+        # Start both workflows on different servers
+        task_queue = f"tq-{uuid.uuid4()}"
+        handle1 = await client.start_workflow(
+            TickingWorkflow.run, id=f"wf-{uuid.uuid4()}", task_queue=task_queue
+        )
+        handle2 = await other_env.client.start_workflow(
+            TickingWorkflow.run, id=f"wf-{uuid.uuid4()}", task_queue=task_queue
+        )
+
+        async def any_task_completed(handle: WorkflowHandle) -> bool:
+            async for e in handle.fetch_history_events():
+                if e.HasField("workflow_task_completed_event_attributes"):
+                    return True
+            return False
+
+        # Now start the worker on the first env
+        async with Worker(
+            client,
+            task_queue=task_queue,
+            workflows=[TickingWorkflow],
+            max_cached_workflows=0,
+            max_concurrent_workflow_task_polls=1,
+        ) as worker:
+            # Confirm the first ticking workflow has completed a task but not
+            # the second
+            await assert_eq_eventually(True, lambda: any_task_completed(handle1))
+            assert not await any_task_completed(handle2)
+
+            # Now replace the client, which should be used fairly quickly
+            # because we should have timer-done poll completions every 100ms
+            worker.client = other_env.client
+
+            # Now confirm the other workflow has started
+            await assert_eq_eventually(True, lambda: any_task_completed(handle2))
+
+            # Terminate both
+            await handle1.terminate()
+            await handle2.terminate()


### PR DESCRIPTION
## What was changed

* Update core to get https://github.com/temporalio/sdk-core/pull/721
* Added `client` property on `Worker` w/ getter/setter
  * Setter now replaces the worker client
* Added test proving the worker switches servers (even if this is not how people should use client replacement)

## Checklist

1. Closes #513