### PR TITLE
During eviction, set is_replaying and raise special exception

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,4 +105,3 @@ jobs:
       python-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}
       version-is-repo-ref: true
-      features-repo-ref: http-connect-proxy-python


### PR DESCRIPTION
## What was changed

* Set `workflow.unsafe.is_replaying()` to `True` during eviction
* Raise a special `BaseException`-based exception during eviction instead of `RuntimeError` which has an `Exception` base

## Checklist

1. Closes #523