### PR TITLE
Add deterministic alternatives for asyncio.wait and asyncio.as_completed

### DIFF
--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -4378,7 +4378,7 @@ def as_completed(
     if asyncio.isfuture(fs) or asyncio.iscoroutine(fs):
         raise TypeError(f"expect an iterable of futures, not {type(fs).__name__}")
 
-    done = asyncio.Queue[Optional[asyncio.Future]]()
+    done: asyncio.Queue[Optional[asyncio.Future]] = asyncio.Queue()
 
     loop = asyncio.get_event_loop()
     todo: List[asyncio.Future] = [asyncio.ensure_future(f, loop=loop) for f in list(fs)]

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -22,6 +22,7 @@ from typing import (
     Callable,
     Dict,
     Generic,
+    Iterable,
     Iterator,
     List,
     Mapping,
@@ -31,6 +32,7 @@ from typing import (
     Sequence,
     Tuple,
     Type,
+    TypeVar,
     Union,
     cast,
     overload,
@@ -4359,6 +4361,176 @@ def set_dynamic_update_handler(
         validator: Callable to set or None to unset as the update validator.
     """
     _Runtime.current().workflow_set_update_handler(None, handler, validator)
+
+
+def as_completed(
+    fs: Iterable[Awaitable[AnyType]], *, timeout: Optional[float] = None
+) -> Iterator[Awaitable[AnyType]]:
+    """Return an iterator whose values are coroutines.
+
+    This is a deterministic version of :py:func:`asyncio.as_completed`. This
+    function should be used instead of that one in workflows.
+    """
+    # Taken almost verbatim from
+    # https://github.com/python/cpython/blob/v3.12.3/Lib/asyncio/tasks.py#L584
+    # but the "set" is changed out for a "list" and fixed up some typing/format
+
+    if asyncio.isfuture(fs) or asyncio.iscoroutine(fs):
+        raise TypeError(f"expect an iterable of futures, not {type(fs).__name__}")
+
+    done = asyncio.Queue[Optional[asyncio.Future]]()
+
+    loop = asyncio.get_event_loop()
+    todo: List[asyncio.Future] = [asyncio.ensure_future(f, loop=loop) for f in list(fs)]
+    timeout_handle = None
+
+    def _on_timeout():
+        for f in todo:
+            f.remove_done_callback(_on_completion)
+            done.put_nowait(None)  # Queue a dummy value for _wait_for_one().
+        todo.clear()  # Can't do todo.remove(f) in the loop.
+
+    def _on_completion(f):
+        if not todo:
+            return  # _on_timeout() was here first.
+        todo.remove(f)
+        done.put_nowait(f)
+        if not todo and timeout_handle is not None:
+            timeout_handle.cancel()
+
+    async def _wait_for_one():
+        f = await done.get()
+        if f is None:
+            # Dummy value from _on_timeout().
+            raise asyncio.TimeoutError
+        return f.result()  # May raise f.exception().
+
+    for f in todo:
+        f.add_done_callback(_on_completion)
+    if todo and timeout is not None:
+        timeout_handle = loop.call_later(timeout, _on_timeout)
+    for _ in range(len(todo)):
+        yield _wait_for_one()
+
+
+if TYPE_CHECKING:
+    _FT = TypeVar("_FT", bound=asyncio.Future[Any])
+else:
+    _FT = TypeVar("_FT", bound=asyncio.Future)
+
+
+@overload
+async def wait(  # type: ignore[misc]
+    fs: Iterable[_FT],
+    *,
+    timeout: Optional[float] = None,
+    return_when: str = asyncio.ALL_COMPLETED,
+) -> Tuple[List[_FT], List[_FT]]:
+    ...
+
+
+@overload
+async def wait(
+    fs: Iterable[asyncio.Task[AnyType]],
+    *,
+    timeout: Optional[float] = None,
+    return_when: str = asyncio.ALL_COMPLETED,
+) -> Tuple[List[asyncio.Task[AnyType]], set[asyncio.Task[AnyType]]]:
+    ...
+
+
+async def wait(
+    fs: Iterable,
+    *,
+    timeout: Optional[float] = None,
+    return_when: str = asyncio.ALL_COMPLETED,
+) -> Tuple:
+    """Wait for the Futures or Tasks given by fs to complete.
+
+    This is a deterministic version of :py:func:`asyncio.wait`. This function
+    should be used instead of that one in workflows.
+    """
+    # Taken almost verbatim from
+    # https://github.com/python/cpython/blob/v3.12.3/Lib/asyncio/tasks.py#L435
+    # but the "set" is changed out for a "list" and fixed up some typing/format
+
+    if asyncio.isfuture(fs) or asyncio.iscoroutine(fs):
+        raise TypeError(f"expect a list of futures, not {type(fs).__name__}")
+    if not fs:
+        raise ValueError("Set of Tasks/Futures is empty.")
+    if return_when not in (
+        asyncio.FIRST_COMPLETED,
+        asyncio.FIRST_EXCEPTION,
+        asyncio.ALL_COMPLETED,
+    ):
+        raise ValueError(f"Invalid return_when value: {return_when}")
+
+    fs = list(fs)
+
+    if any(asyncio.iscoroutine(f) for f in fs):
+        raise TypeError("Passing coroutines is forbidden, use tasks explicitly.")
+
+    loop = asyncio.get_running_loop()
+    return await _wait(fs, timeout, return_when, loop)
+
+
+async def _wait(
+    fs: Iterable[Union[asyncio.Future, asyncio.Task]],
+    timeout: Optional[float],
+    return_when: str,
+    loop: asyncio.AbstractEventLoop,
+) -> Tuple[List, List]:
+    # Taken almost verbatim from
+    # https://github.com/python/cpython/blob/v3.12.3/Lib/asyncio/tasks.py#L522
+    # but the "set" is changed out for a "list" and fixed up some typing/format
+
+    assert fs, "Set of Futures is empty."
+    waiter = loop.create_future()
+    timeout_handle = None
+    if timeout is not None:
+        timeout_handle = loop.call_later(timeout, _release_waiter, waiter)
+    counter = len(fs)  # type: ignore[arg-type]
+
+    def _on_completion(f):
+        nonlocal counter
+        counter -= 1
+        if (
+            counter <= 0
+            or return_when == asyncio.FIRST_COMPLETED
+            or return_when == asyncio.FIRST_EXCEPTION
+            and (not f.cancelled() and f.exception() is not None)
+        ):
+            if timeout_handle is not None:
+                timeout_handle.cancel()
+            if not waiter.done():
+                waiter.set_result(None)
+
+    for f in fs:
+        f.add_done_callback(_on_completion)
+
+    try:
+        await waiter
+    finally:
+        if timeout_handle is not None:
+            timeout_handle.cancel()
+        for f in fs:
+            f.remove_done_callback(_on_completion)
+
+    done, pending = [], []
+    for f in fs:
+        if f.done():
+            done.append(f)
+        else:
+            pending.append(f)
+    return done, pending
+
+
+def _release_waiter(waiter: asyncio.Future[Any], *args) -> None:
+    # Taken almost verbatim from
+    # https://github.com/python/cpython/blob/v3.12.3/Lib/asyncio/tasks.py#L467
+
+    if not waiter.done():
+        waiter.set_result(None)
 
 
 def _is_unbound_method_on_cls(fn: Callable[..., Any], cls: Type) -> bool:

--- a/tests/helpers/worker.py
+++ b/tests/helpers/worker.py
@@ -196,7 +196,7 @@ class KitchenSinkWorkflow:
             for i in range(opt.count or 1):
                 pending_tasks.append(asyncio.create_task(run_activity(i)))
             # Wait on them all and raise error if one happened
-            done, _ = await asyncio.wait(
+            done, _ = await workflow.wait(
                 pending_tasks, return_when=asyncio.FIRST_EXCEPTION
             )
             for task in done:

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -2065,7 +2065,7 @@ class StackTraceWorkflow:
             ),
             self.never_completing_coroutine(),
         ]
-        await asyncio.wait([asyncio.create_task(v) for v in awaitables])
+        await workflow.wait([asyncio.create_task(v) for v in awaitables])
 
     async def never_completing_coroutine(self) -> None:
         self._status = "waiting"


### PR DESCRIPTION
## What was changed

`asyncio.as_completed` and `asyncio.wait` are non-deterministic sometimes so we need alternatives.

* Created deterministic `workflow.as_completed` and `workflow.wait` alternatives
* Updated the README to encourage their use
* Issue [warnings](https://docs.python.org/3/library/warnings.html) when the asyncio ones are called (to become errors in #535 in the future)

## Checklist

1. Closes #429
1. Closes #518
