### PR TITLE
Access current update info with ID inside update handler

### DIFF
--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -463,6 +463,11 @@ class _WorkflowInstanceImpl(
         # inside the task, since the update may not be defined until after we have started the workflow - for example
         # if an update is in the first WFT & is also registered dynamically at the top of workflow code.
         async def run_update() -> None:
+            # Set the current update for the life of this task
+            temporalio.workflow._set_current_update_info(
+                temporalio.workflow.UpdateInfo(id=job.id)
+            )
+
             command = self._add_command()
             command.update_response.protocol_instance_id = job.protocol_instance_id
             past_validation = False

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -465,7 +465,7 @@ class _WorkflowInstanceImpl(
         async def run_update() -> None:
             # Set the current update for the life of this task
             temporalio.workflow._set_current_update_info(
-                temporalio.workflow.UpdateInfo(id=job.id)
+                temporalio.workflow.UpdateInfo(id=job.id, name=job.name)
             )
 
             command = self._add_command()

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -679,7 +679,8 @@ def current_update_info() -> Optional[UpdateInfo]:
     update handler and coroutines/tasks it has started.
 
     Returns:
-        Info for the current update handler if any.
+        Info for the current update handler the code calling this is executing
+            within if any.
     """
     return _current_update_info.get(None)
 

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -432,6 +432,9 @@ class UpdateInfo:
     id: str
     """Update ID."""
 
+    name: str
+    """Update type name."""
+
 
 class _Runtime(ABC):
     @staticmethod
@@ -677,6 +680,9 @@ def current_update_info() -> Optional[UpdateInfo]:
 
     This is powered by :py:mod:`contextvars` so it is only valid within the
     update handler and coroutines/tasks it has started.
+
+    .. warning::
+       This API is experimental
 
     Returns:
         Info for the current update handler the code calling this is executing

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import inspect
 import logging
 import threading
@@ -424,6 +425,14 @@ class ParentInfo:
     workflow_id: str
 
 
+@dataclass(frozen=True)
+class UpdateInfo:
+    """Information about a workflow update."""
+
+    id: str
+    """Update ID."""
+
+
 class _Runtime(ABC):
     @staticmethod
     def current() -> _Runtime:
@@ -652,6 +661,27 @@ class _Runtime(ABC):
         self, fn: Callable[[], bool], *, timeout: Optional[float] = None
     ) -> None:
         ...
+
+
+_current_update_info: contextvars.ContextVar[UpdateInfo] = contextvars.ContextVar(
+    "__temporal_current_update_info"
+)
+
+
+def _set_current_update_info(info: UpdateInfo) -> None:
+    _current_update_info.set(info)
+
+
+def current_update_info() -> Optional[UpdateInfo]:
+    """Info for the current update if any.
+
+    This is powered by :py:mod:`contextvars` so it is only valid within the
+    update handler and coroutines/tasks it has started.
+
+    Returns:
+        Info for the current update handler if any.
+    """
+    return _current_update_info.get(None)
 
 
 def deprecate_patch(id: str) -> None:

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -4971,7 +4971,11 @@ class CurrentUpdateWorkflow:
         return info.id
 
 
-async def test_workflow_current_update(client: Client):
+async def test_workflow_current_update(client: Client, env: WorkflowEnvironment):
+    if env.supports_time_skipping:
+        pytest.skip(
+            "Java test server: https://github.com/temporalio/sdk-java/issues/1903"
+        )
     async with new_worker(client, CurrentUpdateWorkflow) as worker:
         handle = await client.start_workflow(
             CurrentUpdateWorkflow.run,

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -4951,9 +4951,10 @@ class CurrentUpdateWorkflow:
         # Check that simple helper awaited has the ID
         info = workflow.current_update_info()
         assert info
+        assert info.name == "do_update"
         assert info.id == await self.get_update_id()
 
-        # Also schedule the task but run it in the main workflow to confirm
+        # Also schedule the task and wait for it in the main workflow to confirm
         # it still gets the update ID
         self._pending_get_update_id_tasks.append(
             asyncio.create_task(self.get_update_id())

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -4965,6 +4965,12 @@ class CurrentUpdateWorkflow:
         assert info
         return info.id
 
+    @do_update.validator
+    def do_update_validator(self) -> None:
+        info = workflow.current_update_info()
+        assert info
+        assert info.name == "do_update"
+
     async def get_update_id(self) -> str:
         await asyncio.sleep(0.01)
         info = workflow.current_update_info()


### PR DESCRIPTION
## What was changed

* Added `temporalio.workflow.UpdateInfo`, similar to `temporalio.workflow.Info`, with workflow-accessible information for an update (currently `id` and `name`)
* Added `temporalio.workflow.current_update_info()`, similar to `temporalio.workflow.info()`, with the current in-context update info
  * This uses `contextvars` so it works inside the handler and things it starts but nowhere else
  * `current_update_info()` is preferred over `info()` because the latter is always present and there is nothing "current" about it, whereas the former can return `None` if you're not in an update

## Checklist

1. Closes #542
