### PR TITLE
Bump GitHub Actions

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -29,16 +29,16 @@ jobs:
             package-suffix: windows-amd64
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       # actions/setup-python doesn't yet support Linux ARM
       - if: ${{ matrix.os != 'ubuntu-arm' }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - if: ${{ matrix.os == 'ubuntu-arm' }}
-        uses: deadsnakes/action@v2.1.1
+        uses: deadsnakes/action@v3
         with:
           python-version: "3.12"
 
@@ -46,11 +46,9 @@ jobs:
       # command to build with cibuildwheel which uses rustup install defined
       # in pyproject.toml)
       - if: ${{ runner.os != 'Linux' }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
       - if: ${{ runner.os != 'Linux' }}
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           working-directory: temporalio/bridge
 
@@ -73,7 +71,7 @@ jobs:
       - run: poe test-dist-single
 
       # Upload dist
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: packages-${{ matrix.package-suffix }}
           path: dist

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           python-version: "3.12"
       - if: ${{ matrix.os == 'ubuntu-arm' }}
-        uses: deadsnakes/action@v3
+        uses: deadsnakes/action@v3.1.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - if: ${{ matrix.os == 'ubuntu-arm' }}
-        uses: deadsnakes/action@v3
+        uses: deadsnakes/action@v3.1.0
         with:
           python-version: ${{ matrix.python }}
       # Using fixed Poetry version until

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,22 +36,20 @@ jobs:
             python: "3.8"
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@v1
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
         with:
           working-directory: temporalio/bridge
       # actions/setup-python doesn't yet support Linux ARM
       - if: ${{ matrix.os != 'ubuntu-arm' }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - if: ${{ matrix.os == 'ubuntu-arm' }}
-        uses: deadsnakes/action@v2.1.1
+        uses: deadsnakes/action@v3
         with:
           python-version: ${{ matrix.python }}
       # Using fixed Poetry version until
@@ -91,7 +89,7 @@ jobs:
         run: npx vercel deploy build/apidocs -t ${{ secrets.VERCEL_TOKEN }} --name python --scope temporal --prod --yes
 
       # Confirm README ToC is generated properly
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - name: Check generated README ToC
         if: ${{ matrix.docsTarget }}
         run: |

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -26,16 +26,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       # Prepare
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           working-directory: temporalio/bridge
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## What was changed

- Updated all GHA actions to latest.

## Why?

- GitHub is pulling the plug on `download-artifact@v2` and `upload-artifact@v2` on June 30th;
- `actions-rs/toolchain@v1` is no longer maintained;
- All GHA official actions based on Node 16 are deprecated.
