### PR TITLE
Fix GHA config for swatinem/rust-cache@v2

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -50,7 +50,7 @@ jobs:
       - if: ${{ runner.os != 'Linux' }}
         uses: Swatinem/rust-cache@v2
         with:
-          working-directory: temporalio/bridge
+          workspaces: temporalio/bridge -> target
 
       # Prepare
       # Using fixed Poetry version until

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          working-directory: temporalio/bridge
+          workspaces: temporalio/bridge -> target
       # actions/setup-python doesn't yet support Linux ARM
       - if: ${{ matrix.os != 'ubuntu-arm' }}
         uses: actions/setup-python@v5

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -34,7 +34,7 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
         with:
-          working-directory: temporalio/bridge
+          workspaces: temporalio/bridge -> target
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"


### PR DESCRIPTION
## What was changed and why?

- Fix options on GHA `swatinem/rust-cache@v2`, because I forgot to make adjustment while updating from `@v1` in previous PR.