### PR TITLE
Install protoc in run-bench CI job

### DIFF
--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -38,7 +38,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-
+      - uses: arduino/setup-protoc@v3
+        with:
+          # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed
+          version: "23.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+  
       # Build
       - run: python -m pip install --upgrade wheel poetry poethepoet
       - run: poetry install --no-root --all-extras


### PR DESCRIPTION
## What was changed

- Install protoc in run-bench CI job. It is required since #547.