### PR TITLE
Server 1.24 related fixes

### DIFF
--- a/temporalio/common.py
+++ b/temporalio/common.py
@@ -511,7 +511,11 @@ class TypedSearchAttributes(Collection[SearchAttributePair]):
         # Go over each update, replacing matching keys by index or adding
         for attr in search_attributes:
             existing_index = next(
-                (i for i, attr in enumerate(attrs) if attr.key.name == attr.key.name),
+                (
+                    i
+                    for i, index_attr in enumerate(attrs)
+                    if attr.key.name == index_attr.key.name
+                ),
                 None,
             )
             if existing_index is None:


### PR DESCRIPTION
## What was changed

* Fix schedule test assertions that expect certain num actions on backfill (backfill logic changed in 1.24)
* Fix schedule test assertions that expect untyped search attributes (search attributes for scheduled workflows are mapped to proper types in 1.24)
* Fix issue found during schedule test assertions where we were improperly checking against a shadowed variable when appending search attributes