### PR TITLE
New API to wait for handler executions to complete and warnings on unfinished handler executions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,8 +107,8 @@ testpaths = ["tests"]
 timeout = 600
 timeout_func_only = true
 filterwarnings = [
-  "error::temporalio.worker._workflow_instance.UnfinishedUpdateHandlerWarning",
-  "error::temporalio.worker._workflow_instance.UnfinishedSignalHandlerWarning",
+  "error::temporalio.workflow.UnfinishedUpdateHandlerWarning",
+  "error::temporalio.workflow.UnfinishedSignalHandlerWarning",
   "ignore::pytest.PytestDeprecationWarning",
   "ignore::DeprecationWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,8 +107,8 @@ testpaths = ["tests"]
 timeout = 600
 timeout_func_only = true
 filterwarnings = [
-  "error::temporalio.workflow.UnfinishedUpdateHandlerWarning",
-  "error::temporalio.workflow.UnfinishedSignalHandlerWarning",
+  "error::temporalio.workflow.UnfinishedUpdateHandlersWarning",
+  "error::temporalio.workflow.UnfinishedSignalHandlersWarning",
   "ignore::pytest.PytestDeprecationWarning",
   "ignore::DeprecationWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ env = { TEMPORAL_INTEGRATION_TEST = "1" }
 cmd = "pip uninstall temporalio -y"
 
 [tool.pytest.ini_options]
-addopts = "-p no:warnings"
 asyncio_mode = "auto"
 log_cli = true
 log_cli_level = "INFO"
@@ -107,6 +106,12 @@ log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(linen
 testpaths = ["tests"]
 timeout = 600
 timeout_func_only = true
+filterwarnings = [
+  "error::temporalio.worker._workflow_instance.UnfinishedUpdateHandlerWarning",
+  "error::temporalio.worker._workflow_instance.UnfinishedSignalHandlerWarning",
+  "ignore::pytest.PytestDeprecationWarning",
+  "ignore::DeprecationWarning",
+]
 
 [tool.cibuildwheel]
 # We only want the 3.8 64-bit build of each type. However, due to

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -887,6 +887,9 @@ class _WorkflowInstanceImpl(
     #### _Runtime direct workflow call overrides ####
     # These are in alphabetical order and all start with "workflow_".
 
+    def workflow_all_handlers_finished(self) -> bool:
+        return not self._in_progress_updates and not self._in_progress_signals
+
     def workflow_continue_as_new(
         self,
         *args: Any,
@@ -1119,9 +1122,6 @@ class _WorkflowInstanceImpl(
                 )
         else:
             self._updates.pop(name, None)
-
-    def workflow_all_handlers_finished(self) -> bool:
-        return not self._in_progress_updates and not self._in_progress_signals
 
     def workflow_start_activity(
         self,

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -11,13 +11,11 @@ import logging
 import random
 import sys
 import traceback
-import typing
 import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import timedelta
-from enum import Enum
 from typing import (
     Any,
     Awaitable,

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -1629,7 +1629,7 @@ class _WorkflowInstanceImpl(
         warnable_updates = warnable(self._in_progress_updates.values())
         if warnable_updates:
             warnings.warn(
-                temporalio.workflow.UnfinishedUpdateHandlerWarning(
+                temporalio.workflow.UnfinishedUpdateHandlersWarning(
                     _make_unfinished_update_handler_message(warnable_updates)
                 )
             )
@@ -1637,7 +1637,7 @@ class _WorkflowInstanceImpl(
         warnable_signals = warnable(self._in_progress_signals.values())
         if warnable_signals:
             warnings.warn(
-                temporalio.workflow.UnfinishedSignalHandlerWarning(
+                temporalio.workflow.UnfinishedSignalHandlersWarning(
                     _make_unfinished_signal_handler_message(warnable_signals)
                 )
             )

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -2761,10 +2761,10 @@ def _make_unfinished_update_handler_message(
 Workflow finished while update handlers are still running. This may have interrupted work that the
 update handler was doing, and the client that sent the update will receive a 'workflow execution
 already completed' RPCError instead of the update result. You can wait for all update and signal
-handlers to complete by using `await workflow.wait_condition(lambda: workflow.all_handlers_finished())`.
-Alternatively, if both you and the clients sending updates and signals are okay with interrupting
-running handlers when the workflow finishes, and causing clients to receive errors, then you can
-disable this warning via the update handler decorator:
+handlers to complete by using `await workflow.wait_condition(lambda:
+workflow.all_handlers_finished())`. Alternatively, if both you and the clients sending the update
+are okay with interrupting running handlers when the workflow finishes, and causing clients to
+receive errors, then you can disable this warning via the update handler decorator:
 `@workflow.update(unfinished_policy=workflow.HandlerUnfinishedPolicy.ABANDON)`.
 """.replace(
         "\n", " "
@@ -2782,10 +2782,9 @@ def _make_unfinished_signal_handler_message(
 Workflow finished while signal handlers are still running. This may have interrupted work that the
 signal handler was doing. You can wait for all update and signal handlers to complete by using
 `await workflow.wait_condition(lambda: workflow.all_handlers_finished())`. Alternatively, if both
-you and the clients sending updates and signals are okay with interrupting running handlers when the
-workflow finishes, and causing clients to receive errors, then you can disable this warning via the
-signal handler decorator:
-`@workflow.signal(unfinished_policy=workflow.HandlerUnfinishedPolicy.ABANDON)`.
+you and the clients sending the signal are okay with interrupting running handlers when the workflow
+finishes, and causing clients to receive errors, then you can disable this warning via the signal
+handler decorator: `@workflow.signal(unfinished_policy=workflow.HandlerUnfinishedPolicy.ABANDON)`.
 """.replace(
         "\n", " "
     ).strip()

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -244,7 +244,7 @@ class _WorkflowInstanceImpl(
         self._updates = dict(self._defn.updates)
 
         # We record in-progress signals and updates in order to support waiting for handlers to
-        # complete, and issuing warnings when the workflow exits with incomplete handlers. Since
+        # finish, and issuing warnings when the workflow exits with unfinished handlers. Since
         # signals lack a unique per-invocation identifier, we introduce a sequence number for the
         # purpose.
         self._handled_signals_seq = 0
@@ -424,7 +424,7 @@ class _WorkflowInstanceImpl(
             i += 1
 
         if seen_completion:
-            self._warn_if_incomplete_handlers()
+            self._warn_if_unfinished_handlers()
         return self._current_completion
 
     def _apply(
@@ -504,7 +504,7 @@ class _WorkflowInstanceImpl(
                         f"known updates: [{' '.join(known_updates)}]"
                     )
                 self._in_progress_updates[job.id] = HandlerExecution(
-                    job.name, defn.incomplete_handlers_policy, job.id
+                    job.name, defn.unfinished_handlers_policy, job.id
                 )
                 args = self._process_handler_args(
                     job.name,
@@ -1120,7 +1120,7 @@ class _WorkflowInstanceImpl(
         else:
             self._updates.pop(name, None)
 
-    def workflow_all_handlers_complete(self) -> bool:
+    def workflow_all_handlers_finished(self) -> bool:
         return not self._in_progress_updates and not self._in_progress_signals
 
     def workflow_start_activity(
@@ -1617,22 +1617,22 @@ class _WorkflowInstanceImpl(
             )
         )
 
-    def _warn_if_incomplete_handlers(self) -> None:
+    def _warn_if_unfinished_handlers(self) -> None:
         def warnable(handler_executions: Iterable[HandlerExecution]):
             return [
                 ex
                 for ex in handler_executions
-                if ex.incomplete_handlers_policy
-                == temporalio.workflow.IncompleteHandlersPolicy.WARN_AND_ABANDON
+                if ex.unfinished_handlers_policy
+                == temporalio.workflow.UnfinishedHandlersPolicy.WARN_AND_ABANDON
             ]
 
         warnable_updates = warnable(self._in_progress_updates.values())
         if warnable_updates:
-            warnings.warn(IncompleteUpdateHandlerWarning(warnable_updates))
+            warnings.warn(UnfinishedUpdateHandlerWarning(warnable_updates))
 
         warnable_signals = warnable(self._in_progress_signals.values())
         if warnable_signals:
-            warnings.warn(IncompleteSignalHandlerWarning(warnable_signals))
+            warnings.warn(UnfinishedSignalHandlerWarning(warnable_signals))
 
     def _next_seq(self, type: str) -> int:
         seq = self._curr_seqs.get(type, 0) + 1
@@ -1690,7 +1690,7 @@ class _WorkflowInstanceImpl(
                 self._handled_signals_seq += 1
                 id = self._handled_signals_seq
                 self._in_progress_signals[id] = HandlerExecution(
-                    job.signal_name, defn.incomplete_handlers_policy
+                    job.signal_name, defn.unfinished_handlers_policy
                 )
                 await self._run_top_level_workflow_function(
                     self._inbound.handle_signal(input)
@@ -2743,11 +2743,11 @@ class _WorkflowBeingEvictedError(BaseException):
 @dataclass
 class HandlerExecution:
     name: str
-    incomplete_handlers_policy: temporalio.workflow.IncompleteHandlersPolicy
+    unfinished_handlers_policy: temporalio.workflow.UnfinishedHandlersPolicy
     id: Optional[str] = None
 
 
-class IncompleteUpdateHandlerWarning(RuntimeWarning):
+class UnfinishedUpdateHandlerWarning(RuntimeWarning):
     def __init__(self, handler_executions: List[HandlerExecution]) -> None:
         super().__init__()
         self.handler_executions = handler_executions
@@ -2757,23 +2757,23 @@ class IncompleteUpdateHandlerWarning(RuntimeWarning):
 Workflow finished while update handlers are still running. This may have interrupted work that the
 update handler was doing, and the client that sent the update will receive a 'workflow execution
 already completed' RPCError instead of the update result. You can wait for all update and signal
-handlers to complete by using `await workflow.wait_condition(lambda: workflow.all_handlers_complete())`.
+handlers to complete by using `await workflow.wait_condition(lambda: workflow.all_handlers_finished())`.
 Alternatively, if both you and the clients sending updates and signals are okay with interrupting
 running handlers when the workflow finishes, and causing clients to receive errors, then you can
 disable this warning via the update handler decorator:
-`@workflow.update(incomplete_handlers_policy=workflow.IncompleteHandlersPolicy.ABANDON)`.
+`@workflow.update(unfinished_handlers_policy=workflow.UnfinishedHandlersPolicy.ABANDON)`.
 """.replace(
             "\n", " "
         ).strip()
         return (
-            f"{message} The following updates were incomplete (and warnings were not disabled for their handler): "
+            f"{message} The following updates were unfinished (and warnings were not disabled for their handler): "
             + json.dumps(
                 [{"name": ex.name, "id": ex.id} for ex in self.handler_executions]
             )
         )
 
 
-class IncompleteSignalHandlerWarning(RuntimeWarning):
+class UnfinishedSignalHandlerWarning(RuntimeWarning):
     def __init__(self, handler_executions: List[HandlerExecution]) -> None:
         super().__init__()
         self.handler_executions = handler_executions
@@ -2782,17 +2782,17 @@ class IncompleteSignalHandlerWarning(RuntimeWarning):
         message = """
 Workflow finished while signal handlers are still running. This may have interrupted work that the
 signal handler was doing. You can wait for all update and signal handlers to complete by using
-`await workflow.wait_condition(lambda: workflow.all_handlers_complete())`. Alternatively, if both
+`await workflow.wait_condition(lambda: workflow.all_handlers_finished())`. Alternatively, if both
 you and the clients sending updates and signals are okay with interrupting running handlers when the
 workflow finishes, and causing clients to receive errors, then you can disable this warning via the
 signal handler decorator:
-`@workflow.signal(incomplete_handlers_policy=workflow.IncompleteHandlersPolicy.ABANDON)`.
+`@workflow.signal(unfinished_handlers_policy=workflow.UnfinishedHandlersPolicy.ABANDON)`.
 """.replace(
             "\n", " "
         ).strip()
         names = collections.Counter(ex.name for ex in self.handler_executions)
         return (
-            f"{message} The following signals were incomplete (and warnings were not disabled for their handler): "
+            f"{message} The following signals were unfinished (and warnings were not disabled for their handler): "
             + json.dumps(
                 [{"name": name, "count": count} for name, count in names.most_common()]
             )

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -504,7 +504,7 @@ class _WorkflowInstanceImpl(
                         f"known updates: [{' '.join(known_updates)}]"
                     )
                 self._in_progress_updates[job.id] = HandlerExecution(
-                    job.name, defn.unfinished_handlers_policy, job.id
+                    job.name, defn.unfinished_policy, job.id
                 )
                 args = self._process_handler_args(
                     job.name,
@@ -1688,7 +1688,7 @@ class _WorkflowInstanceImpl(
         self._handled_signals_seq += 1
         id = self._handled_signals_seq
         self._in_progress_signals[id] = HandlerExecution(
-            job.signal_name, defn.unfinished_handlers_policy
+            job.signal_name, defn.unfinished_policy
         )
 
         def done_callback(f):

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -417,6 +417,7 @@ class _WorkflowInstanceImpl(
                     command.HasField("complete_workflow_execution")
                     or command.HasField("continue_as_new_workflow_execution")
                     or command.HasField("fail_workflow_execution")
+                    or command.HasField("cancel_workflow_execution")
                 )
             elif not command.HasField("respond_to_query"):
                 del self._current_completion.successful.commands[i]

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -1622,8 +1622,8 @@ class _WorkflowInstanceImpl(
             return [
                 ex
                 for ex in handler_executions
-                if ex.unfinished_handlers_policy
-                == temporalio.workflow.UnfinishedHandlersPolicy.WARN_AND_ABANDON
+                if ex.unfinished_policy
+                == temporalio.workflow.HandlerUnfinishedPolicy.WARN_AND_ABANDON
             ]
 
         warnable_updates = warnable(self._in_progress_updates.values())
@@ -2742,7 +2742,7 @@ class HandlerExecution:
     """Information about an execution of a signal or update handler."""
 
     name: str
-    unfinished_handlers_policy: temporalio.workflow.UnfinishedHandlersPolicy
+    unfinished_policy: temporalio.workflow.HandlerUnfinishedPolicy
     id: Optional[str] = None
 
 
@@ -2764,7 +2764,7 @@ handlers to complete by using `await workflow.wait_condition(lambda: workflow.al
 Alternatively, if both you and the clients sending updates and signals are okay with interrupting
 running handlers when the workflow finishes, and causing clients to receive errors, then you can
 disable this warning via the update handler decorator:
-`@workflow.update(unfinished_handlers_policy=workflow.UnfinishedHandlersPolicy.ABANDON)`.
+`@workflow.update(unfinished_policy=workflow.HandlerUnfinishedPolicy.ABANDON)`.
 """.replace(
             "\n", " "
         ).strip()
@@ -2793,7 +2793,7 @@ signal handler was doing. You can wait for all update and signal handlers to com
 you and the clients sending updates and signals are okay with interrupting running handlers when the
 workflow finishes, and causing clients to receive errors, then you can disable this warning via the
 signal handler decorator:
-`@workflow.signal(unfinished_handlers_policy=workflow.UnfinishedHandlersPolicy.ABANDON)`.
+`@workflow.signal(unfinished_policy=workflow.HandlerUnfinishedPolicy.ABANDON)`.
 """.replace(
             "\n", " "
         ).strip()

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -1147,6 +1147,9 @@ class _WorkflowInstanceImpl(
         else:
             self._updates.pop(name, None)
 
+    def workflow_all_handlers_finished(self) -> bool:
+        return not self._in_progress_updates and not self._in_progress_signals
+
     def workflow_start_activity(
         self,
         activity: Any,

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -634,7 +634,7 @@ class _WorkflowInstanceImpl(
                     return
                 raise
             finally:
-                del self._in_progress_updates[job.id]
+                self._in_progress_updates.pop(job.id, None)
 
         self.create_task(
             run_update(),
@@ -1722,7 +1722,7 @@ class _WorkflowInstanceImpl(
                     self._inbound.handle_signal(input)
                 )
             finally:
-                del self._in_progress_signals[id]
+                self._in_progress_signals.pop(id, None)
 
         self.create_task(
             run_signal(),

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -2739,17 +2739,23 @@ class _WorkflowBeingEvictedError(BaseException):
 
 @dataclass
 class HandlerExecution:
+    """Information about an execution of a signal or update handler."""
+
     name: str
     unfinished_handlers_policy: temporalio.workflow.UnfinishedHandlersPolicy
     id: Optional[str] = None
 
 
 class UnfinishedUpdateHandlerWarning(RuntimeWarning):
+    """Warning issued when a workflow exits before an update handler has finished executing"""
+
     def __init__(self, handler_executions: List[HandlerExecution]) -> None:
+        """Initialize warning object"""
         super().__init__()
         self.handler_executions = handler_executions
 
     def __str__(self) -> str:
+        """Return warning message"""
         message = """
 Workflow finished while update handlers are still running. This may have interrupted work that the
 update handler was doing, and the client that sent the update will receive a 'workflow execution
@@ -2771,11 +2777,15 @@ disable this warning via the update handler decorator:
 
 
 class UnfinishedSignalHandlerWarning(RuntimeWarning):
+    """Warning issued when a workflow exits before a signal handler has finished executing"""
+
     def __init__(self, handler_executions: List[HandlerExecution]) -> None:
+        """Initialize warning object"""
         super().__init__()
         self.handler_executions = handler_executions
 
     def __str__(self) -> str:
+        """Return warning message"""
         message = """
 Workflow finished while signal handlers are still running. This may have interrupted work that the
 signal handler was doing. You can wait for all update and signal handlers to complete by using

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -4729,3 +4729,11 @@ class VersioningIntent(Enum):
         elif self == VersioningIntent.DEFAULT:
             return temporalio.bridge.proto.common.VersioningIntent.DEFAULT
         return temporalio.bridge.proto.common.VersioningIntent.UNSPECIFIED
+
+
+class UnfinishedUpdateHandlerWarning(RuntimeWarning):
+    """Warning issued when a workflow exits before an update handler has finished executing"""
+
+
+class UnfinishedSignalHandlerWarning(RuntimeWarning):
+    """Warning issued when a workflow exits before a signal handler has finished executing"""

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -187,6 +187,15 @@ class HandlerUnfinishedPolicy(Enum):
     ABANDON = 2
 
 
+
+class UnfinishedUpdateHandlersWarning(RuntimeWarning):
+    """The workflow exited before all update handlers had finished executing."""
+
+
+class UnfinishedSignalHandlersWarning(RuntimeWarning):
+    """The workflow exited before all signal handlers had finished executing."""
+
+
 @overload
 def signal(fn: CallableSyncOrAsyncReturnNoneType) -> CallableSyncOrAsyncReturnNoneType:
     ...
@@ -4729,11 +4738,3 @@ class VersioningIntent(Enum):
         elif self == VersioningIntent.DEFAULT:
             return temporalio.bridge.proto.common.VersioningIntent.DEFAULT
         return temporalio.bridge.proto.common.VersioningIntent.UNSPECIFIED
-
-
-class UnfinishedUpdateHandlerWarning(RuntimeWarning):
-    """Warning issued when a workflow exits before an update handler has finished executing"""
-
-
-class UnfinishedSignalHandlerWarning(RuntimeWarning):
-    """Warning issued when a workflow exits before a signal handler has finished executing"""

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -195,7 +195,7 @@ def signal(fn: CallableSyncOrAsyncReturnNoneType) -> CallableSyncOrAsyncReturnNo
 @overload
 def signal(
     *,
-    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ) -> Callable[[CallableSyncOrAsyncReturnNoneType], CallableSyncOrAsyncReturnNoneType]:
     ...
 
@@ -204,7 +204,7 @@ def signal(
 def signal(
     *,
     name: str,
-    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ) -> Callable[[CallableSyncOrAsyncReturnNoneType], CallableSyncOrAsyncReturnNoneType]:
     ...
 
@@ -213,7 +213,7 @@ def signal(
 def signal(
     *,
     dynamic: Literal[True],
-    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ) -> Callable[[CallableSyncOrAsyncReturnNoneType], CallableSyncOrAsyncReturnNoneType]:
     ...
 
@@ -223,7 +223,7 @@ def signal(
     *,
     name: Optional[str] = None,
     dynamic: Optional[bool] = False,
-    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ):
     """Decorator for a workflow signal method.
 
@@ -244,13 +244,13 @@ def signal(
             parameters of the method must be self, a string name, and a
             ``*args`` positional varargs. Cannot be present when ``name`` is
             present.
-        unfinished_handlers_policy: Actions taken if a workflow terminates with
+        unfinished_policy: Actions taken if a workflow terminates with
             a running instance of this handler.
     """
 
     def decorator(
         name: Optional[str],
-        unfinished_handlers_policy: UnfinishedHandlersPolicy,
+        unfinished_policy: UnfinishedHandlersPolicy,
         fn: CallableSyncOrAsyncReturnNoneType,
     ) -> CallableSyncOrAsyncReturnNoneType:
         if not name and not dynamic:
@@ -259,7 +259,7 @@ def signal(
             name=name,
             fn=fn,
             is_method=True,
-            unfinished_handlers_policy=unfinished_handlers_policy,
+            unfinished_policy=unfinished_policy,
         )
         setattr(fn, "__temporal_signal_definition", defn)
         if defn.dynamic_vararg:
@@ -273,9 +273,9 @@ def signal(
     if not fn:
         if name is not None and dynamic:
             raise RuntimeError("Cannot provide name and dynamic boolean")
-        return partial(decorator, name, unfinished_handlers_policy)
+        return partial(decorator, name, unfinished_policy)
     else:
-        return decorator(fn.__name__, unfinished_handlers_policy, fn)
+        return decorator(fn.__name__, unfinished_policy, fn)
 
 
 @overload
@@ -965,7 +965,7 @@ def update(
 @overload
 def update(
     *,
-    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ) -> Callable[
     [Callable[MultiParamSpec, ReturnType]],
     UpdateMethodMultiParam[MultiParamSpec, ReturnType],
@@ -977,7 +977,7 @@ def update(
 def update(
     *,
     name: str,
-    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ) -> Callable[
     [Callable[MultiParamSpec, ReturnType]],
     UpdateMethodMultiParam[MultiParamSpec, ReturnType],
@@ -989,7 +989,7 @@ def update(
 def update(
     *,
     dynamic: Literal[True],
-    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ) -> Callable[
     [Callable[MultiParamSpec, ReturnType]],
     UpdateMethodMultiParam[MultiParamSpec, ReturnType],
@@ -1002,7 +1002,7 @@ def update(
     *,
     name: Optional[str] = None,
     dynamic: Optional[bool] = False,
-    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ):
     """Decorator for a workflow update handler method.
 
@@ -1030,13 +1030,13 @@ def update(
             parameters of the method must be self, a string name, and a
             ``*args`` positional varargs. Cannot be present when ``name`` is
             present.
-        unfinished_handlers_policy: Actions taken if a workflow terminates with
+        unfinished_policy: Actions taken if a workflow terminates with
             a running instance of this handler.
     """
 
     def decorator(
         name: Optional[str],
-        unfinished_handlers_policy: UnfinishedHandlersPolicy,
+        unfinished_policy: UnfinishedHandlersPolicy,
         fn: CallableSyncOrAsyncType,
     ) -> CallableSyncOrAsyncType:
         if not name and not dynamic:
@@ -1045,7 +1045,7 @@ def update(
             name=name,
             fn=fn,
             is_method=True,
-            unfinished_handlers_policy=unfinished_handlers_policy,
+            unfinished_policy=unfinished_policy,
         )
         if defn.dynamic_vararg:
             raise RuntimeError(
@@ -1058,9 +1058,9 @@ def update(
     if not fn:
         if name is not None and dynamic:
             raise RuntimeError("Cannot provide name and dynamic boolean")
-        return partial(decorator, name, unfinished_handlers_policy)
+        return partial(decorator, name, unfinished_policy)
     else:
-        return decorator(fn.__name__, unfinished_handlers_policy, fn)
+        return decorator(fn.__name__, unfinished_policy, fn)
 
 
 def _update_validator(
@@ -1517,7 +1517,7 @@ class _SignalDefinition:
     name: Optional[str]
     fn: Callable[..., Union[None, Awaitable[None]]]
     is_method: bool
-    unfinished_handlers_policy: UnfinishedHandlersPolicy = (
+    unfinished_policy: UnfinishedHandlersPolicy = (
         UnfinishedHandlersPolicy.WARN_AND_ABANDON
     )
     # Types loaded on post init if None
@@ -1601,7 +1601,7 @@ class _UpdateDefinition:
     name: Optional[str]
     fn: Callable[..., Union[Any, Awaitable[Any]]]
     is_method: bool
-    unfinished_handlers_policy: UnfinishedHandlersPolicy = (
+    unfinished_policy: UnfinishedHandlersPolicy = (
         UnfinishedHandlersPolicy.WARN_AND_ABANDON
     )
     # Types loaded on post init if None

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -180,12 +180,13 @@ class HandlerUnfinishedPolicy(Enum):
     The workflow exit may be due to successful return, failure, cancellation, or continue-as-new.
     """
 
-    # Issue a warning in addition to abandoning.
     WARN_AND_ABANDON = 1
-    # Abandon the handler. In the case of an update handler this means that the client will receive
-    # an error rather than the update result.
+    """Issue a warning in addition to abandoning."""
     ABANDON = 2
+    """Abandon the handler.
 
+    In the case of an update handler this means that the client will receive an error rather than
+    the update result."""
 
 
 class UnfinishedUpdateHandlersWarning(RuntimeWarning):

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -173,6 +173,20 @@ def run(fn: CallableAsyncType) -> CallableAsyncType:
     return fn  # type: ignore[return-value]
 
 
+class UnfinishedHandlersPolicy(IntEnum):
+    """Actions taken if a workflow terminates with running handlers.
+
+    Policy defining actions taken when a workflow exits while update or signal handlers are running.
+    The workflow exit may be due to successful return, failure, cancellation, or continue-as-new.
+    """
+
+    # Abandon the handler. In the case of an update handler this means that the client will receive
+    # an error rather than the update result.
+    ABANDON = 1
+    # Issue a warning in addition to abandoning.
+    WARN_AND_ABANDON = 2
+
+
 @overload
 def signal(fn: CallableSyncOrAsyncReturnNoneType) -> CallableSyncOrAsyncReturnNoneType:
     ...

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -211,6 +211,7 @@ def signal(
     *,
     name: Optional[str] = None,
     dynamic: Optional[bool] = False,
+    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ):
     """Decorator for a workflow signal method.
 
@@ -231,6 +232,8 @@ def signal(
             parameters of the method must be self, a string name, and a
             ``*args`` positional varargs. Cannot be present when ``name`` is
             present.
+        unfinished_handlers_policy: Actions taken if a workflow terminates with
+            a running instance of this handler.
     """
 
     def with_name(
@@ -964,6 +967,7 @@ def update(
     *,
     name: Optional[str] = None,
     dynamic: Optional[bool] = False,
+    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ):
     """Decorator for a workflow update handler method.
 
@@ -991,6 +995,8 @@ def update(
             parameters of the method must be self, a string name, and a
             ``*args`` positional varargs. Cannot be present when ``name`` is
             present.
+        unfinished_handlers_policy: Actions taken if a workflow terminates with
+            a running instance of this handler.
     """
 
     def with_name(
@@ -1468,6 +1474,9 @@ class _SignalDefinition:
     name: Optional[str]
     fn: Callable[..., Union[None, Awaitable[None]]]
     is_method: bool
+    unfinished_handlers_policy: UnfinishedHandlersPolicy = (
+        UnfinishedHandlersPolicy.WARN_AND_ABANDON
+    )
     # Types loaded on post init if None
     arg_types: Optional[List[Type]] = None
     dynamic_vararg: bool = False
@@ -1549,6 +1558,9 @@ class _UpdateDefinition:
     name: Optional[str]
     fn: Callable[..., Union[Any, Awaitable[Any]]]
     is_method: bool
+    unfinished_handlers_policy: UnfinishedHandlersPolicy = (
+        UnfinishedHandlersPolicy.WARN_AND_ABANDON
+    )
     # Types loaded on post init if None
     arg_types: Optional[List[Type]] = None
     ret_type: Optional[Type] = None

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -194,35 +194,26 @@ def signal(fn: CallableSyncOrAsyncReturnNoneType) -> CallableSyncOrAsyncReturnNo
 
 @overload
 def signal(
-    *, name: str
+    *,
+    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ) -> Callable[[CallableSyncOrAsyncReturnNoneType], CallableSyncOrAsyncReturnNoneType]:
     ...
 
 
 @overload
 def signal(
-    *, dynamic: Literal[True]
+    *,
+    name: str,
+    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ) -> Callable[[CallableSyncOrAsyncReturnNoneType], CallableSyncOrAsyncReturnNoneType]:
     ...
 
 
 @overload
 def signal(
-    *, unfinished_handlers_policy: UnfinishedHandlersPolicy
-) -> Callable[[CallableSyncOrAsyncReturnNoneType], CallableSyncOrAsyncReturnNoneType]:
-    ...
-
-
-@overload
-def signal(
-    *, name: str, unfinished_handlers_policy: UnfinishedHandlersPolicy
-) -> Callable[[CallableSyncOrAsyncReturnNoneType], CallableSyncOrAsyncReturnNoneType]:
-    ...
-
-
-@overload
-def signal(
-    *, dynamic: Literal[True], unfinished_handlers_policy: UnfinishedHandlersPolicy
+    *,
+    dynamic: Literal[True],
+    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ) -> Callable[[CallableSyncOrAsyncReturnNoneType], CallableSyncOrAsyncReturnNoneType]:
     ...
 
@@ -973,7 +964,8 @@ def update(
 
 @overload
 def update(
-    *, name: str
+    *,
+    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ) -> Callable[
     [Callable[MultiParamSpec, ReturnType]],
     UpdateMethodMultiParam[MultiParamSpec, ReturnType],
@@ -983,7 +975,9 @@ def update(
 
 @overload
 def update(
-    *, dynamic: Literal[True]
+    *,
+    name: str,
+    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ) -> Callable[
     [Callable[MultiParamSpec, ReturnType]],
     UpdateMethodMultiParam[MultiParamSpec, ReturnType],
@@ -993,27 +987,9 @@ def update(
 
 @overload
 def update(
-    *, unfinished_handlers_policy: UnfinishedHandlersPolicy
-) -> Callable[
-    [Callable[MultiParamSpec, ReturnType]],
-    UpdateMethodMultiParam[MultiParamSpec, ReturnType],
-]:
-    ...
-
-
-@overload
-def update(
-    *, name: str, unfinished_handlers_policy: UnfinishedHandlersPolicy
-) -> Callable[
-    [Callable[MultiParamSpec, ReturnType]],
-    UpdateMethodMultiParam[MultiParamSpec, ReturnType],
-]:
-    ...
-
-
-@overload
-def update(
-    *, dynamic: Literal[True], unfinished_handlers_policy: UnfinishedHandlersPolicy
+    *,
+    dynamic: Literal[True],
+    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ) -> Callable[
     [Callable[MultiParamSpec, ReturnType]],
     UpdateMethodMultiParam[MultiParamSpec, ReturnType],

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -173,7 +173,7 @@ def run(fn: CallableAsyncType) -> CallableAsyncType:
     return fn  # type: ignore[return-value]
 
 
-class UnfinishedHandlersPolicy(Enum):
+class HandlerUnfinishedPolicy(Enum):
     """Actions taken if a workflow terminates with running handlers.
 
     Policy defining actions taken when a workflow exits while update or signal handlers are running.
@@ -195,7 +195,7 @@ def signal(fn: CallableSyncOrAsyncReturnNoneType) -> CallableSyncOrAsyncReturnNo
 @overload
 def signal(
     *,
-    unfinished_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_policy: HandlerUnfinishedPolicy = HandlerUnfinishedPolicy.WARN_AND_ABANDON,
 ) -> Callable[[CallableSyncOrAsyncReturnNoneType], CallableSyncOrAsyncReturnNoneType]:
     ...
 
@@ -204,7 +204,7 @@ def signal(
 def signal(
     *,
     name: str,
-    unfinished_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_policy: HandlerUnfinishedPolicy = HandlerUnfinishedPolicy.WARN_AND_ABANDON,
 ) -> Callable[[CallableSyncOrAsyncReturnNoneType], CallableSyncOrAsyncReturnNoneType]:
     ...
 
@@ -213,7 +213,7 @@ def signal(
 def signal(
     *,
     dynamic: Literal[True],
-    unfinished_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_policy: HandlerUnfinishedPolicy = HandlerUnfinishedPolicy.WARN_AND_ABANDON,
 ) -> Callable[[CallableSyncOrAsyncReturnNoneType], CallableSyncOrAsyncReturnNoneType]:
     ...
 
@@ -223,7 +223,7 @@ def signal(
     *,
     name: Optional[str] = None,
     dynamic: Optional[bool] = False,
-    unfinished_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_policy: HandlerUnfinishedPolicy = HandlerUnfinishedPolicy.WARN_AND_ABANDON,
 ):
     """Decorator for a workflow signal method.
 
@@ -250,7 +250,7 @@ def signal(
 
     def decorator(
         name: Optional[str],
-        unfinished_policy: UnfinishedHandlersPolicy,
+        unfinished_policy: HandlerUnfinishedPolicy,
         fn: CallableSyncOrAsyncReturnNoneType,
     ) -> CallableSyncOrAsyncReturnNoneType:
         if not name and not dynamic:
@@ -965,7 +965,7 @@ def update(
 @overload
 def update(
     *,
-    unfinished_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_policy: HandlerUnfinishedPolicy = HandlerUnfinishedPolicy.WARN_AND_ABANDON,
 ) -> Callable[
     [Callable[MultiParamSpec, ReturnType]],
     UpdateMethodMultiParam[MultiParamSpec, ReturnType],
@@ -977,7 +977,7 @@ def update(
 def update(
     *,
     name: str,
-    unfinished_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_policy: HandlerUnfinishedPolicy = HandlerUnfinishedPolicy.WARN_AND_ABANDON,
 ) -> Callable[
     [Callable[MultiParamSpec, ReturnType]],
     UpdateMethodMultiParam[MultiParamSpec, ReturnType],
@@ -989,7 +989,7 @@ def update(
 def update(
     *,
     dynamic: Literal[True],
-    unfinished_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_policy: HandlerUnfinishedPolicy = HandlerUnfinishedPolicy.WARN_AND_ABANDON,
 ) -> Callable[
     [Callable[MultiParamSpec, ReturnType]],
     UpdateMethodMultiParam[MultiParamSpec, ReturnType],
@@ -1002,7 +1002,7 @@ def update(
     *,
     name: Optional[str] = None,
     dynamic: Optional[bool] = False,
-    unfinished_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_policy: HandlerUnfinishedPolicy = HandlerUnfinishedPolicy.WARN_AND_ABANDON,
 ):
     """Decorator for a workflow update handler method.
 
@@ -1036,7 +1036,7 @@ def update(
 
     def decorator(
         name: Optional[str],
-        unfinished_policy: UnfinishedHandlersPolicy,
+        unfinished_policy: HandlerUnfinishedPolicy,
         fn: CallableSyncOrAsyncType,
     ) -> CallableSyncOrAsyncType:
         if not name and not dynamic:
@@ -1517,8 +1517,8 @@ class _SignalDefinition:
     name: Optional[str]
     fn: Callable[..., Union[None, Awaitable[None]]]
     is_method: bool
-    unfinished_policy: UnfinishedHandlersPolicy = (
-        UnfinishedHandlersPolicy.WARN_AND_ABANDON
+    unfinished_policy: HandlerUnfinishedPolicy = (
+        HandlerUnfinishedPolicy.WARN_AND_ABANDON
     )
     # Types loaded on post init if None
     arg_types: Optional[List[Type]] = None
@@ -1601,8 +1601,8 @@ class _UpdateDefinition:
     name: Optional[str]
     fn: Callable[..., Union[Any, Awaitable[Any]]]
     is_method: bool
-    unfinished_policy: UnfinishedHandlersPolicy = (
-        UnfinishedHandlersPolicy.WARN_AND_ABANDON
+    unfinished_policy: HandlerUnfinishedPolicy = (
+        HandlerUnfinishedPolicy.WARN_AND_ABANDON
     )
     # Types loaded on post init if None
     arg_types: Optional[List[Type]] = None

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -180,11 +180,11 @@ class UnfinishedHandlersPolicy(IntEnum):
     The workflow exit may be due to successful return, failure, cancellation, or continue-as-new.
     """
 
+    # Issue a warning in addition to abandoning.
+    WARN_AND_ABANDON = 1
     # Abandon the handler. In the case of an update handler this means that the client will receive
     # an error rather than the update result.
-    ABANDON = 1
-    # Issue a warning in addition to abandoning.
-    WARN_AND_ABANDON = 2
+    ABANDON = 2
 
 
 @overload

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -514,6 +514,10 @@ class _Runtime(ABC):
         return self._logger_details
 
     @abstractmethod
+    def workflow_all_handlers_finished(self) -> bool:
+        ...
+
+    @abstractmethod
     def workflow_continue_as_new(
         self,
         *args: Any,
@@ -628,10 +632,6 @@ class _Runtime(ABC):
         handler: Optional[Callable],
         validator: Optional[Callable],
     ) -> None:
-        ...
-
-    @abstractmethod
-    def workflow_all_handlers_finished(self) -> bool:
         ...
 
     @abstractmethod

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -173,7 +173,7 @@ def run(fn: CallableAsyncType) -> CallableAsyncType:
     return fn  # type: ignore[return-value]
 
 
-class UnfinishedHandlersPolicy(IntEnum):
+class UnfinishedHandlersPolicy(Enum):
     """Actions taken if a workflow terminates with running handlers.
 
     Policy defining actions taken when a workflow exits while update or signal handlers are running.

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -173,7 +173,7 @@ def run(fn: CallableAsyncType) -> CallableAsyncType:
     return fn  # type: ignore[return-value]
 
 
-class IncompleteHandlersPolicy(IntEnum):
+class UnfinishedHandlersPolicy(IntEnum):
     """Actions taken if a workflow terminates with running handlers.
 
     Policy defining actions taken when a workflow exits while update or signal handlers are running.
@@ -208,21 +208,21 @@ def signal(
 
 @overload
 def signal(
-    *, incomplete_handlers_policy: IncompleteHandlersPolicy
+    *, unfinished_handlers_policy: UnfinishedHandlersPolicy
 ) -> Callable[[CallableSyncOrAsyncReturnNoneType], CallableSyncOrAsyncReturnNoneType]:
     ...
 
 
 @overload
 def signal(
-    *, name: str, incomplete_handlers_policy: IncompleteHandlersPolicy
+    *, name: str, unfinished_handlers_policy: UnfinishedHandlersPolicy
 ) -> Callable[[CallableSyncOrAsyncReturnNoneType], CallableSyncOrAsyncReturnNoneType]:
     ...
 
 
 @overload
 def signal(
-    *, dynamic: Literal[True], incomplete_handlers_policy: IncompleteHandlersPolicy
+    *, dynamic: Literal[True], unfinished_handlers_policy: UnfinishedHandlersPolicy
 ) -> Callable[[CallableSyncOrAsyncReturnNoneType], CallableSyncOrAsyncReturnNoneType]:
     ...
 
@@ -232,7 +232,7 @@ def signal(
     *,
     name: Optional[str] = None,
     dynamic: Optional[bool] = False,
-    incomplete_handlers_policy: IncompleteHandlersPolicy = IncompleteHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ):
     """Decorator for a workflow signal method.
 
@@ -253,13 +253,13 @@ def signal(
             parameters of the method must be self, a string name, and a
             ``*args`` positional varargs. Cannot be present when ``name`` is
             present.
-        incomplete_handlers_policy: Actions taken if a workflow terminates with
+        unfinished_handlers_policy: Actions taken if a workflow terminates with
             a running instance of this handler.
     """
 
     def decorator(
         name: Optional[str],
-        incomplete_handlers_policy: IncompleteHandlersPolicy,
+        unfinished_handlers_policy: UnfinishedHandlersPolicy,
         fn: CallableSyncOrAsyncReturnNoneType,
     ) -> CallableSyncOrAsyncReturnNoneType:
         if not name and not dynamic:
@@ -268,7 +268,7 @@ def signal(
             name=name,
             fn=fn,
             is_method=True,
-            incomplete_handlers_policy=incomplete_handlers_policy,
+            unfinished_handlers_policy=unfinished_handlers_policy,
         )
         setattr(fn, "__temporal_signal_definition", defn)
         if defn.dynamic_vararg:
@@ -282,9 +282,9 @@ def signal(
     if not fn:
         if name is not None and dynamic:
             raise RuntimeError("Cannot provide name and dynamic boolean")
-        return partial(decorator, name, incomplete_handlers_policy)
+        return partial(decorator, name, unfinished_handlers_policy)
     else:
-        return decorator(fn.__name__, incomplete_handlers_policy, fn)
+        return decorator(fn.__name__, unfinished_handlers_policy, fn)
 
 
 @overload
@@ -631,7 +631,7 @@ class _Runtime(ABC):
         ...
 
     @abstractmethod
-    def workflow_all_handlers_complete(self) -> bool:
+    def workflow_all_handlers_finished(self) -> bool:
         ...
 
     @abstractmethod
@@ -993,7 +993,7 @@ def update(
 
 @overload
 def update(
-    *, incomplete_handlers_policy: IncompleteHandlersPolicy
+    *, unfinished_handlers_policy: UnfinishedHandlersPolicy
 ) -> Callable[
     [Callable[MultiParamSpec, ReturnType]],
     UpdateMethodMultiParam[MultiParamSpec, ReturnType],
@@ -1003,7 +1003,7 @@ def update(
 
 @overload
 def update(
-    *, name: str, incomplete_handlers_policy: IncompleteHandlersPolicy
+    *, name: str, unfinished_handlers_policy: UnfinishedHandlersPolicy
 ) -> Callable[
     [Callable[MultiParamSpec, ReturnType]],
     UpdateMethodMultiParam[MultiParamSpec, ReturnType],
@@ -1013,7 +1013,7 @@ def update(
 
 @overload
 def update(
-    *, dynamic: Literal[True], incomplete_handlers_policy: IncompleteHandlersPolicy
+    *, dynamic: Literal[True], unfinished_handlers_policy: UnfinishedHandlersPolicy
 ) -> Callable[
     [Callable[MultiParamSpec, ReturnType]],
     UpdateMethodMultiParam[MultiParamSpec, ReturnType],
@@ -1026,7 +1026,7 @@ def update(
     *,
     name: Optional[str] = None,
     dynamic: Optional[bool] = False,
-    incomplete_handlers_policy: IncompleteHandlersPolicy = IncompleteHandlersPolicy.WARN_AND_ABANDON,
+    unfinished_handlers_policy: UnfinishedHandlersPolicy = UnfinishedHandlersPolicy.WARN_AND_ABANDON,
 ):
     """Decorator for a workflow update handler method.
 
@@ -1054,13 +1054,13 @@ def update(
             parameters of the method must be self, a string name, and a
             ``*args`` positional varargs. Cannot be present when ``name`` is
             present.
-        incomplete_handlers_policy: Actions taken if a workflow terminates with
+        unfinished_handlers_policy: Actions taken if a workflow terminates with
             a running instance of this handler.
     """
 
     def decorator(
         name: Optional[str],
-        incomplete_handlers_policy: IncompleteHandlersPolicy,
+        unfinished_handlers_policy: UnfinishedHandlersPolicy,
         fn: CallableSyncOrAsyncType,
     ) -> CallableSyncOrAsyncType:
         if not name and not dynamic:
@@ -1069,7 +1069,7 @@ def update(
             name=name,
             fn=fn,
             is_method=True,
-            incomplete_handlers_policy=incomplete_handlers_policy,
+            unfinished_handlers_policy=unfinished_handlers_policy,
         )
         if defn.dynamic_vararg:
             raise RuntimeError(
@@ -1082,9 +1082,9 @@ def update(
     if not fn:
         if name is not None and dynamic:
             raise RuntimeError("Cannot provide name and dynamic boolean")
-        return partial(decorator, name, incomplete_handlers_policy)
+        return partial(decorator, name, unfinished_handlers_policy)
     else:
-        return decorator(fn.__name__, incomplete_handlers_policy, fn)
+        return decorator(fn.__name__, unfinished_handlers_policy, fn)
 
 
 def _update_validator(
@@ -1541,8 +1541,8 @@ class _SignalDefinition:
     name: Optional[str]
     fn: Callable[..., Union[None, Awaitable[None]]]
     is_method: bool
-    incomplete_handlers_policy: IncompleteHandlersPolicy = (
-        IncompleteHandlersPolicy.WARN_AND_ABANDON
+    unfinished_handlers_policy: UnfinishedHandlersPolicy = (
+        UnfinishedHandlersPolicy.WARN_AND_ABANDON
     )
     # Types loaded on post init if None
     arg_types: Optional[List[Type]] = None
@@ -1625,8 +1625,8 @@ class _UpdateDefinition:
     name: Optional[str]
     fn: Callable[..., Union[Any, Awaitable[Any]]]
     is_method: bool
-    incomplete_handlers_policy: IncompleteHandlersPolicy = (
-        IncompleteHandlersPolicy.WARN_AND_ABANDON
+    unfinished_handlers_policy: UnfinishedHandlersPolicy = (
+        UnfinishedHandlersPolicy.WARN_AND_ABANDON
     )
     # Types loaded on post init if None
     arg_types: Optional[List[Type]] = None
@@ -4497,17 +4497,17 @@ def set_dynamic_update_handler(
     _Runtime.current().workflow_set_update_handler(None, handler, validator)
 
 
-def all_handlers_complete() -> bool:
+def all_handlers_finished() -> bool:
     """Whether update and signal handlers have finished executing.
 
     Consider waiting on this condition before workflow return or continue-as-new, to prevent
     interruption of in-progress handlers by workflow exit:
-    ``await workflow.wait_condition(lambda: workflow.all_handlers_complete())``
+    ``await workflow.wait_condition(lambda: workflow.all_handlers_finished())``
 
     Returns:
         True if there are no in-progress update or signal handler executions.
     """
-    return _Runtime.current().workflow_all_handlers_complete()
+    return _Runtime.current().workflow_all_handlers_finished()
 
 
 def as_completed(

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -599,6 +599,10 @@ class _Runtime(ABC):
         ...
 
     @abstractmethod
+    def workflow_all_handlers_finished(self) -> bool:
+        ...
+
+    @abstractmethod
     def workflow_start_activity(
         self,
         activity: Any,
@@ -4412,6 +4416,19 @@ def set_dynamic_update_handler(
         validator: Callable to set or None to unset as the update validator.
     """
     _Runtime.current().workflow_set_update_handler(None, handler, validator)
+
+
+def all_handlers_finished() -> bool:
+    """Whether update and signal handlers have finished executing.
+
+    Consider waiting on this condition before workflow return or continue-as-new, to prevent
+    interruption of in-progress handlers by workflow exit:
+    ``await workflow.wait_condition(lambda: workflow.all_handlers_finished())``
+
+    Returns:
+        True if there are no in-progress update or signal handler executions.
+    """
+    return _Runtime.current().workflow_all_handlers_finished()
 
 
 def as_completed(

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import dataclasses
 import json

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -5285,7 +5285,9 @@ class _UnfinishedHandlersTest:
             )
         )
         await assert_eq_eventually(
-            True, partial(self._workflow_task_failed, workflow_id=(await handle).id)
+            True,
+            partial(self._workflow_task_failed, workflow_id=(await handle).id),
+            timeout=timedelta(seconds=20),
         )
 
     async def _workflow_task_failed(self, workflow_id: str) -> bool:

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -5203,14 +5203,12 @@ class UnfinishedHandlersWorkflow:
     async def my_update(self) -> None:
         await self._do_update_or_signal()
 
-    @workflow.update(
-        unfinished_handlers_policy=workflow.UnfinishedHandlersPolicy.ABANDON
-    )
+    @workflow.update(unfinished_policy=workflow.UnfinishedHandlersPolicy.ABANDON)
     async def my_update_ABANDON(self) -> None:
         await self._do_update_or_signal()
 
     @workflow.update(
-        unfinished_handlers_policy=workflow.UnfinishedHandlersPolicy.WARN_AND_ABANDON
+        unfinished_policy=workflow.UnfinishedHandlersPolicy.WARN_AND_ABANDON
     )
     async def my_update_WARN_AND_ABANDON(self) -> None:
         await self._do_update_or_signal()
@@ -5219,14 +5217,12 @@ class UnfinishedHandlersWorkflow:
     async def my_signal(self):
         await self._do_update_or_signal()
 
-    @workflow.signal(
-        unfinished_handlers_policy=workflow.UnfinishedHandlersPolicy.ABANDON
-    )
+    @workflow.signal(unfinished_policy=workflow.UnfinishedHandlersPolicy.ABANDON)
     async def my_signal_ABANDON(self):
         await self._do_update_or_signal()
 
     @workflow.signal(
-        unfinished_handlers_policy=workflow.UnfinishedHandlersPolicy.WARN_AND_ABANDON
+        unfinished_policy=workflow.UnfinishedHandlersPolicy.WARN_AND_ABANDON
     )
     async def my_signal_WARN_AND_ABANDON(self):
         await self._do_update_or_signal()
@@ -5257,7 +5253,7 @@ class _UnfinishedHandlersTest:
         # and when the workflow sets the unfinished_handlers_policy to WARN_AND_ABANDON,
         handler_finished, warning = await self.get_workflow_result_and_warning(
             wait_for_handlers=False,
-            unfinished_handlers_policy=workflow.UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+            unfinished_policy=workflow.UnfinishedHandlersPolicy.WARN_AND_ABANDON,
         )
         assert not handler_finished and warning
         # but not when the workflow waits for handlers to complete,
@@ -5268,14 +5264,14 @@ class _UnfinishedHandlersTest:
         # nor when the silence-warnings policy is set on the handler.
         handler_finished, warning = await self.get_workflow_result_and_warning(
             wait_for_handlers=False,
-            unfinished_handlers_policy=workflow.UnfinishedHandlersPolicy.ABANDON,
+            unfinished_policy=workflow.UnfinishedHandlersPolicy.ABANDON,
         )
         assert not handler_finished and not warning
 
     async def get_workflow_result_and_warning(
         self,
         wait_for_handlers: bool,
-        unfinished_handlers_policy: Optional[workflow.UnfinishedHandlersPolicy] = None,
+        unfinished_policy: Optional[workflow.UnfinishedHandlersPolicy] = None,
     ) -> Tuple[bool, bool]:
         handle = await self.client.start_workflow(
             UnfinishedHandlersWorkflow.run,
@@ -5284,8 +5280,8 @@ class _UnfinishedHandlersTest:
             task_queue=self.worker.task_queue,
         )
         handler_name = f"my_{self.handler_type}"
-        if unfinished_handlers_policy:
-            handler_name += f"_{unfinished_handlers_policy.name}"
+        if unfinished_policy:
+            handler_name += f"_{unfinished_policy.name}"
         with pytest.WarningsRecorder() as warnings:
             if self.handler_type == "signal":
                 await asyncio.gather(handle.signal(handler_name))

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -42,7 +42,6 @@ from temporalio.api.common.v1 import Payload, Payloads, WorkflowExecution
 from temporalio.api.enums.v1 import EventType
 from temporalio.api.failure.v1 import Failure
 from temporalio.api.sdk.v1 import EnhancedStackTrace
-from temporalio.api.update.v1 import UpdateRef
 from temporalio.api.workflowservice.v1 import (
     GetWorkflowExecutionHistoryRequest,
     ResetStickyTaskQueueRequest,

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -5351,6 +5351,6 @@ class _UnfinishedHandlersTest:
     @property
     def unfinished_handler_warning_cls(self) -> Type:
         return {
-            "update": workflow.UnfinishedUpdateHandlerWarning,
-            "signal": workflow.UnfinishedSignalHandlerWarning,
+            "update": workflow.UnfinishedUpdateHandlersWarning,
+            "signal": workflow.UnfinishedSignalHandlersWarning,
         }[self.handler_type]

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -5205,12 +5205,12 @@ class UnfinishedHandlersWorkflow:
     async def my_update(self) -> None:
         await self._do_update_or_signal()
 
-    @workflow.update(unfinished_policy=workflow.UnfinishedHandlersPolicy.ABANDON)
+    @workflow.update(unfinished_policy=workflow.HandlerUnfinishedPolicy.ABANDON)
     async def my_update_ABANDON(self) -> None:
         await self._do_update_or_signal()
 
     @workflow.update(
-        unfinished_policy=workflow.UnfinishedHandlersPolicy.WARN_AND_ABANDON
+        unfinished_policy=workflow.HandlerUnfinishedPolicy.WARN_AND_ABANDON
     )
     async def my_update_WARN_AND_ABANDON(self) -> None:
         await self._do_update_or_signal()
@@ -5219,12 +5219,12 @@ class UnfinishedHandlersWorkflow:
     async def my_signal(self):
         await self._do_update_or_signal()
 
-    @workflow.signal(unfinished_policy=workflow.UnfinishedHandlersPolicy.ABANDON)
+    @workflow.signal(unfinished_policy=workflow.HandlerUnfinishedPolicy.ABANDON)
     async def my_signal_ABANDON(self):
         await self._do_update_or_signal()
 
     @workflow.signal(
-        unfinished_policy=workflow.UnfinishedHandlersPolicy.WARN_AND_ABANDON
+        unfinished_policy=workflow.HandlerUnfinishedPolicy.WARN_AND_ABANDON
     )
     async def my_signal_WARN_AND_ABANDON(self):
         await self._do_update_or_signal()
@@ -5252,10 +5252,10 @@ class _UnfinishedHandlersTest:
             wait_for_handlers=False,
         )
         assert not handler_finished and warning
-        # and when the workflow sets the unfinished_handlers_policy to WARN_AND_ABANDON,
+        # and when the workflow sets the unfinished_policy to WARN_AND_ABANDON,
         handler_finished, warning = await self.get_workflow_result_and_warning(
             wait_for_handlers=False,
-            unfinished_policy=workflow.UnfinishedHandlersPolicy.WARN_AND_ABANDON,
+            unfinished_policy=workflow.HandlerUnfinishedPolicy.WARN_AND_ABANDON,
         )
         assert not handler_finished and warning
         # but not when the workflow waits for handlers to complete,
@@ -5266,14 +5266,14 @@ class _UnfinishedHandlersTest:
         # nor when the silence-warnings policy is set on the handler.
         handler_finished, warning = await self.get_workflow_result_and_warning(
             wait_for_handlers=False,
-            unfinished_policy=workflow.UnfinishedHandlersPolicy.ABANDON,
+            unfinished_policy=workflow.HandlerUnfinishedPolicy.ABANDON,
         )
         assert not handler_finished and not warning
 
     async def get_workflow_result_and_warning(
         self,
         wait_for_handlers: bool,
-        unfinished_policy: Optional[workflow.UnfinishedHandlersPolicy] = None,
+        unfinished_policy: Optional[workflow.HandlerUnfinishedPolicy] = None,
     ) -> Tuple[bool, bool]:
         handle = await self.client.start_workflow(
             UnfinishedHandlersWorkflow.run,

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -5420,7 +5420,13 @@ async def test_unfinished_update_handler_with_workflow_failure(
     ).test_warning_is_issued_when_cancellation_or_failure_causes_exit_with_unfinished_handler()
 
 
-async def test_unfinished_signal_handler_with_workflow_failure(client: Client):
+async def test_unfinished_signal_handler_with_workflow_failure(
+    client: Client, env: WorkflowEnvironment
+):
+    if env.supports_time_skipping:
+        pytest.skip(
+            "Java test server: https://github.com/temporalio/sdk-java/issues/2127"
+        )
     await _UnfinishedHandlersWithCancellationOrFailureTest(
         client,
         "signal",

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -10,10 +10,9 @@ import sys
 import threading
 import typing
 import uuid
-import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import IntEnum
 from functools import partial

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -5338,21 +5338,17 @@ class _UnfinishedHandlersTest:
         if unfinished_policy:
             handler_name += f"_{unfinished_policy.name}"
         if self.handler_type == "signal":
-            await asyncio.gather(handle.signal(handler_name))
+            await handle.signal(handler_name)
         else:
             if not wait_all_handlers_finished:
                 with pytest.raises(RPCError) as err:
-                    await asyncio.gather(
-                        handle.execute_update(handler_name, id="my-update")
-                    )
+                    await handle.execute_update(handler_name, id="my-update")
                 assert (
                     err.value.status == RPCStatusCode.NOT_FOUND
                     and "workflow execution already completed" in str(err.value).lower()
                 )
             else:
-                await asyncio.gather(
-                    handle.execute_update(handler_name, id="my-update")
-                )
+                await handle.execute_update(handler_name, id="my-update")
 
         return await handle.result()
 

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -5228,7 +5228,11 @@ class UnfinishedHandlersWorkflow:
         await self._do_update_or_signal()
 
 
-async def test_unfinished_update_handler(client: Client):
+async def test_unfinished_update_handler(client: Client, env: WorkflowEnvironment):
+    if env.supports_time_skipping:
+        pytest.skip(
+            "Java test server: https://github.com/temporalio/sdk-java/issues/1903"
+        )
     async with new_worker(client, UnfinishedHandlersWorkflow) as worker:
         test = _UnfinishedHandlersTest(client, worker, "update")
         await test.test_wait_all_handlers_finished_and_unfinished_handlers_warning()
@@ -5383,7 +5387,13 @@ class UnfinishedHandlersWithCancellationOrFailureWorkflow:
         raise AssertionError("unreachable")
 
 
-async def test_unfinished_update_handler_with_workflow_cancellation(client: Client):
+async def test_unfinished_update_handler_with_workflow_cancellation(
+    client: Client, env: WorkflowEnvironment
+):
+    if env.supports_time_skipping:
+        pytest.skip(
+            "Java test server: https://github.com/temporalio/sdk-java/issues/1903"
+        )
     await _UnfinishedHandlersWithCancellationOrFailureTest(
         client,
         "update",
@@ -5399,7 +5409,13 @@ async def test_unfinished_signal_handler_with_workflow_cancellation(client: Clie
     ).test_warning_is_issued_when_cancellation_or_failure_causes_exit_with_unfinished_handler()
 
 
-async def test_unfinished_update_handler_with_workflow_failure(client: Client):
+async def test_unfinished_update_handler_with_workflow_failure(
+    client: Client, env: WorkflowEnvironment
+):
+    if env.supports_time_skipping:
+        pytest.skip(
+            "Java test server: https://github.com/temporalio/sdk-java/issues/1903"
+        )
     await _UnfinishedHandlersWithCancellationOrFailureTest(
         client,
         "update",

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -110,10 +110,8 @@ from tests.helpers import (
     new_worker,
     workflow_update_exists,
 )
-from tests.helpers.external_coroutine import wait_on_timer
 from tests.helpers.external_stack_trace import (
     ExternalStackTraceWorkflow,
-    MultiFileStackTraceWorkflow,
     external_wait_cancel,
 )
 

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -106,10 +106,6 @@ from temporalio.worker import (
     WorkflowInstanceDetails,
     WorkflowRunner,
 )
-from temporalio.worker._workflow_instance import (
-    UnfinishedSignalHandlerWarning,
-    UnfinishedUpdateHandlerWarning,
-)
 from tests.helpers import (
     assert_eq_eventually,
     ensure_search_attributes_present,
@@ -5355,6 +5351,6 @@ class _UnfinishedHandlersTest:
     @property
     def unfinished_handler_warning_cls(self) -> Type:
         return {
-            "update": UnfinishedUpdateHandlerWarning,
-            "signal": UnfinishedSignalHandlerWarning,
+            "update": workflow.UnfinishedUpdateHandlerWarning,
+            "signal": workflow.UnfinishedSignalHandlerWarning,
         }[self.handler_type]

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -5253,10 +5253,7 @@ class _UnfinishedHandlersTest:
             self.get_workflow_result(wait_for_handlers=False, handle_future=handle)
         )
         await assert_eq_eventually(
-            True,
-            partial(self.workflow_task_failed, workflow_id=(await handle).id),
-            timeout=timedelta(seconds=5),
-            interval=timedelta(seconds=1),
+            True, partial(self.workflow_task_failed, workflow_id=(await handle).id)
         )
 
         # The unfinished handler warning is issued by default,


### PR DESCRIPTION
Closes #538

Implementation ready for review; names are still under discussion.

## What was changed
- Added a new API to wait for update and signal handler executions to complete. Provisionally named `workflow.all_handlers_finished()`.
- Issue warnings on workflow exit if any handlers are unfinished.
- Allow warnings to be disabled on a per-handler basis via a signal/update decorator parameter.

## Why?
Workflows exiting while handler executions are in progress is an important category of run-time workflow incorrectness.