### PR TITLE
Use minimal scope with pytest.raises

### DIFF
--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -5492,7 +5492,7 @@ class _UnfinishedHandlersWithCancellationOrFailureTest:
 
                 with pytest.raises(WorkflowFailureError) as err:
                     await handle.result()
-                    assert "workflow execution failed" in str(err.value).lower()
+                assert str(err.value).lower() == "workflow execution failed"
 
                 unfinished_handler_warning_emitted = any(
                     issubclass(w.category, self._unfinished_handler_warning_cls)

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -5491,7 +5491,12 @@ class _UnfinishedHandlersWithCancellationOrFailureTest:
 
                 with pytest.raises(WorkflowFailureError) as err:
                     await handle.result()
-                assert str(err.value).lower() == "workflow execution failed"
+                assert isinstance(
+                    err.value.cause,
+                    {"cancellation": CancelledError, "failure": ApplicationError}[
+                        self.workflow_termination_type
+                    ],
+                )
 
                 unfinished_handler_warning_emitted = any(
                     issubclass(w.category, self._unfinished_handler_warning_cls)


### PR DESCRIPTION
`pytest.raises()` scope should be limited to the statement that raises only.


This PR fixes a couple of bugs (mine) in test assertions and improves style in others that were not incorrect (other peoples').