### PR TITLE
Fix old manylinux image issue via cibuildwheel update

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -221,13 +221,13 @@ unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "cibuildwheel"
-version = "2.17.0"
+version = "2.19.2"
 description = "Build Python wheels on CI with minimal configuration."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "cibuildwheel-2.17.0-py3-none-any.whl", hash = "sha256:62ddd06179269b9da111bf9e97aca8ecb7b9642e1151a0bac702dd46429b52bf"},
-    {file = "cibuildwheel-2.17.0.tar.gz", hash = "sha256:889510a7d974da855a8b793f8dbe718ce18189a42c2560741868e68900e02be2"},
+    {file = "cibuildwheel-2.19.2-py3-none-any.whl", hash = "sha256:02ead5d7e3e81fe2ee0afb78746b1494af6b37afc1e32fae12f9c9a28c14e369"},
+    {file = "cibuildwheel-2.19.2.tar.gz", hash = "sha256:d331c81c505106ee585333b871718cf0516ac10d55c4dda2c00c8a7405743cab"},
 ]
 
 [package.dependencies]
@@ -245,6 +245,7 @@ bin = ["click", "packaging (>=21.0)", "pip-tools", "pygithub", "pyyaml", "reques
 dev = ["build", "click", "jinja2", "packaging (>=21.0)", "pip-tools", "pygithub", "pytest (>=6)", "pytest-timeout", "pytest-xdist", "pyyaml", "requests", "rich (>=9.6)", "tomli-w", "validate-pyproject"]
 docs = ["jinja2 (>=3.1.2)", "mkdocs (==1.3.1)", "mkdocs-include-markdown-plugin (==2.8.0)", "mkdocs-macros-plugin", "pymdown-extensions"]
 test = ["build", "jinja2", "pytest (>=6)", "pytest-timeout", "pytest-xdist", "tomli-w", "validate-pyproject"]
+uv = ["uv"]
 
 [[package]]
 name = "colorama"
@@ -1753,4 +1754,4 @@ opentelemetry = ["opentelemetry-api", "opentelemetry-sdk"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "08a8d78df69979e1f2c667a18cd3f26ef3d898c00e78837383f5fc36f5ef7bcd"
+content-hash = "0e394859d0cd8522c57955db0e9358eacf18609cd0bd4bb0611403f2de7952c4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ types-protobuf = ">=3.20"
 typing-extensions = "^4.2.0"
 
 [tool.poetry.dev-dependencies]
-cibuildwheel = "^2.17.0"
+cibuildwheel = "^2.19.0"
 grpcio-tools = "^1.48.0"
 mypy = "^1.0.0"
 mypy-protobuf = "^3.3.0"


### PR DESCRIPTION
## What was changed

Cibuildwheel was using old manylinux image, just had to update cibuildwheel itself. This was tested for build binary while this PR was in draft mode.

## Checklist

1. Closes #577
