### PR TITLE
Updated lazy loaded logger_details

### DIFF
--- a/temporalio/activity.py
+++ b/temporalio/activity.py
@@ -459,7 +459,7 @@ class LoggerAdapter(logging.LoggerAdapter):
                 if self.activity_info_on_extra:
                     # Extra can be absent or None, this handles both
                     extra = kwargs.get("extra", None) or {}
-                    extra["temporal_activity"] = context._logger_details
+                    extra["temporal_activity"] = context.logger_details
                     kwargs["extra"] = extra
                 if self.full_activity_info_on_extra:
                     # Extra can be absent or None, this handles both


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This PR updates the lazy loading behavior for activity `_logger_details` so that activity details will be included in logging outputs even if not preloaded by adding to message.

Solution identified/proposed by @cretz  in this Issue: https://github.com/temporalio/sdk-python/issues/592

## Why?
<!-- Tell your future self why have you made these changes -->
Desire to allow activity logs to include extra information without adding them to the message string.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here --> 592

2. How was this tested:  Manually running logs
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed? No
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
