### PR TITLE
Unfinished handlers: add rule and test CAN, dynamic, and late-registered handlers

### DIFF
--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -2778,7 +2778,7 @@ def _make_unfinished_update_handler_message(
     handler_executions: List[HandlerExecution],
 ) -> str:
     message = """
-Workflow finished while update handlers are still running. This may have interrupted work that the
+[TMPRL1102] Workflow finished while update handlers are still running. This may have interrupted work that the
 update handler was doing, and the client that sent the update will receive a 'workflow execution
 already completed' RPCError instead of the update result. You can wait for all update and signal
 handlers to complete by using `await workflow.wait_condition(lambda:
@@ -2797,7 +2797,7 @@ def _make_unfinished_signal_handler_message(
     handler_executions: List[HandlerExecution],
 ) -> str:
     message = """
-Workflow finished while signal handlers are still running. This may have interrupted work that the
+[TMPRL1102] Workflow finished while signal handlers are still running. This may have interrupted work that the
 signal handler was doing. You can wait for all update and signal handlers to complete by using
 `await workflow.wait_condition(lambda: workflow.all_handlers_finished())`. Alternatively, if both
 you and the clients sending the signal are okay with interrupting running handlers when the workflow

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -2801,8 +2801,8 @@ def _make_unfinished_signal_handler_message(
 signal handler was doing. You can wait for all update and signal handlers to complete by using
 `await workflow.wait_condition(lambda: workflow.all_handlers_finished())`. Alternatively, if both
 you and the clients sending the signal are okay with interrupting running handlers when the workflow
-finishes, and causing clients to receive errors, then you can disable this warning via the signal
-handler decorator: `@workflow.signal(unfinished_policy=workflow.HandlerUnfinishedPolicy.ABANDON)`.
+finishes, then you can disable this warning via the signal handler decorator:
+`@workflow.signal(unfinished_policy=workflow.HandlerUnfinishedPolicy.ABANDON)`.
 """.replace("\n", " ").strip()
     names = collections.Counter(ex.name for ex in handler_executions)
     return (

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -5343,7 +5343,7 @@ class _UnfinishedHandlersWarningsTest:
         for event in reversed(resp.history.events):
             if event.event_type == EventType.EVENT_TYPE_WORKFLOW_TASK_FAILED:
                 assert event.workflow_task_failed_event_attributes.failure.message.startswith(
-                    f"Workflow finished while {self.handler_type} handlers are still running"
+                    f"[TMPRL1102] Workflow finished while {self.handler_type} handlers are still running"
                 )
                 return True
         return False


### PR DESCRIPTION
Closes https://github.com/temporalio/sdk-python/issues/584

- Add the `[TMPR1102]` rule tag to the warning messages
- Add tests confirming that the `all_handlers_finished` and warnings logic work for continue-as-new, dynamic handlers, and late-registered handlers.
- Refactor all tests as a `pytest.mark.parametrize` Cartesian product
