### PR TITLE
Fix exception-swallowing code path

### DIFF
--- a/temporalio/client.py
+++ b/temporalio/client.py
@@ -5089,8 +5089,7 @@ class _ClientImpl(OutboundInterceptor):
                     raise temporalio.exceptions.WorkflowAlreadyStartedError(
                         input.id, input.workflow, run_id=details.run_id
                     )
-            else:
-                raise
+            raise
         handle: WorkflowHandle[Any, Any] = WorkflowHandle(
             self._client,
             req.workflow_id,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -321,11 +321,8 @@ async def test_rpc_already_exists_error_is_raised(client: Client):
         ) -> temporalio.api.workflowservice.v1.StartWorkflowExecutionResponse:
             raise self.already_exists_err
 
-    workflow_service: temporalio.service.WorkflowService = (
-        client._impl._client.workflow_service  # type: ignore
-    )
     with mock.patch.object(
-        workflow_service, "start_workflow_execution", start_workflow_execution()
+        client.workflow_service, "start_workflow_execution", start_workflow_execution()
     ):
         with pytest.raises(RPCError) as err:
             await client.start_workflow("fake", id="fake", task_queue="fake")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,7 @@ import json
 import os
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Any, List, Optional, Tuple, cast
+from typing import Any, List, Mapping, Optional, Tuple, cast
 from unittest import mock
 
 import google.protobuf.any_pb2
@@ -311,7 +311,14 @@ async def test_rpc_already_exists_error_is_raised(client: Client):
         def __init__(self) -> None:
             pass
 
-        async def __call__(self, *args, **kwargs) -> google.protobuf.message.Message:
+        async def __call__(
+            self,
+            req: temporalio.api.workflowservice.v1.StartWorkflowExecutionRequest,
+            *,
+            retry: bool = False,
+            metadata: Mapping[str, str] = {},
+            timeout: Optional[timedelta] = None,
+        ) -> temporalio.api.workflowservice.v1.StartWorkflowExecutionResponse:
             raise self.already_exists_err
 
     workflow_service: temporalio.service.WorkflowService = (

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,11 +4,17 @@ import os
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, List, Optional, Tuple, cast
+from unittest import mock
 
+import google.protobuf.any_pb2
+import google.protobuf.message
 import pytest
 from google.protobuf import json_format
 
+import temporalio.api.common.v1
 import temporalio.api.enums.v1
+import temporalio.api.errordetails.v1
+import temporalio.api.workflowservice.v1
 import temporalio.common
 import temporalio.exceptions
 from temporalio import workflow
@@ -80,6 +86,7 @@ from temporalio.common import (
 )
 from temporalio.converter import DataConverter
 from temporalio.exceptions import WorkflowAlreadyStartedError
+from temporalio.service import ServiceCall
 from temporalio.testing import WorkflowEnvironment
 from tests.helpers import (
     assert_eq_eventually,
@@ -281,6 +288,41 @@ async def test_terminate(client: Client, worker: ExternalWorker):
     assert isinstance(err.value.cause, temporalio.exceptions.TerminatedError)
     assert str(err.value.cause) == "some reason"
     assert list(err.value.cause.details) == ["arg1", "arg2"]
+
+
+async def test_rpc_already_exists_error_is_raised(client: Client):
+    class start_workflow_execution(
+        ServiceCall[
+            temporalio.api.workflowservice.v1.StartWorkflowExecutionRequest,
+            temporalio.api.workflowservice.v1.StartWorkflowExecutionResponse,
+        ]
+    ):
+        already_exists_err = RPCError(
+            "fake already exists error", RPCStatusCode.ALREADY_EXISTS, b""
+        )
+        already_exists_err._grpc_status = temporalio.api.common.v1.GrpcStatus(
+            details=[
+                google.protobuf.any_pb2.Any(
+                    type_url="not-WorkflowExecutionAlreadyStartedFailure", value=b""
+                )
+            ],
+        )
+
+        def __init__(self) -> None:
+            pass
+
+        async def __call__(self, *args, **kwargs) -> google.protobuf.message.Message:
+            raise self.already_exists_err
+
+    workflow_service: temporalio.service.WorkflowService = (
+        client._impl._client.workflow_service  # type: ignore
+    )
+    with mock.patch.object(
+        workflow_service, "start_workflow_execution", start_workflow_execution()
+    ):
+        with pytest.raises(RPCError) as err:
+            await client.start_workflow("fake", id="fake", task_queue="fake")
+    assert err.value.status == RPCStatusCode.ALREADY_EXISTS
 
 
 async def test_cancel_not_found(client: Client):


### PR DESCRIPTION
Fixes #624

This is a bug identified by pyright type checking.

### How this was tested

- PR includes two commits: a test that fails on `main` before the fix, and the fix.

I also confirmed manually that if the server responds with gRPC error `ALREADY_EXISTS`, but the error details do not satisfy the logic in the SDK code, then the user gets

```
UnboundLocalError: cannot access local variable 'resp' where it is not associated with a value
```

What they should get is `temporalio.service.RPCError`.