### PR TITLE
Fix logic bug in create_schedule() re. backfills

### DIFF
--- a/temporalio/client.py
+++ b/temporalio/client.py
@@ -5502,9 +5502,12 @@ class _ClientImpl(OutboundInterceptor):
                     overlap_policy=temporalio.api.enums.v1.ScheduleOverlapPolicy.ValueType(
                         input.schedule.policy.overlap
                     ),
-                ) if input.trigger_immediately else None,
+                )
+                if input.trigger_immediately
+                else None,
                 backfill_request=[b._to_proto() for b in input.backfill]
-                    if input.backfill else None,
+                if input.backfill
+                else None,
             )
         try:
             request = temporalio.api.workflowservice.v1.CreateScheduleRequest(

--- a/temporalio/client.py
+++ b/temporalio/client.py
@@ -5502,8 +5502,9 @@ class _ClientImpl(OutboundInterceptor):
                     overlap_policy=temporalio.api.enums.v1.ScheduleOverlapPolicy.ValueType(
                         input.schedule.policy.overlap
                     ),
-                ),
-                backfill_request=[b._to_proto() for b in input.backfill],
+                ) if input.trigger_immediately else None,
+                backfill_request=[b._to_proto() for b in input.backfill]
+                    if input.backfill else None,
             )
         try:
             request = temporalio.api.workflowservice.v1.CreateScheduleRequest(


### PR DESCRIPTION
Don't ask for immediate trigger when a backfill is requested, and don't ask for a backfill when an immediate trigger is requested.

Closes #678.