### PR TITLE
fix(converter): handle serialization of recursive exceptions

### DIFF
--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -800,7 +800,8 @@ class DefaultFailureConverter(FailureConverter):
                 str(exception), type=exception.__class__.__name__
             )
             failure_error.__traceback__ = exception.__traceback__
-            failure_error.__cause__ = exception.__cause__
+            if exception.__cause__ and exception.__cause__ != exception:
+                failure_error.__cause__ = exception.__cause__
             self._error_to_failure(failure_error, payload_converter, failure)
         # Encode common attributes if requested
         if self._encode_common_attributes:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -490,6 +490,20 @@ class SimpleCodec(PayloadCodec):
         return list(wrapper.payloads)
 
 
+async def test_broken_exception_serialization():
+    conv = DataConverter(
+        payload_codec=SimpleCodec(),
+    )
+    try:
+        try:
+            raise ValueError("test")
+        except Exception as e:
+            raise e from e
+    except Exception as e:
+        failure = Failure()
+        conv.failure_converter.to_failure(e, conv.payload_converter, failure)
+
+
 async def test_failure_encoded_attributes():
     try:
         raise ApplicationError("some message", "some detail")


### PR DESCRIPTION
Handle edge case of recursive exceptions in failure converter.

Why?

It is kind of an easy mistake to do in python:

```
try:
    raise ValueError("test")
except Exception as e:
    raise e from e
```

The re-raised exception will have `e.__cause__` referencing itself resulting in failure to serialize error and python sdk won't report anything resulting in retries and startToClose timeouts.

