### PR TITLE
Update-with-start

### DIFF
--- a/temporalio/worker/_workflow.py
+++ b/temporalio/worker/_workflow.py
@@ -442,7 +442,7 @@ class _DeadlockError(Exception):
     """Exception class for deadlocks. Contains functionality to swap the default traceback for another."""
 
     def __init__(self, message: str, replacement_tb: Optional[TracebackType] = None):
-        """Create a new DeadlockError, with message `msg` and optionally a traceback `tb` to be swapped in later.
+        """Create a new DeadlockError, with message `message` and optionally a traceback `replacement_tb` to be swapped in later.
 
         Args:
             message: Message to be presented through exception.

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -1190,7 +1190,7 @@ async def wait_condition(
         fn: Non-async callback that accepts no parameters and returns a boolean.
         timeout: Optional number of seconds to wait until throwing
             :py:class:`asyncio.TimeoutError`.
-        timeout_summary: Optional simple string identifying the timer (created if `timeout` is
+        timeout_summary: Optional simple string identifying the timer (created if ``timeout`` is
             present) that may be visible in UI/CLI. While it can be normal text, it is best to treat
             as a timer ID.
     """
@@ -1313,7 +1313,7 @@ class LoggerAdapter(logging.LoggerAdapter):
 
     Values added to ``extra`` are merged with the ``extra`` dictionary from a
     logging call, with values from the logging call taking precedence. I.e. the
-    behavior is that of `merge_extra=True` in Python >= 3.13.
+    behavior is that of ``merge_extra=True`` in Python >= 3.13.
     """
 
     def __init__(
@@ -1425,6 +1425,20 @@ class _Definition:
         raise ValueError(
             f"Function {fn_name} missing attributes, was it decorated with @workflow.run and was its class decorated with @workflow.defn?"
         )
+
+    @classmethod
+    def get_name_and_result_type(
+        cls, name_or_run_fn: Union[str, Callable[..., Awaitable[Any]]]
+    ) -> Tuple[str, Optional[Type]]:
+        if isinstance(name_or_run_fn, str):
+            return name_or_run_fn, None
+        elif callable(name_or_run_fn):
+            defn = cls.must_from_run_fn(name_or_run_fn)
+            if not defn.name:
+                raise ValueError("Cannot invoke dynamic workflow explicitly")
+            return defn.name, defn.ret_type
+        else:
+            raise TypeError("Workflow must be a string or callable")
 
     @staticmethod
     def _apply_to_class(
@@ -3940,7 +3954,7 @@ async def start_child_workflow(
         static_details: General fixed details for this child workflow execution that may appear in
             UI/CLI. This can be in Temporal markdown format and can span multiple lines. This is
             a fixed value on the workflow that cannot be updated. For details that can be
-            updated, use `Workflow.CurrentDetails` within the workflow.
+            updated, use :py:meth:`Workflow.get_current_details` within the workflow.
 
     Returns:
         A workflow handle to the started/existing workflow.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,9 +47,10 @@ if sys.version_info < (3, 8) and sys.platform.startswith("darwin"):
 
 def pytest_addoption(parser):
     parser.addoption(
+        "-E",
         "--workflow-environment",
         default="local",
-        help="Which workflow environment to use ('local', 'time-skipping', or target to existing server)",
+        help="Which workflow environment to use ('local', 'time-skipping', or ip:port for existing server)",
     )
 
 
@@ -83,6 +84,8 @@ async def env(env_type: str) -> AsyncGenerator[WorkflowEnvironment, None]:
                 f"limit.historyCount.suggestContinueAsNew={CONTINUE_AS_NEW_SUGGEST_HISTORY_COUNT}",
                 "--dynamic-config-value",
                 "system.enableEagerWorkflowStart=true",
+                "--dynamic-config-value",
+                "frontend.enableExecuteMultiOperation=true",
             ]
         )
     elif env_type == "time-skipping":

--- a/tests/worker/test_update_with_start.py
+++ b/tests/worker/test_update_with_start.py
@@ -1,0 +1,517 @@
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from datetime import timedelta
+from enum import Enum
+from typing import Any, Iterator
+from unittest.mock import patch
+
+import pytest
+
+from temporalio import activity, workflow
+from temporalio.client import (
+    Client,
+    Interceptor,
+    OutboundInterceptor,
+    StartWorkflowUpdateWithStartInput,
+    WithStartWorkflowOperation,
+    WorkflowUpdateFailedError,
+    WorkflowUpdateHandle,
+    WorkflowUpdateStage,
+)
+from temporalio.common import (
+    WorkflowIDConflictPolicy,
+)
+from temporalio.exceptions import ApplicationError, WorkflowAlreadyStartedError
+from temporalio.testing import WorkflowEnvironment
+from tests.helpers import (
+    new_worker,
+)
+
+
+@activity.defn
+async def activity_called_by_update() -> None:
+    pass
+
+
+@workflow.defn
+class WorkflowForUpdateWithStartTest:
+    def __init__(self) -> None:
+        self.update_finished = False
+        self.update_may_exit = False
+        self.received_done_signal = False
+
+    @workflow.run
+    async def run(self, i: int) -> str:
+        await workflow.wait_condition(lambda: self.received_done_signal)
+        return f"workflow-result-{i}"
+
+    @workflow.update
+    def my_non_blocking_update(self, s: str) -> str:
+        if s == "fail-after-acceptance":
+            raise ApplicationError("Workflow deliberate failed update")
+        return f"update-result-{s}"
+
+    @workflow.update
+    async def my_blocking_update(self, s: str) -> str:
+        if s == "fail-after-acceptance":
+            raise ApplicationError("Workflow deliberate failed update")
+        await workflow.execute_activity(
+            activity_called_by_update, start_to_close_timeout=timedelta(seconds=10)
+        )
+        return f"update-result-{s}"
+
+    @workflow.signal
+    async def done(self):
+        self.received_done_signal = True
+
+
+class ExpectErrorWhenWorkflowExists(Enum):
+    YES = "yes"
+    NO = "no"
+
+
+class UpdateHandlerType(Enum):
+    NON_BLOCKING = "non-blocking"
+    BLOCKING = "blocking"
+
+
+class TestUpdateWithStart:
+    client: Client
+    workflow_id: str
+    task_queue: str
+    update_id = "test-uws-up-id"
+
+    @pytest.mark.parametrize(
+        "wait_for_stage",
+        [WorkflowUpdateStage.ACCEPTED, WorkflowUpdateStage.COMPLETED],
+    )
+    async def test_non_blocking_update_with_must_create_workflow_semantics(
+        self,
+        client: Client,
+        env: WorkflowEnvironment,
+        wait_for_stage: WorkflowUpdateStage,
+    ):
+        if env.supports_time_skipping:
+            pytest.skip(
+                "TODO: make update_with_start_tests pass under Java test server"
+            )
+        await self._do_test(
+            client,
+            f"test-uws-nb-mc-wf-id-{wait_for_stage.name}",
+            UpdateHandlerType.NON_BLOCKING,
+            wait_for_stage,
+            WorkflowIDConflictPolicy.FAIL,
+            ExpectErrorWhenWorkflowExists.YES,
+        )
+
+    @pytest.mark.parametrize(
+        "wait_for_stage",
+        [WorkflowUpdateStage.ACCEPTED, WorkflowUpdateStage.COMPLETED],
+    )
+    async def test_non_blocking_update_with_get_or_create_workflow_semantics(
+        self,
+        client: Client,
+        env: WorkflowEnvironment,
+        wait_for_stage: WorkflowUpdateStage,
+    ):
+        if env.supports_time_skipping:
+            pytest.skip(
+                "TODO: make update_with_start_tests pass under Java test server"
+            )
+        await self._do_test(
+            client,
+            f"test-uws-nb-goc-wf-id-{wait_for_stage.name}",
+            UpdateHandlerType.NON_BLOCKING,
+            wait_for_stage,
+            WorkflowIDConflictPolicy.USE_EXISTING,
+            ExpectErrorWhenWorkflowExists.NO,
+        )
+
+    @pytest.mark.parametrize(
+        "wait_for_stage",
+        [WorkflowUpdateStage.ACCEPTED, WorkflowUpdateStage.COMPLETED],
+    )
+    async def test_blocking_update_with_get_or_create_workflow_semantics(
+        self,
+        client: Client,
+        env: WorkflowEnvironment,
+        wait_for_stage: WorkflowUpdateStage,
+    ):
+        if env.supports_time_skipping:
+            pytest.skip(
+                "TODO: make update_with_start_tests pass under Java test server"
+            )
+        await self._do_test(
+            client,
+            f"test-uws-b-goc-wf-id-{wait_for_stage.name}",
+            UpdateHandlerType.BLOCKING,
+            wait_for_stage,
+            WorkflowIDConflictPolicy.USE_EXISTING,
+            ExpectErrorWhenWorkflowExists.NO,
+        )
+
+    async def _do_test(
+        self,
+        client: Client,
+        workflow_id: str,
+        update_handler_type: UpdateHandlerType,
+        wait_for_stage: WorkflowUpdateStage,
+        id_conflict_policy: WorkflowIDConflictPolicy,
+        expect_error_when_workflow_exists: ExpectErrorWhenWorkflowExists,
+    ):
+        await self._do_execute_update_test(
+            client,
+            workflow_id + "-execute-update",
+            update_handler_type,
+            id_conflict_policy,
+            expect_error_when_workflow_exists,
+        )
+        await self._do_start_update_test(
+            client,
+            workflow_id + "-start-update",
+            update_handler_type,
+            wait_for_stage,
+            id_conflict_policy,
+        )
+
+    async def _do_execute_update_test(
+        self,
+        client: Client,
+        workflow_id: str,
+        update_handler_type: UpdateHandlerType,
+        id_conflict_policy: WorkflowIDConflictPolicy,
+        expect_error_when_workflow_exists: ExpectErrorWhenWorkflowExists,
+    ):
+        update_handler = (
+            WorkflowForUpdateWithStartTest.my_blocking_update
+            if update_handler_type == UpdateHandlerType.BLOCKING
+            else WorkflowForUpdateWithStartTest.my_non_blocking_update
+        )
+        async with new_worker(
+            client,
+            WorkflowForUpdateWithStartTest,
+            activities=[activity_called_by_update],
+        ) as worker:
+            self.client = client
+            self.workflow_id = workflow_id
+            self.task_queue = worker.task_queue
+
+            start_op_1 = WithStartWorkflowOperation(
+                WorkflowForUpdateWithStartTest.run,
+                1,
+                id=self.workflow_id,
+                task_queue=self.task_queue,
+                id_conflict_policy=id_conflict_policy,
+            )
+
+            # First UWS succeeds
+            assert (
+                await client.execute_update_with_start_workflow(
+                    update_handler, "1", start_workflow_operation=start_op_1
+                )
+                == "update-result-1"
+            )
+            assert (
+                await start_op_1.workflow_handle()
+            ).first_execution_run_id is not None
+
+            # Whether a repeat UWS succeeds depends on the workflow ID conflict policy
+            start_op_2 = WithStartWorkflowOperation(
+                WorkflowForUpdateWithStartTest.run,
+                2,
+                id=self.workflow_id,
+                task_queue=self.task_queue,
+                id_conflict_policy=id_conflict_policy,
+            )
+
+            if expect_error_when_workflow_exists == ExpectErrorWhenWorkflowExists.NO:
+                assert (
+                    await client.execute_update_with_start_workflow(
+                        update_handler, "21", start_workflow_operation=start_op_2
+                    )
+                    == "update-result-21"
+                )
+                assert (
+                    await start_op_2.workflow_handle()
+                ).first_execution_run_id is not None
+            else:
+                for aw in [
+                    client.execute_update_with_start_workflow(
+                        update_handler, "21", start_workflow_operation=start_op_2
+                    ),
+                    start_op_2.workflow_handle(),
+                ]:
+                    with pytest.raises(WorkflowAlreadyStartedError):
+                        await aw
+
+                assert (
+                    await start_op_1.workflow_handle()
+                ).first_execution_run_id is not None
+
+            # The workflow is still running; finish it.
+
+            wf_handle_1 = await start_op_1.workflow_handle()
+            await wf_handle_1.signal(WorkflowForUpdateWithStartTest.done)
+            assert await wf_handle_1.result() == "workflow-result-1"
+
+    async def _do_start_update_test(
+        self,
+        client: Client,
+        workflow_id: str,
+        update_handler_type: UpdateHandlerType,
+        wait_for_stage: WorkflowUpdateStage,
+        id_conflict_policy: WorkflowIDConflictPolicy,
+    ):
+        update_handler = (
+            WorkflowForUpdateWithStartTest.my_blocking_update
+            if update_handler_type == UpdateHandlerType.BLOCKING
+            else WorkflowForUpdateWithStartTest.my_non_blocking_update
+        )
+        async with new_worker(
+            client,
+            WorkflowForUpdateWithStartTest,
+            activities=[activity_called_by_update],
+        ) as worker:
+            self.client = client
+            self.workflow_id = workflow_id
+            self.task_queue = worker.task_queue
+
+            start_op = WithStartWorkflowOperation(
+                WorkflowForUpdateWithStartTest.run,
+                1,
+                id=self.workflow_id,
+                task_queue=self.task_queue,
+                id_conflict_policy=id_conflict_policy,
+            )
+
+            update_handle = await client.start_update_with_start_workflow(
+                update_handler,
+                "1",
+                wait_for_stage=wait_for_stage,
+                start_workflow_operation=start_op,
+            )
+            assert await update_handle.result() == "update-result-1"
+
+    @contextmanager
+    def assert_network_call(
+        self,
+        expect_network_call: bool,
+    ) -> Iterator[None]:
+        with patch.object(
+            self.client.workflow_service,
+            "poll_workflow_execution_update",
+            wraps=self.client.workflow_service.poll_workflow_execution_update,
+        ) as _wrapped_poll:
+            yield
+            assert _wrapped_poll.called == expect_network_call
+
+
+async def test_update_with_start_sets_first_execution_run_id(
+    client: Client, env: WorkflowEnvironment
+):
+    if env.supports_time_skipping:
+        pytest.skip("TODO: make update_with_start_tests pass under Java test server")
+    async with new_worker(
+        client,
+        WorkflowForUpdateWithStartTest,
+        activities=[activity_called_by_update],
+    ) as worker:
+
+        def make_start_op(workflow_id: str):
+            return WithStartWorkflowOperation(
+                WorkflowForUpdateWithStartTest.run,
+                0,
+                id=workflow_id,
+                id_conflict_policy=WorkflowIDConflictPolicy.FAIL,
+                task_queue=worker.task_queue,
+            )
+
+        # conflict policy is FAIL
+        # First UWS succeeds and sets the first execution run ID
+        start_op_1 = make_start_op("wid-1")
+        update_handle_1 = await client.start_update_with_start_workflow(
+            WorkflowForUpdateWithStartTest.my_non_blocking_update,
+            "1",
+            wait_for_stage=WorkflowUpdateStage.COMPLETED,
+            start_workflow_operation=start_op_1,
+        )
+        assert (await start_op_1.workflow_handle()).first_execution_run_id is not None
+        assert await update_handle_1.result() == "update-result-1"
+
+        # Second UWS start fails because the workflow already exists
+        # first execution run ID is not set on the second UWS handle
+        start_op_2 = make_start_op("wid-1")
+
+        for aw in [
+            client.start_update_with_start_workflow(
+                WorkflowForUpdateWithStartTest.my_non_blocking_update,
+                "2",
+                wait_for_stage=WorkflowUpdateStage.COMPLETED,
+                start_workflow_operation=start_op_2,
+            ),
+            start_op_2.workflow_handle(),
+        ]:
+            with pytest.raises(WorkflowAlreadyStartedError):
+                await aw
+
+        # Third UWS start succeeds, but the update fails after acceptance
+        start_op_3 = make_start_op("wid-2")
+        update_handle_3 = await client.start_update_with_start_workflow(
+            WorkflowForUpdateWithStartTest.my_non_blocking_update,
+            "fail-after-acceptance",
+            wait_for_stage=WorkflowUpdateStage.COMPLETED,
+            start_workflow_operation=start_op_3,
+        )
+        assert (await start_op_3.workflow_handle()).first_execution_run_id is not None
+        with pytest.raises(WorkflowUpdateFailedError):
+            await update_handle_3.result()
+
+        # Despite the update failure, the first execution run ID is set on the with_start_request,
+        # and the handle can be used to obtain the workflow result.
+        assert (await start_op_3.workflow_handle()).first_execution_run_id is not None
+        wf_handle_3 = await start_op_3.workflow_handle()
+        await wf_handle_3.signal(WorkflowForUpdateWithStartTest.done)
+        assert await wf_handle_3.result() == "workflow-result-0"
+
+        # Fourth UWS is same as third, but we use execute_update instead of start_update.
+        start_op_4 = make_start_op("wid-3")
+        with pytest.raises(WorkflowUpdateFailedError):
+            await client.execute_update_with_start_workflow(
+                WorkflowForUpdateWithStartTest.my_non_blocking_update,
+                "fail-after-acceptance",
+                start_workflow_operation=start_op_4,
+            )
+        assert (await start_op_4.workflow_handle()).first_execution_run_id is not None
+
+
+async def test_update_with_start_failure_start_workflow_error(
+    client: Client, env: WorkflowEnvironment
+):
+    """
+    When the workflow start fails, the update_with_start_call should raise the appropriate
+    gRPC error, and the start_workflow_operation promise should be rejected with the same
+    error.
+    """
+    if env.supports_time_skipping:
+        pytest.skip("TODO: make update_with_start_tests pass under Java test server")
+    async with new_worker(
+        client,
+        WorkflowForUpdateWithStartTest,
+    ) as worker:
+
+        def make_start_op(workflow_id: str):
+            return WithStartWorkflowOperation(
+                WorkflowForUpdateWithStartTest.run,
+                0,
+                id=workflow_id,
+                id_conflict_policy=WorkflowIDConflictPolicy.FAIL,
+                task_queue=worker.task_queue,
+            )
+
+        wid = f"wf-{uuid.uuid4()}"
+        start_op_1 = make_start_op(wid)
+        await client.start_update_with_start_workflow(
+            WorkflowForUpdateWithStartTest.my_non_blocking_update,
+            "1",
+            wait_for_stage=WorkflowUpdateStage.COMPLETED,
+            start_workflow_operation=start_op_1,
+        )
+
+        start_op_2 = make_start_op(wid)
+
+        for aw in [
+            client.start_update_with_start_workflow(
+                WorkflowForUpdateWithStartTest.my_non_blocking_update,
+                "2",
+                wait_for_stage=WorkflowUpdateStage.COMPLETED,
+                start_workflow_operation=start_op_2,
+            ),
+            start_op_2.workflow_handle(),
+        ]:
+            with pytest.raises(WorkflowAlreadyStartedError):
+                await aw
+
+
+class SimpleClientInterceptor(Interceptor):
+    def intercept_client(self, next: OutboundInterceptor) -> OutboundInterceptor:
+        return SimpleClientOutboundInterceptor(super().intercept_client(next))
+
+
+class SimpleClientOutboundInterceptor(OutboundInterceptor):
+    def __init__(self, next: OutboundInterceptor) -> None:
+        super().__init__(next)
+
+    async def start_update_with_start_workflow(
+        self, input: StartWorkflowUpdateWithStartInput
+    ) -> WorkflowUpdateHandle[Any]:
+        input.start_workflow_input.args = ["intercepted-workflow-arg"]
+        input.update_workflow_input.args = ["intercepted-update-arg"]
+        return await super().start_update_with_start_workflow(input)
+
+
+@workflow.defn
+class UpdateWithStartInterceptorWorkflow:
+    def __init__(self) -> None:
+        self.received_update = False
+
+    @workflow.run
+    async def run(self, arg: str) -> str:
+        await workflow.wait_condition(lambda: self.received_update)
+        return arg
+
+    @workflow.update
+    async def my_update(self, arg: str) -> str:
+        self.received_update = True
+        await workflow.wait_condition(lambda: self.received_update)
+        return arg
+
+
+async def test_update_with_start_client_outbound_interceptor(
+    client: Client, env: WorkflowEnvironment
+):
+    if env.supports_time_skipping:
+        pytest.skip("TODO: make update_with_start_tests pass under Java test server")
+    interceptor = SimpleClientInterceptor()
+    client = Client(**{**client.config(), "interceptors": [interceptor]})  # type: ignore
+
+    async with new_worker(
+        client,
+        UpdateWithStartInterceptorWorkflow,
+    ) as worker:
+        start_op = WithStartWorkflowOperation(
+            UpdateWithStartInterceptorWorkflow.run,
+            "original-workflow-arg",
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=worker.task_queue,
+            id_conflict_policy=WorkflowIDConflictPolicy.FAIL,
+        )
+        update_result = await client.execute_update_with_start_workflow(
+            UpdateWithStartInterceptorWorkflow.my_update,
+            "original-update-arg",
+            start_workflow_operation=start_op,
+        )
+        assert update_result == "intercepted-update-arg"
+
+        wf_handle = await start_op.workflow_handle()
+        assert await wf_handle.result() == "intercepted-workflow-arg"
+
+
+def test_with_start_workflow_operation_requires_conflict_policy():
+    with pytest.raises(ValueError):
+        WithStartWorkflowOperation(
+            WorkflowForUpdateWithStartTest.run,
+            0,
+            id="wid-1",
+            id_conflict_policy=WorkflowIDConflictPolicy.UNSPECIFIED,
+            task_queue="test-queue",
+        )
+
+    with pytest.raises(TypeError):
+        WithStartWorkflowOperation(  # type: ignore
+            WorkflowForUpdateWithStartTest.run,
+            0,
+            id="wid-1",
+            task_queue="test-queue",
+        )


### PR DESCRIPTION
Add an update-with-start API, using the MultiOperation gRPC API.

The test suite is not complete yet, but please feel free to review.

In addition to the tests, an example of using the new API is https://github.com/temporalio/samples-python/pull/156:

```python
    cart_id = f"cart-{session_id}"
    start_op = WithStartWorkflowOperation(
        ShoppingCartWorkflow.run,
        id=cart_id,
        id_conflict_policy=common.WorkflowIDConflictPolicy.USE_EXISTING,
        task_queue="uws",
    )
    try:
        price = Decimal(
            await temporal_client.execute_update_with_start(
                ShoppingCartWorkflow.add_item,
                ShoppingCartItem(sku=item_id, quantity=quantity),
                start_workflow_operation=start_op,
            )
        )
    except WorkflowUpdateFailedError:
        price = None

    return price, await start_op.workflow_handle()
```


From the docstring:

```
        A WorkflowIDConflictPolicy must be set in the start_workflow_operation. If the
        specified workflow execution is not running, a new workflow execution is started
        and the update is sent in the first workflow task. Alternatively if the specified
        workflow execution is running then, if the WorkflowIDConflictPolicy is
        USE_EXISTING, the update is issued against the specified workflow, and if the
        WorkflowIDConflictPolicy is FAIL, an error is returned. This call will block until
        the update has completed, and return the update result. Note that this means that
        the call will not return successfully until the update has been delivered to a
        worker.
```