### PR TITLE
Fix uws client-side result types

### DIFF
--- a/temporalio/client.py
+++ b/temporalio/client.py
@@ -1105,7 +1105,7 @@ class Client:
                     start_workflow_operation._start_workflow_input.id,
                     first_execution_run_id=start_response.run_id,
                     result_run_id=start_response.run_id,
-                    result_type=result_type,
+                    result_type=start_workflow_operation._start_workflow_input.ret_type,
                 )
             )
 

--- a/temporalio/client.py
+++ b/temporalio/client.py
@@ -6183,6 +6183,7 @@ class _ClientImpl(OutboundInterceptor):
             workflow_id=start_input.id,
             workflow_run_id=start_response.run_id,
             known_outcome=known_outcome,
+            result_type=update_input.ret_type,
         )
         if update_input.wait_for_stage == WorkflowUpdateStage.COMPLETED:
             await handle._poll_until_outcome()

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -53,6 +53,7 @@ import temporalio.bridge.proto.workflow_commands
 import temporalio.common
 import temporalio.converter
 import temporalio.exceptions
+import temporalio.workflow
 
 from .types import (
     AnyType,
@@ -1782,6 +1783,20 @@ class _UpdateDefinition:
         if self.validator:
             raise RuntimeError(f"Validator already set for update {self.name}")
         object.__setattr__(self, "validator", validator)
+
+    @classmethod
+    def get_name_and_result_type(
+        cls,
+        name_or_update_fn: Union[str, Callable[..., Any]],
+    ) -> Tuple[str, Optional[Type]]:
+        if isinstance(name_or_update_fn, temporalio.workflow.UpdateMethodMultiParam):
+            defn = name_or_update_fn._defn
+            if not defn.name:
+                raise RuntimeError("Cannot invoke dynamic update definition")
+            # TODO(cretz): Check count/type of args at runtime?
+            return defn.name, defn.ret_type
+        else:
+            return str(name_or_update_fn), None
 
 
 # See https://mypy.readthedocs.io/en/latest/runtime_troubles.html#using-classes-that-are-generic-in-stubs-but-not-at-runtime

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -6439,26 +6439,3 @@ async def test_concurrent_sleeps_use_proper_options(
 
         # Force replay with a query to ensure determinism
         await handle.query("__temporal_workflow_metadata")
-
-
-@dataclass
-class MyDataClass2:
-    a: int
-    b: str
-
-
-@workflow.defn
-class WorkflowCanReturnDataClass:
-    @workflow.run
-    async def run(self) -> MyDataClass2:
-        return MyDataClass2(a=1, b="hello")
-
-
-async def test_workflow_can_return_dataclass(client: Client):
-    async with new_worker(client, WorkflowCanReturnDataClass) as worker:
-        handle = await client.start_workflow(
-            WorkflowCanReturnDataClass.run,
-            id=f"workflow-{uuid.uuid4()}",
-            task_queue=worker.task_queue,
-        )
-        assert await handle.result() == MyDataClass2(a=1, b="hello")


### PR DESCRIPTION
Bug fix: Under Update-with-start, neither update nor workflow client-side results were honoring the result type passed by the user or obtained from type annotations. This meant that dataclasses were being returned as dicts.