### PR TITLE
Run-time check for update validator signature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ bridge-lint = { cmd = "cargo clippy -- -D warnings", cwd = "temporalio/bridge" }
 lint-docs = "pydocstyle --ignore-decorators=overload"
 lint-types = "mypy --namespace-packages --check-untyped-defs ."
 run-bench = "python scripts/run_bench.py"
-test = "pytest tests/worker/test_workflow.py::test_unfinished_handler_on_workflow_termination"
+test = "pytest"
 
 # Install local, run single pytest with env var, uninstall local
 [tool.poe.tasks.test-dist-single]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ bridge-lint = { cmd = "cargo clippy -- -D warnings", cwd = "temporalio/bridge" }
 lint-docs = "pydocstyle --ignore-decorators=overload"
 lint-types = "mypy --namespace-packages --check-untyped-defs ."
 run-bench = "python scripts/run_bench.py"
-test = "pytest"
+test = "pytest tests/worker/test_workflow.py::test_unfinished_handler_on_workflow_termination"
 
 # Install local, run single pytest with env var, uninstall local
 [tool.poe.tasks.test-dist-single]

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -1512,6 +1512,13 @@ class _Definition:
                         f"Multiple update methods found for {defn_name} "
                         f"(at least on {name} and {updates[update_defn.name].fn.__name__})"
                     )
+                elif update_defn.validator and not _parameters_identical_up_to_naming(
+                    update_defn.fn, update_defn.validator
+                ):
+                    issues.append(
+                        f"Update validator method {update_defn.validator.__name__} parameters "
+                        f"do not match update method {update_defn.fn.__name__} parameters"
+                    )
                 else:
                     updates[update_defn.name] = update_defn
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -418,3 +418,26 @@ def test_workflow_init_not__init__():
     with pytest.raises(ValueError) as err:
         workflow.init(BadWorkflowInit.not__init__)
     assert "@workflow.init may only be used on the __init__ method" in str(err.value)
+
+
+class BadUpdateValidator:
+    @workflow.update
+    def my_update(self, a: str):
+        pass
+
+    @my_update.validator  # type: ignore
+    def my_validator(self, a: int):
+        pass
+
+    @workflow.run
+    async def run(self):
+        pass
+
+
+def test_workflow_update_validator_not_update():
+    with pytest.raises(ValueError) as err:
+        workflow.defn(BadUpdateValidator)
+    assert (
+        "Update validator method my_validator parameters do not match update method my_update parameters"
+        in str(err.value)
+    )


### PR DESCRIPTION
Fixes #689 

This PR causes the workflow decorator to raise an exception if the workflow definition contains an (update, validator) pair with inconsistent signatures. The exception will therefore be raised at import time when running a workflow worker. We re-use the same definition of "inconsistent signatures" that we use when comparing the `@workflow.run` and workflow `__init__` methods. We already had type-checking for this, but we lacked a run-time check; an exception would have been raised eventually, but at update validation time.