### PR TITLE
Expose http option for OTLP

### DIFF
--- a/temporalio/bridge/runtime.py
+++ b/temporalio/bridge/runtime.py
@@ -69,6 +69,7 @@ class OpenTelemetryConfig:
     metric_periodicity_millis: Optional[int]
     metric_temporality_delta: bool
     durations_as_seconds: bool
+    http: bool
 
 
 @dataclass(frozen=True)

--- a/temporalio/bridge/src/runtime.rs
+++ b/temporalio/bridge/src/runtime.rs
@@ -17,7 +17,7 @@ use temporal_sdk_core::{CoreRuntime, TokioRuntimeBuilder};
 use temporal_sdk_core_api::telemetry::metrics::{CoreMeter, MetricCallBufferer};
 use temporal_sdk_core_api::telemetry::{
     CoreLog, Logger, MetricTemporality, OtelCollectorOptionsBuilder,
-    PrometheusExporterOptionsBuilder, TelemetryOptionsBuilder,
+    PrometheusExporterOptionsBuilder, TelemetryOptionsBuilder, OtlpProtocol
 };
 use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
@@ -74,6 +74,7 @@ pub struct OpenTelemetryConfig {
     metric_periodicity_millis: Option<u64>,
     metric_temporality_delta: bool,
     durations_as_seconds: bool,
+    http: bool,
 }
 
 #[derive(FromPyObject)]
@@ -321,6 +322,9 @@ impl TryFrom<MetricsConfig> for Arc<dyn CoreMeter> {
             }
             if let Some(global_tags) = conf.global_tags {
                 build.global_tags(global_tags);
+            }
+            if otel_conf.http {
+                build.protocol(OtlpProtocol::Http);
             }
             let otel_options = build
                 .build()

--- a/temporalio/runtime.py
+++ b/temporalio/runtime.py
@@ -259,17 +259,22 @@ class OpenTelemetryConfig:
         OpenTelemetryMetricTemporality.CUMULATIVE
     )
     durations_as_seconds: bool = False
+    http: bool = False
 
     def _to_bridge_config(self) -> temporalio.bridge.runtime.OpenTelemetryConfig:
         return temporalio.bridge.runtime.OpenTelemetryConfig(
             url=self.url,
             headers=self.headers or {},
-            metric_periodicity_millis=None
-            if not self.metric_periodicity
-            else round(self.metric_periodicity.total_seconds() * 1000),
-            metric_temporality_delta=self.metric_temporality
-            == OpenTelemetryMetricTemporality.DELTA,
+            metric_periodicity_millis=(
+                None
+                if not self.metric_periodicity
+                else round(self.metric_periodicity.total_seconds() * 1000)
+            ),
+            metric_temporality_delta=(
+                self.metric_temporality == OpenTelemetryMetricTemporality.DELTA
+            ),
             durations_as_seconds=self.durations_as_seconds,
+            http=self.http,
         )
 
 


### PR DESCRIPTION
Tested using

```
docker run \
  -p 127.0.0.1:4317:4317 \
  -p 127.0.0.1:4318:4318 \
  -p 127.0.0.1:55679:55679 \
  otel/opentelemetry-collector-contrib:0.118.0
```

and running https://github.com/temporalio/samples-python/blob/main/open_telemetry/README.md

using

```
    Runtime(
        telemetry=TelemetryConfig(
            metrics=OpenTelemetryConfig(
                url="http://localhost:4318/v1/metrics", http=True
            )
        )
    )
```