### PR TITLE
Pydantic contrib module

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,10 +317,11 @@ The default data converter supports converting multiple types including:
 
 To use pydantic model instances, see [](#pydantic-support).
 
-`datetime.date`, `datetime.time`, and `datetime.datetime` can only be used as fields of Pydantic models.
+`datetime.date`, `datetime.time`, and `datetime.datetime` can only be used with the Pydantic data converter.
 
-Users are strongly encouraged to use a single `dataclass` or Pydantic model for parameter and return types, so that fields
-with defaults can be easily added without breaking compatibility.
+Although workflows, updates, signals, and queries can all be defined with multiple input parameters, users are strongly
+encouraged to use a single `dataclass` or Pydantic model parameter, so that fields with defaults can be easily added
+without breaking compatibility. Similar advice applies to return values.
 
 Classes with generics may not have the generics properly resolved. The current implementation does not have generic
 type resolution. Users should use concrete types.
@@ -335,10 +336,13 @@ from temporalio.contrib.pydantic import pydantic_data_converter
 client = Client(data_converter=pydantic_data_converter, ...)
 ```
 
+This data converter supports conversion of all types supported by Pydantic to and from JSON.
+
+In addition to Pydantic models, these include all `json.dump`-able types, various non-`json.dump`-able standard library
+types such as dataclasses, types from the datetime module, sets, UUID, etc, and custom types composed of any of these.
+
 Pydantic v1 is not supported by this data converter. If you are not yet able to upgrade from Pydantic v1, see
 https://github.com/temporalio/samples-python/tree/main/pydantic_converter/v1 for limited v1 support.
-
-Do not use pydantic's [strict mode](https://docs.pydantic.dev/latest/concepts/strict_mode/).
 
 
 ##### Custom Type Data Conversion

--- a/README.md
+++ b/README.md
@@ -297,10 +297,10 @@ other_ns_client = Client(**config)
 #### Data Conversion
 
 Data converters are used to convert raw Temporal payloads to/from actual Python types. A custom data converter of type
-`temporalio.converter.DataConverter` can be set via the `data_converter` client parameter. Data converters are a
-combination of payload converters, payload codecs, and failure converters. Payload converters convert Python values
-to/from serialized bytes. Payload codecs convert bytes to bytes (e.g. for compression or encryption). Failure converters
-convert exceptions to/from serialized failures.
+`temporalio.converter.DataConverter` can be set via the `data_converter` parameter of the `Client` constructor. Data
+converters are a combination of payload converters, payload codecs, and failure converters. Payload converters convert
+Python values to/from serialized bytes. Payload codecs convert bytes to bytes (e.g. for compression or encryption).
+Failure converters convert exceptions to/from serialized failures.
 
 The default data converter supports converting multiple types including:
 
@@ -314,21 +314,31 @@ The default data converter supports converting multiple types including:
   * [IntEnum, StrEnum](https://docs.python.org/3/library/enum.html) based enumerates
   * [UUID](https://docs.python.org/3/library/uuid.html)
 
-This notably doesn't include any `date`, `time`, or `datetime` objects as they may not work across SDKs.
+To use pydantic model instances, see [](#pydantic-support).
 
-Users are strongly encouraged to use a single `dataclass` for parameter and return types so fields with defaults can be
-easily added without breaking compatibility.
+`datetime.date`, `datetime.time`, and `datetime.datetime` can only be used as fields of Pydantic models.
 
-To use pydantic model instances (or python objects containing pydantic model instances), use
+Users are strongly encouraged to use a single `dataclass` or Pydantic model for parameter and return types, so that fields
+with defaults can be easily added without breaking compatibility.
+
+Classes with generics may not have the generics properly resolved. The current implementation does not have generic
+type resolution. Users should use concrete types.
+
+##### Pydantic Support
+
+To use Pydantic model instances, install Pydantic and set the Pydantic data converter when creating client instances:
+
 ```python
 from temporalio.contrib.pydantic import pydantic_data_converter
 
 client = Client(data_converter=pydantic_data_converter, ...)
 ```
+
+Pydantic v1 is not supported by this data converter. If you are not yet able to upgrade from Pydantic v1, see
+https://github.com/temporalio/samples-python/tree/main/pydantic_converter/v1 for limited v1 support.
+
 Do not use pydantic's [strict mode](https://docs.pydantic.dev/latest/concepts/strict_mode/).
 
-Classes with generics may not have the generics properly resolved. The current implementation does not have generic
-type resolution. Users should use concrete types.
 
 ##### Custom Type Data Conversion
 
@@ -1334,7 +1344,7 @@ async def check_past_histories(my_client: Client):
 OpenTelemetry support requires the optional `opentelemetry` dependencies which are part of the `opentelemetry` extra.
 When using `pip`, running
 
-    pip install temporalio[opentelemetry]
+    pip install 'temporalio[opentelemetry]'
 
 will install needed dependencies. Then the `temporalio.contrib.opentelemetry.TracingInterceptor` can be created and set
 as an interceptor on the `interceptors` argument of `Client.connect`. When set, spans will be created for all client

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ informal introduction to the features and their implementation.
 - [Usage](#usage)
     - [Client](#client)
       - [Data Conversion](#data-conversion)
+        - [Pydantic Support](#pydantic-support)
         - [Custom Type Data Conversion](#custom-type-data-conversion)
     - [Workers](#workers)
     - [Workflows](#workflows)

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,7 +7,6 @@ description = "Reusable constraint types to use with typing.Annotated"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"pydantic\""
 files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
@@ -1084,7 +1083,6 @@ description = "Data validation using Python type hints"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"pydantic\""
 files = [
     {file = "pydantic-2.10.6-py3-none-any.whl", hash = "sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584"},
     {file = "pydantic-2.10.6.tar.gz", hash = "sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236"},
@@ -1106,7 +1104,6 @@ description = "Core functionality for Pydantic validation and serialization"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"pydantic\""
 files = [
     {file = "pydantic_core-2.27.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2d367ca20b2f14095a8f4fa1210f5a7b78b8a20009ecced6b12818f455b1e9fa"},
     {file = "pydantic_core-2.27.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:491a2b73db93fab69731eaee494f320faa4e093dbed776be1a829c2eb222c34c"},
@@ -1904,9 +1901,8 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [extras]
 grpc = ["grpcio"]
 opentelemetry = ["opentelemetry-api", "opentelemetry-sdk"]
-pydantic = ["pydantic"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "595afb046373e5c826930cf0f1bc112f70cbfae14c72775c33221e96d66fc869"
+content-hash = "6e479ea624b39564fb33a40ce6ad8f9139a9a8849182251bf84942fe456e36b0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,7 @@ description = "Reusable constraint types to use with typing.Annotated"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"pydantic\""
 files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
@@ -1083,6 +1084,7 @@ description = "Data validation using Python type hints"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"pydantic\""
 files = [
     {file = "pydantic-2.10.6-py3-none-any.whl", hash = "sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584"},
     {file = "pydantic-2.10.6.tar.gz", hash = "sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236"},
@@ -1104,6 +1106,7 @@ description = "Core functionality for Pydantic validation and serialization"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"pydantic\""
 files = [
     {file = "pydantic_core-2.27.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2d367ca20b2f14095a8f4fa1210f5a7b78b8a20009ecced6b12818f455b1e9fa"},
     {file = "pydantic_core-2.27.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:491a2b73db93fab69731eaee494f320faa4e093dbed776be1a829c2eb222c34c"},
@@ -1901,8 +1904,9 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [extras]
 grpc = ["grpcio"]
 opentelemetry = ["opentelemetry-api", "opentelemetry-sdk"]
+pydantic = ["pydantic"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "6e479ea624b39564fb33a40ce6ad8f9139a9a8849182251bf84942fe456e36b0"
+content-hash = "8279e4840e0d8124cfec01cf11c5076f090583d33580bb4e39adcd1f168105df"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1909,4 +1909,4 @@ pydantic = ["pydantic"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "8279e4840e0d8124cfec01cf11c5076f090583d33580bb4e39adcd1f168105df"
+content-hash = "fe88ba77a85c62862831e8286dddfc0530d1b7ad3c5c38be31f1508fd496c6e2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ grpcio = {version = "^1.48.2", optional = true}
 opentelemetry-api = { version = "^1.11.1", optional = true }
 opentelemetry-sdk = { version = "^1.11.1", optional = true }
 protobuf = ">=3.20"
-pydantic = { version = "^2.10.6", optional = true }
+pydantic = { version = ">=1.10.0,<3.0.0", optional = true }
 python = "^3.9"
 python-dateutil = { version = "^2.8.2", python = "<3.11" }
 types-protobuf = ">=3.20"
@@ -63,7 +63,6 @@ wheel = "^0.42.0"
 [tool.poetry.extras]
 opentelemetry = ["opentelemetry-api", "opentelemetry-sdk"]
 grpc = ["grpcio"]
-pydantic = ["pydantic"]
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,9 @@ twine = "^4.0.1"
 wheel = "^0.42.0"
 
 [tool.poetry.extras]
-opentelemetry = ["opentelemetry-api", "opentelemetry-sdk"]
 grpc = ["grpcio"]
+opentelemetry = ["opentelemetry-api", "opentelemetry-sdk"]
+pydantic = ["pydantic"]
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ grpcio = {version = "^1.48.2", optional = true}
 opentelemetry-api = { version = "^1.11.1", optional = true }
 opentelemetry-sdk = { version = "^1.11.1", optional = true }
 protobuf = ">=3.20"
-pydantic = { version = ">=1.10.0,<3.0.0", optional = true }
+pydantic = { version = "^2.0.0", optional = true }
 python = "^3.9"
 python-dateutil = { version = "^2.8.2", python = "<3.11" }
 types-protobuf = ">=3.20"

--- a/temporalio/contrib/pydantic.py
+++ b/temporalio/contrib/pydantic.py
@@ -52,7 +52,7 @@ class PydanticJSONPlainPayloadConverter(EncodingPayloadConverter):
     def to_payload(self, value: Any) -> Optional[temporalio.api.common.v1.Payload]:
         """See base class.
 
-        Uses :py:func:`pydantic_core.to_json` to serialize ``value` to JSON.
+        Uses ``pydantic_core.to_json`` to serialize ``value`` to JSON.
 
         See
         https://docs.pydantic.dev/latest/api/pydantic_core/#pydantic_core.to_json.
@@ -68,7 +68,7 @@ class PydanticJSONPlainPayloadConverter(EncodingPayloadConverter):
     ) -> Any:
         """See base class.
 
-        Uses :py:func:`pydantic.TypeAdapter.validate_json` to construct an
+        Uses ``pydantic.TypeAdapter.validate_json`` to construct an
         instance of the type specified by ``type_hint`` from the JSON payload.
 
         See

--- a/temporalio/contrib/pydantic.py
+++ b/temporalio/contrib/pydantic.py
@@ -12,10 +12,7 @@ To use, pass ``pydantic_data_converter`` as the ``data_converter`` argument to
 """
 
 import inspect
-from typing import (
-    Any,
-    Type,
-)
+from typing import Any, Type
 
 import pydantic
 

--- a/temporalio/contrib/pydantic.py
+++ b/temporalio/contrib/pydantic.py
@@ -15,7 +15,7 @@ Pydantic v1 is not supported.
 
 from typing import Any, Optional, Type
 
-from pydantic import TypeAdapter, ValidationError
+from pydantic import TypeAdapter
 from pydantic_core import to_json
 
 import temporalio.api.common.v1
@@ -75,10 +75,7 @@ class PydanticJSONPlainPayloadConverter(EncodingPayloadConverter):
         https://docs.pydantic.dev/latest/api/type_adapter/#pydantic.type_adapter.TypeAdapter.validate_json.
         """
         _type_hint = type_hint if type_hint is not None else Any
-        try:
-            return TypeAdapter(_type_hint).validate_json(payload.data)
-        except ValidationError as err:
-            raise RuntimeError("Failed parsing") from err
+        return TypeAdapter(_type_hint).validate_json(payload.data)
 
 
 class PydanticPayloadConverter(CompositePayloadConverter):

--- a/temporalio/contrib/pydantic.py
+++ b/temporalio/contrib/pydantic.py
@@ -74,8 +74,9 @@ class PydanticJSONPlainPayloadConverter(EncodingPayloadConverter):
         See
         https://docs.pydantic.dev/latest/api/type_adapter/#pydantic.type_adapter.TypeAdapter.validate_json.
         """
+        _type_hint = type_hint if type_hint is not None else Any
         try:
-            return TypeAdapter(type_hint).validate_json(payload.data)
+            return TypeAdapter(_type_hint).validate_json(payload.data)
         except ValidationError as err:
             raise RuntimeError("Failed parsing") from err
 

--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -489,9 +489,9 @@ class AdvancedJSONEncoder(json.JSONEncoder):
 
     This encoder supports dataclasses and all iterables as lists.
 
-    It also uses Pydantic's "model_dump" or "dict" methods if available on the
-    object, but with a warning that the dedicated pydantic data converter should
-    be used.
+    It also uses Pydantic v1's "dict" methods if available on the object,
+    but this is deprecated. Pydantic users should upgrade to v2 and use
+    temporalio.contrib.pydantic.pydantic_data_converter.
     """
 
     def default(self, o: Any) -> Any:

--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -564,7 +564,7 @@ class JSONPlainPayloadConverter(EncodingPayloadConverter):
         if hasattr(value, "parse_obj"):
             warnings.warn(
                 "If you're using Pydantic v2, use temporalio.contrib.pydantic.pydantic_data_converter. "
-                "If you're using Pydantic v1 and cannot upgrade, refer to https://github.com/temporalio/samples-python/tree/main/pydantic_converter/v1 for better v1 support."
+                "If you're using Pydantic v1 and cannot upgrade, refer to https://github.com/temporalio/samples-python/tree/main/pydantic_converter_v1 for better v1 support."
             )
         # We let JSON conversion errors be thrown to caller
         return temporalio.api.common.v1.Payload(

--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -563,8 +563,8 @@ class JSONPlainPayloadConverter(EncodingPayloadConverter):
         # Check for Pydantic v1
         if hasattr(value, "parse_obj"):
             warnings.warn(
-                "If you're using Pydantic v1, upgrade to Pydantic v2 and use temporalio.contrib.pydantic.pydantic_data_converter. "
-                "If you cannot upgrade, refer to https://github.com/temporalio/samples-python/tree/main/pydantic_converter/v1 for better v1 support."
+                "If you're using Pydantic v2, use temporalio.contrib.pydantic.pydantic_data_converter. "
+                "If you're using Pydantic v1 and cannot upgrade, refer to https://github.com/temporalio/samples-python/tree/main/pydantic_converter/v1 for better v1 support."
             )
         # We let JSON conversion errors be thrown to caller
         return temporalio.api.common.v1.Payload(

--- a/temporalio/worker/workflow_sandbox/_restrictions.py
+++ b/temporalio/worker/workflow_sandbox/_restrictions.py
@@ -1065,7 +1065,7 @@ class _RestrictedProxy:
     )
     __str__ = _RestrictedProxyLookup(str)  # type: ignore
     __bytes__ = _RestrictedProxyLookup(bytes)
-    __format__ = _RestrictedProxyLookup()  # type: ignore
+    __format__ = _RestrictedProxyLookup(format)  # type: ignore
     __lt__ = _RestrictedProxyLookup(operator.lt)
     __le__ = _RestrictedProxyLookup(operator.le)
     __eq__ = _RestrictedProxyLookup(operator.eq)  # type: ignore

--- a/temporalio/worker/workflow_sandbox/_restrictions.py
+++ b/temporalio/worker/workflow_sandbox/_restrictions.py
@@ -447,6 +447,7 @@ SandboxRestrictions.passthrough_modules_minimum = {
     # Very general modules needed by many things including pytest's
     # assertion rewriter
     "typing",
+    # Required for Pydantic TypedDict fields.
     "typing_extensions",
     # Required due to https://github.com/protocolbuffers/protobuf/issues/10143
     # for older versions. This unfortunately means that on those versions,

--- a/temporalio/worker/workflow_sandbox/_restrictions.py
+++ b/temporalio/worker/workflow_sandbox/_restrictions.py
@@ -962,7 +962,7 @@ def _is_restrictable(v: Any) -> bool:
             str,
             bytes,
             bytearray,
-            datetime.date,  # from which datetime.datetime inherits
+            datetime.date,  # e.g. datetime.datetime
         ),
     )
 

--- a/temporalio/worker/workflow_sandbox/_restrictions.py
+++ b/temporalio/worker/workflow_sandbox/_restrictions.py
@@ -961,8 +961,7 @@ def _is_restrictable(v: Any) -> bool:
             str,
             bytes,
             bytearray,
-            datetime.date,
-            datetime.datetime,
+            datetime.date,  # from which datetime.datetime inherits
         ),
     )
 

--- a/temporalio/worker/workflow_sandbox/_restrictions.py
+++ b/temporalio/worker/workflow_sandbox/_restrictions.py
@@ -444,9 +444,10 @@ SandboxRestrictions.passthrough_modules_minimum = {
     # Due to a metaclass conflict in sandbox, we need zipfile module to pass
     # through always
     "zipfile",
-    # This is a very general module needed by many things including pytest's
+    # Very general modules needed by many things including pytest's
     # assertion rewriter
     "typing",
+    "typing_extensions",
     # Required due to https://github.com/protocolbuffers/protobuf/issues/10143
     # for older versions. This unfortunately means that on those versions,
     # everyone using Python protos has to pass their module through.

--- a/tests/contrib/pydantic/activities.py
+++ b/tests/contrib/pydantic/activities.py
@@ -1,11 +1,20 @@
+from datetime import datetime
 from typing import List
+from uuid import UUID
 
 from temporalio import activity
 from tests.contrib.pydantic.models import PydanticModels
 
 
 @activity.defn
-async def pydantic_models_activity(
+async def pydantic_objects_activity(
     models: List[PydanticModels],
 ) -> List[PydanticModels]:
+    return models
+
+
+@activity.defn
+async def misc_objects_activity(
+    models: tuple[datetime, UUID],
+) -> tuple[datetime, UUID]:
     return models

--- a/tests/contrib/pydantic/activities.py
+++ b/tests/contrib/pydantic/activities.py
@@ -1,0 +1,11 @@
+from typing import List
+
+from temporalio import activity
+from tests.contrib.pydantic.models import PydanticModels
+
+
+@activity.defn
+async def pydantic_models_activity(
+    models: List[PydanticModels],
+) -> List[PydanticModels]:
+    return models

--- a/tests/contrib/pydantic/activities.py
+++ b/tests/contrib/pydantic/activities.py
@@ -15,6 +15,22 @@ async def pydantic_objects_activity(
 
 @activity.defn
 async def misc_objects_activity(
-    models: tuple[datetime, UUID],
-) -> tuple[datetime, UUID]:
+    models: tuple[
+        int,
+        str,
+        dict[str, float],
+        list[dict[str, float]],
+        tuple[dict[str, float]],
+        datetime,
+        UUID,
+    ],
+) -> tuple[
+    int,
+    str,
+    dict[str, float],
+    list[dict[str, float]],
+    tuple[dict[str, float]],
+    datetime,
+    UUID,
+]:
     return models

--- a/tests/contrib/pydantic/models.py
+++ b/tests/contrib/pydantic/models.py
@@ -84,7 +84,6 @@ class SpecialTypesModel(BaseModel):
 def make_special_types_object() -> SpecialTypesModel:
     return SpecialTypesModel(
         datetime_field=datetime(2000, 1, 2, 3, 4, 5),
-        # 946800245
         datetime_field_int=946782245,  # type: ignore
         datetime_field_float=946782245.0,  # type: ignore
         datetime_field_str_formatted="2000-01-02T03:04:05Z",  # type: ignore

--- a/tests/contrib/pydantic/models.py
+++ b/tests/contrib/pydantic/models.py
@@ -1,5 +1,7 @@
 import dataclasses
-from datetime import date, datetime, timedelta
+import uuid
+from datetime import date, datetime, time, timedelta, timezone
+from ipaddress import IPv4Address
 from pathlib import Path
 from typing import (
     Annotated,
@@ -22,15 +24,77 @@ from temporalio import workflow
 with workflow.unsafe.imports_passed_through():
     from tests.contrib.pydantic.models_2 import (
         ComplexTypesModel,
-        SpecialTypesModel,
         StandardTypesModel,
         make_complex_types_object,
-        make_special_types_object,
         make_standard_types_object,
     )
 
 SequenceType = TypeVar("SequenceType", bound=Sequence[Any])
 ShortSequence = Annotated[SequenceType, Len(max_length=2)]
+
+
+class SpecialTypesModel(BaseModel):
+    datetime_field: datetime
+    datetime_field_int: datetime
+    datetime_field_float: datetime
+    datetime_field_str_formatted: datetime
+    datetime_field_str_int: datetime
+    datetime_field_date: datetime
+
+    time_field: time
+    time_field_str: time
+
+    date_field: date
+    timedelta_field: timedelta
+    path_field: Path
+    uuid_field: uuid.UUID
+    ip_field: IPv4Address
+
+    def _check_instance(self) -> None:
+        dt = datetime(2000, 1, 2, 3, 4, 5)
+        dtz = datetime(2000, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+        assert isinstance(self.datetime_field, datetime)
+        assert isinstance(self.datetime_field_int, datetime)
+        assert isinstance(self.datetime_field_float, datetime)
+        assert isinstance(self.datetime_field_str_formatted, datetime)
+        assert isinstance(self.datetime_field_str_int, datetime)
+        assert isinstance(self.datetime_field_date, datetime)
+        assert isinstance(self.timedelta_field, timedelta)
+        assert isinstance(self.path_field, Path)
+        assert isinstance(self.uuid_field, uuid.UUID)
+        assert isinstance(self.ip_field, IPv4Address)
+        assert self.datetime_field == dt
+        assert self.datetime_field_int == dtz
+        assert self.datetime_field_float == dtz
+        assert self.datetime_field_str_formatted == dtz
+        assert self.datetime_field_str_int == dtz
+        assert self.datetime_field_date == datetime(2000, 1, 2)
+        assert self.time_field == time(3, 4, 5)
+        assert self.time_field_str == time(3, 4, 5, tzinfo=timezone.utc)
+        assert self.date_field == date(2000, 1, 2)
+        assert self.timedelta_field == timedelta(days=1, hours=2)
+        assert self.path_field == Path("test/path")
+        assert self.uuid_field == uuid.UUID("12345678-1234-5678-1234-567812345678")
+        assert self.ip_field == IPv4Address("127.0.0.1")
+
+
+def make_special_types_object() -> SpecialTypesModel:
+    return SpecialTypesModel(
+        datetime_field=datetime(2000, 1, 2, 3, 4, 5),
+        # 946800245
+        datetime_field_int=946782245,  # type: ignore
+        datetime_field_float=946782245.0,  # type: ignore
+        datetime_field_str_formatted="2000-01-02T03:04:05Z",  # type: ignore
+        datetime_field_str_int="946782245",  # type: ignore
+        datetime_field_date=datetime(2000, 1, 2),
+        time_field=time(3, 4, 5),
+        time_field_str="03:04:05Z",  # type: ignore
+        date_field=date(2000, 1, 2),
+        timedelta_field=timedelta(days=1, hours=2),
+        path_field=Path("test/path"),
+        uuid_field=uuid.UUID("12345678-1234-5678-1234-567812345678"),
+        ip_field=IPv4Address("127.0.0.1"),
+    )
 
 
 class ChildModel(BaseModel):

--- a/tests/contrib/pydantic/models.py
+++ b/tests/contrib/pydantic/models.py
@@ -1,25 +1,13 @@
-import collections
 import dataclasses
-import decimal
-import fractions
-import re
-import uuid
-from datetime import date, datetime, time, timedelta, timezone
-from enum import Enum, IntEnum
-from ipaddress import IPv4Address
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import (
     Annotated,
     Any,
     Dict,
     Generic,
-    Hashable,
     List,
-    NamedTuple,
-    Optional,
-    Pattern,
     Sequence,
-    Set,
     Tuple,
     TypeVar,
     Union,
@@ -27,297 +15,22 @@ from typing import (
 
 from annotated_types import Len
 from pydantic import BaseModel, Field, WithJsonSchema
-from typing_extensions import TypedDict
+
+from temporalio import workflow
+
+# Define some of the models outside the sandbox
+with workflow.unsafe.imports_passed_through():
+    from tests.contrib.pydantic.models_2 import (
+        ComplexTypesModel,
+        SpecialTypesModel,
+        StandardTypesModel,
+        make_complex_types_object,
+        make_special_types_object,
+        make_standard_types_object,
+    )
 
 SequenceType = TypeVar("SequenceType", bound=Sequence[Any])
 ShortSequence = Annotated[SequenceType, Len(max_length=2)]
-
-
-class FruitEnum(str, Enum):
-    apple = "apple"
-    banana = "banana"
-
-
-class NumberEnum(IntEnum):
-    one = 1
-    two = 2
-
-
-class UserTypedDict(TypedDict):
-    name: str
-    id: int
-
-
-class TypedDictModel(BaseModel):
-    typed_dict_field: UserTypedDict
-
-    def _check_instance(self) -> None:
-        assert isinstance(self.typed_dict_field, dict)
-        assert self.typed_dict_field == {"name": "username", "id": 7}
-
-
-def make_typed_dict_object() -> TypedDictModel:
-    return TypedDictModel(typed_dict_field={"name": "username", "id": 7})
-
-
-class StandardTypesModel(BaseModel):
-    # Boolean
-    bool_field: bool
-    bool_field_int: bool
-    bool_field_str: bool
-
-    # Numbers
-    int_field: int
-    float_field: float
-    decimal_field: decimal.Decimal
-    complex_field: complex
-    fraction_field: fractions.Fraction
-
-    # Strings and Bytes
-    str_field: str
-    bytes_field: bytes
-
-    # None
-    none_field: None
-
-    # Enums
-    str_enum_field: FruitEnum
-    int_enum_field: NumberEnum
-
-    # Collections
-    list_field: list
-    tuple_field: tuple
-    set_field: set
-    frozenset_field: frozenset
-    deque_field: collections.deque
-    sequence_field: Sequence[int]
-    # Iterable[int] supported but not tested since original vs round-tripped do not compare equal
-
-    # Mappings
-    dict_field: dict
-    # defaultdict_field: collections.defaultdict
-    counter_field: collections.Counter
-    typed_dict_field: UserTypedDict
-
-    # Other Types
-    pattern_field: Pattern
-    hashable_field: Hashable
-    any_field: Any
-    # callable_field: Callable
-
-    def _check_instance(self) -> None:
-        # Boolean checks
-        assert isinstance(self.bool_field, bool)
-        assert self.bool_field is True
-        assert isinstance(self.bool_field_int, bool)
-        assert self.bool_field_int is True
-        assert isinstance(self.bool_field_str, bool)
-        assert self.bool_field_str is True
-
-        # Number checks
-        assert isinstance(self.int_field, int)
-        assert self.int_field == 42
-        assert isinstance(self.float_field, float)
-        assert self.float_field == 3.14
-        assert isinstance(self.decimal_field, decimal.Decimal)
-        assert self.decimal_field == decimal.Decimal("3.14")
-        assert isinstance(self.complex_field, complex)
-        assert self.complex_field == complex(1, 2)
-        assert isinstance(self.fraction_field, fractions.Fraction)
-        assert self.fraction_field == fractions.Fraction(22, 7)
-
-        # String and Bytes checks
-        assert isinstance(self.str_field, str)
-        assert self.str_field == "hello"
-        assert isinstance(self.bytes_field, bytes)
-        assert self.bytes_field == b"world"
-
-        # None check
-        assert self.none_field is None
-
-        # Enum checks
-        assert isinstance(self.str_enum_field, Enum)
-        assert isinstance(self.int_enum_field, IntEnum)
-
-        # Collection checks
-        assert isinstance(self.list_field, list)
-        assert self.list_field == [1, 2, 3]
-        assert isinstance(self.tuple_field, tuple)
-        assert self.tuple_field == (1, 2, 3)
-        assert isinstance(self.set_field, set)
-        assert self.set_field == {1, 2, 3}
-        assert isinstance(self.frozenset_field, frozenset)
-        assert self.frozenset_field == frozenset([1, 2, 3])
-        assert isinstance(self.deque_field, collections.deque)
-        assert list(self.deque_field) == [1, 2, 3]
-        assert isinstance(self.sequence_field, list)
-        assert list(self.sequence_field) == [1, 2, 3]
-
-        # Mapping checks
-        assert isinstance(self.dict_field, dict)
-        assert self.dict_field == {"a": 1, "b": 2}
-        # assert isinstance(self.defaultdict_field, collections.defaultdict)
-        # assert dict(self.defaultdict_field) == {"a": 1, "b": 2}
-        assert isinstance(self.counter_field, collections.Counter)
-        assert dict(self.counter_field) == {"a": 1, "b": 2}
-        assert isinstance(self.typed_dict_field, dict)
-        assert self.typed_dict_field == {"name": "username", "id": 7}
-
-        # Other type checks
-        assert isinstance(self.pattern_field, Pattern)
-        assert self.pattern_field.pattern == r"\d+"
-        assert isinstance(self.hashable_field, Hashable)
-        assert self.hashable_field == "test"
-        assert self.any_field == "anything goes"
-        # assert callable(self.callable_field)
-
-
-def make_standard_types_object() -> StandardTypesModel:
-    return StandardTypesModel(
-        # Boolean
-        bool_field=True,
-        bool_field_int=1,  # type: ignore
-        bool_field_str="true",  # type: ignore
-        # Numbers
-        int_field=42,
-        float_field=3.14,
-        decimal_field=decimal.Decimal("3.14"),
-        complex_field=complex(1, 2),
-        fraction_field=fractions.Fraction(22, 7),
-        # Strings and Bytes
-        str_field="hello",
-        bytes_field=b"world",
-        # None
-        none_field=None,
-        # Enums
-        str_enum_field=FruitEnum.apple,
-        int_enum_field=NumberEnum.one,
-        # Collections
-        # these cast input to list, tuple, set, etc.
-        list_field={1, 2, 3},  # type: ignore
-        tuple_field=(1, 2, 3),
-        set_field={1, 2, 3},
-        frozenset_field=frozenset([1, 2, 3]),
-        deque_field=collections.deque([1, 2, 3]),
-        # other sequence types are converted to list, as documented
-        sequence_field=[1, 2, 3],
-        # Mappings
-        dict_field={"a": 1, "b": 2},
-        # defaultdict_field=collections.defaultdict(int, {"a": 1, "b": 2}),
-        counter_field=collections.Counter({"a": 1, "b": 2}),
-        typed_dict_field={"name": "username", "id": 7},
-        # Other Types
-        pattern_field=re.compile(r"\d+"),
-        hashable_field="test",
-        any_field="anything goes",
-        # callable_field=lambda x: x,
-    )
-
-
-class Point(NamedTuple):
-    x: int
-    y: int
-
-
-class ComplexTypesModel(BaseModel):
-    list_field: List[str]
-    dict_field: Dict[str, int]
-    set_field: Set[int]
-    tuple_field: Tuple[str, int]
-    union_field: Union[str, int]
-    optional_field: Optional[str]
-    named_tuple_field: Point
-
-    def _check_instance(self) -> None:
-        assert isinstance(self.list_field, list)
-        assert isinstance(self.dict_field, dict)
-        assert isinstance(self.set_field, set)
-        assert isinstance(self.tuple_field, tuple)
-        assert isinstance(self.union_field, str)
-        assert isinstance(self.optional_field, str)
-        assert self.list_field == ["a", "b", "c"]
-        assert self.dict_field == {"x": 1, "y": 2}
-        assert self.set_field == {1, 2, 3}
-        assert self.tuple_field == ("hello", 42)
-        assert self.union_field == "string_or_int"
-        assert self.optional_field == "present"
-        assert self.named_tuple_field == Point(x=1, y=2)
-
-
-def make_complex_types_object() -> ComplexTypesModel:
-    return ComplexTypesModel(
-        list_field=["a", "b", "c"],
-        dict_field={"x": 1, "y": 2},
-        set_field={1, 2, 3},
-        tuple_field=("hello", 42),
-        union_field="string_or_int",
-        optional_field="present",
-        named_tuple_field=Point(x=1, y=2),
-    )
-
-
-class SpecialTypesModel(BaseModel):
-    datetime_field: datetime
-    datetime_field_int: datetime
-    datetime_field_float: datetime
-    datetime_field_str_formatted: datetime
-    datetime_field_str_int: datetime
-    datetime_field_date: datetime
-
-    time_field: time
-    time_field_str: time
-
-    date_field: date
-    timedelta_field: timedelta
-    path_field: Path
-    uuid_field: uuid.UUID
-    ip_field: IPv4Address
-
-    def _check_instance(self) -> None:
-        dt = datetime(2000, 1, 2, 3, 4, 5)
-        dtz = datetime(2000, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
-        assert isinstance(self.datetime_field, datetime)
-        assert isinstance(self.datetime_field_int, datetime)
-        assert isinstance(self.datetime_field_float, datetime)
-        assert isinstance(self.datetime_field_str_formatted, datetime)
-        assert isinstance(self.datetime_field_str_int, datetime)
-        assert isinstance(self.datetime_field_date, datetime)
-        assert isinstance(self.timedelta_field, timedelta)
-        assert isinstance(self.path_field, Path)
-        assert isinstance(self.uuid_field, uuid.UUID)
-        assert isinstance(self.ip_field, IPv4Address)
-        assert self.datetime_field == dt
-        assert self.datetime_field_int == dtz
-        assert self.datetime_field_float == dtz
-        assert self.datetime_field_str_formatted == dtz
-        assert self.datetime_field_str_int == dtz
-        assert self.datetime_field_date == datetime(2000, 1, 2)
-        assert self.time_field == time(3, 4, 5)
-        assert self.time_field_str == time(3, 4, 5, tzinfo=timezone.utc)
-        assert self.date_field == date(2000, 1, 2)
-        assert self.timedelta_field == timedelta(days=1, hours=2)
-        assert self.path_field == Path("test/path")
-        assert self.uuid_field == uuid.UUID("12345678-1234-5678-1234-567812345678")
-        assert self.ip_field == IPv4Address("127.0.0.1")
-
-
-def make_special_types_object() -> SpecialTypesModel:
-    return SpecialTypesModel(
-        datetime_field=datetime(2000, 1, 2, 3, 4, 5),
-        # 946800245
-        datetime_field_int=946782245,  # type: ignore
-        datetime_field_float=946782245.0,  # type: ignore
-        datetime_field_str_formatted="2000-01-02T03:04:05Z",  # type: ignore
-        datetime_field_str_int="946782245",  # type: ignore
-        datetime_field_date=datetime(2000, 1, 2),
-        time_field=time(3, 4, 5),
-        time_field_str="03:04:05Z",  # type: ignore
-        date_field=date(2000, 1, 2),
-        timedelta_field=timedelta(days=1, hours=2),
-        path_field=Path("test/path"),
-        uuid_field=uuid.UUID("12345678-1234-5678-1234-567812345678"),
-        ip_field=IPv4Address("127.0.0.1"),
-    )
 
 
 class ChildModel(BaseModel):

--- a/tests/contrib/pydantic/models.py
+++ b/tests/contrib/pydantic/models.py
@@ -342,3 +342,7 @@ def make_dataclass_objects() -> List[MyDataClass]:
 
 ComplexCustomType = Tuple[List[MyDataClass], List[PydanticModels]]
 ComplexCustomUnionType = List[Union[MyDataClass, PydanticModels]]
+
+
+class PydanticModelWithStrictField(BaseModel):
+    strict_field: datetime = Field(strict=True)

--- a/tests/contrib/pydantic/models.py
+++ b/tests/contrib/pydantic/models.py
@@ -13,10 +13,11 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from annotated_types import Len
-from pydantic import BaseModel, Field, WithJsonSchema
+from pydantic import BaseModel, ConfigDict, Field, WithJsonSchema
 
 from temporalio import workflow
 
@@ -25,8 +26,10 @@ with workflow.unsafe.imports_passed_through():
     from tests.contrib.pydantic.models_2 import (
         ComplexTypesModel,
         StandardTypesModel,
+        StrictStandardTypesModel,
         make_complex_types_object,
         make_standard_types_object,
+        make_strict_standard_types_object,
     )
 
 SequenceType = TypeVar("SequenceType", bound=Sequence[Any])
@@ -95,6 +98,14 @@ def make_special_types_object() -> SpecialTypesModel:
         uuid_field=uuid.UUID("12345678-1234-5678-1234-567812345678"),
         ip_field=IPv4Address("127.0.0.1"),
     )
+
+
+class StrictSpecialTypesModel(SpecialTypesModel):
+    model_config = ConfigDict(strict=True)
+
+
+def make_strict_special_types_object() -> StrictSpecialTypesModel:
+    return cast(StrictSpecialTypesModel, make_special_types_object())
 
 
 class ChildModel(BaseModel):
@@ -362,8 +373,10 @@ def _assert_timedelta_validity(td: timedelta):
 
 PydanticModels = Union[
     StandardTypesModel,
+    StrictStandardTypesModel,
     ComplexTypesModel,
     SpecialTypesModel,
+    StrictSpecialTypesModel,
     ParentModel,
     FieldFeaturesModel,
     AnnotatedFieldsModel,
@@ -378,8 +391,10 @@ PydanticModels = Union[
 def make_list_of_pydantic_objects() -> List[PydanticModels]:
     objects = [
         make_standard_types_object(),
+        make_strict_standard_types_object(),
         make_complex_types_object(),
         make_special_types_object(),
+        make_strict_special_types_object(),
         make_nested_object(),
         make_field_features_object(),
         make_annotated_fields_object(),

--- a/tests/contrib/pydantic/models_2.py
+++ b/tests/contrib/pydantic/models_2.py
@@ -15,6 +15,7 @@ from typing import (
     Set,
     Tuple,
     Union,
+    cast,
 )
 
 from pydantic import BaseModel
@@ -200,6 +201,14 @@ def make_standard_types_object() -> StandardTypesModel:
         any_field="anything goes",
         # callable_field=lambda x: x,
     )
+
+
+class StrictStandardTypesModel(StandardTypesModel, strict=True):
+    pass
+
+
+def make_strict_standard_types_object() -> StrictStandardTypesModel:
+    return cast(StrictStandardTypesModel, make_standard_types_object())
 
 
 class Point(NamedTuple):

--- a/tests/contrib/pydantic/models_2.py
+++ b/tests/contrib/pydantic/models_2.py
@@ -1,0 +1,312 @@
+import collections
+import decimal
+import fractions
+import re
+import uuid
+from datetime import date, datetime, time, timedelta, timezone
+from enum import Enum, IntEnum
+from ipaddress import IPv4Address
+from pathlib import Path
+from typing import (
+    Any,
+    Dict,
+    Hashable,
+    List,
+    NamedTuple,
+    Optional,
+    Pattern,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
+
+from pydantic import BaseModel
+from typing_extensions import TypedDict
+
+
+class FruitEnum(str, Enum):
+    apple = "apple"
+    banana = "banana"
+
+
+class NumberEnum(IntEnum):
+    one = 1
+    two = 2
+
+
+class UserTypedDict(TypedDict):
+    name: str
+    id: int
+
+
+class TypedDictModel(BaseModel):
+    typed_dict_field: UserTypedDict
+
+    def _check_instance(self) -> None:
+        assert isinstance(self.typed_dict_field, dict)
+        assert self.typed_dict_field == {"name": "username", "id": 7}
+
+
+def make_typed_dict_object() -> TypedDictModel:
+    return TypedDictModel(typed_dict_field={"name": "username", "id": 7})
+
+
+class StandardTypesModel(BaseModel):
+    # Boolean
+    bool_field: bool
+    bool_field_int: bool
+    bool_field_str: bool
+
+    # Numbers
+    int_field: int
+    float_field: float
+    decimal_field: decimal.Decimal
+    complex_field: complex
+    fraction_field: fractions.Fraction
+
+    # Strings and Bytes
+    str_field: str
+    bytes_field: bytes
+
+    # None
+    none_field: None
+
+    # Enums
+    str_enum_field: FruitEnum
+    int_enum_field: NumberEnum
+
+    # Collections
+    list_field: list
+    tuple_field: tuple
+    set_field: set
+    frozenset_field: frozenset
+    deque_field: collections.deque
+    sequence_field: Sequence[int]
+    # Iterable[int] supported but not tested since original vs round-tripped do not compare equal
+
+    # Mappings
+    dict_field: dict
+    # defaultdict_field: collections.defaultdict
+    counter_field: collections.Counter
+    typed_dict_field: UserTypedDict
+
+    # Other Types
+    pattern_field: Pattern
+    hashable_field: Hashable
+    any_field: Any
+    # callable_field: Callable
+
+    def _check_instance(self) -> None:
+        # Boolean checks
+        assert isinstance(self.bool_field, bool)
+        assert self.bool_field is True
+        assert isinstance(self.bool_field_int, bool)
+        assert self.bool_field_int is True
+        assert isinstance(self.bool_field_str, bool)
+        assert self.bool_field_str is True
+
+        # Number checks
+        assert isinstance(self.int_field, int)
+        assert self.int_field == 42
+        assert isinstance(self.float_field, float)
+        assert self.float_field == 3.14
+        assert isinstance(self.decimal_field, decimal.Decimal)
+        assert self.decimal_field == decimal.Decimal("3.14")
+        assert isinstance(self.complex_field, complex)
+        assert self.complex_field == complex(1, 2)
+        assert isinstance(self.fraction_field, fractions.Fraction)
+        assert self.fraction_field == fractions.Fraction(22, 7)
+
+        # String and Bytes checks
+        assert isinstance(self.str_field, str)
+        assert self.str_field == "hello"
+        assert isinstance(self.bytes_field, bytes)
+        assert self.bytes_field == b"world"
+
+        # None check
+        assert self.none_field is None
+
+        # Enum checks
+        assert isinstance(self.str_enum_field, Enum)
+        assert isinstance(self.int_enum_field, IntEnum)
+
+        # Collection checks
+        assert isinstance(self.list_field, list)
+        assert self.list_field == [1, 2, 3]
+        assert isinstance(self.tuple_field, tuple)
+        assert self.tuple_field == (1, 2, 3)
+        assert isinstance(self.set_field, set)
+        assert self.set_field == {1, 2, 3}
+        assert isinstance(self.frozenset_field, frozenset)
+        assert self.frozenset_field == frozenset([1, 2, 3])
+        assert isinstance(self.deque_field, collections.deque)
+        assert list(self.deque_field) == [1, 2, 3]
+        assert isinstance(self.sequence_field, list)
+        assert list(self.sequence_field) == [1, 2, 3]
+
+        # Mapping checks
+        assert isinstance(self.dict_field, dict)
+        assert self.dict_field == {"a": 1, "b": 2}
+        # assert isinstance(self.defaultdict_field, collections.defaultdict)
+        # assert dict(self.defaultdict_field) == {"a": 1, "b": 2}
+        assert isinstance(self.counter_field, collections.Counter)
+        assert dict(self.counter_field) == {"a": 1, "b": 2}
+        assert isinstance(self.typed_dict_field, dict)
+        assert self.typed_dict_field == {"name": "username", "id": 7}
+
+        # Other type checks
+        assert isinstance(self.pattern_field, Pattern)
+        assert self.pattern_field.pattern == r"\d+"
+        assert isinstance(self.hashable_field, Hashable)
+        assert self.hashable_field == "test"
+        assert self.any_field == "anything goes"
+        # assert callable(self.callable_field)
+
+
+def make_standard_types_object() -> StandardTypesModel:
+    return StandardTypesModel(
+        # Boolean
+        bool_field=True,
+        bool_field_int=1,  # type: ignore
+        bool_field_str="true",  # type: ignore
+        # Numbers
+        int_field=42,
+        float_field=3.14,
+        decimal_field=decimal.Decimal("3.14"),
+        complex_field=complex(1, 2),
+        fraction_field=fractions.Fraction(22, 7),
+        # Strings and Bytes
+        str_field="hello",
+        bytes_field=b"world",
+        # None
+        none_field=None,
+        # Enums
+        str_enum_field=FruitEnum.apple,
+        int_enum_field=NumberEnum.one,
+        # Collections
+        # these cast input to list, tuple, set, etc.
+        list_field={1, 2, 3},  # type: ignore
+        tuple_field=(1, 2, 3),
+        set_field={1, 2, 3},
+        frozenset_field=frozenset([1, 2, 3]),
+        deque_field=collections.deque([1, 2, 3]),
+        # other sequence types are converted to list, as documented
+        sequence_field=[1, 2, 3],
+        # Mappings
+        dict_field={"a": 1, "b": 2},
+        # defaultdict_field=collections.defaultdict(int, {"a": 1, "b": 2}),
+        counter_field=collections.Counter({"a": 1, "b": 2}),
+        typed_dict_field={"name": "username", "id": 7},
+        # Other Types
+        pattern_field=re.compile(r"\d+"),
+        hashable_field="test",
+        any_field="anything goes",
+        # callable_field=lambda x: x,
+    )
+
+
+class Point(NamedTuple):
+    x: int
+    y: int
+
+
+class ComplexTypesModel(BaseModel):
+    list_field: List[str]
+    dict_field: Dict[str, int]
+    set_field: Set[int]
+    tuple_field: Tuple[str, int]
+    union_field: Union[str, int]
+    optional_field: Optional[str]
+    named_tuple_field: Point
+
+    def _check_instance(self) -> None:
+        assert isinstance(self.list_field, list)
+        assert isinstance(self.dict_field, dict)
+        assert isinstance(self.set_field, set)
+        assert isinstance(self.tuple_field, tuple)
+        assert isinstance(self.union_field, str)
+        assert isinstance(self.optional_field, str)
+        assert self.list_field == ["a", "b", "c"]
+        assert self.dict_field == {"x": 1, "y": 2}
+        assert self.set_field == {1, 2, 3}
+        assert self.tuple_field == ("hello", 42)
+        assert self.union_field == "string_or_int"
+        assert self.optional_field == "present"
+        assert self.named_tuple_field == Point(x=1, y=2)
+
+
+def make_complex_types_object() -> ComplexTypesModel:
+    return ComplexTypesModel(
+        list_field=["a", "b", "c"],
+        dict_field={"x": 1, "y": 2},
+        set_field={1, 2, 3},
+        tuple_field=("hello", 42),
+        union_field="string_or_int",
+        optional_field="present",
+        named_tuple_field=Point(x=1, y=2),
+    )
+
+
+class SpecialTypesModel(BaseModel):
+    datetime_field: datetime
+    datetime_field_int: datetime
+    datetime_field_float: datetime
+    datetime_field_str_formatted: datetime
+    datetime_field_str_int: datetime
+    datetime_field_date: datetime
+
+    time_field: time
+    time_field_str: time
+
+    date_field: date
+    timedelta_field: timedelta
+    path_field: Path
+    uuid_field: uuid.UUID
+    ip_field: IPv4Address
+
+    def _check_instance(self) -> None:
+        dt = datetime(2000, 1, 2, 3, 4, 5)
+        dtz = datetime(2000, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+        assert isinstance(self.datetime_field, datetime)
+        assert isinstance(self.datetime_field_int, datetime)
+        assert isinstance(self.datetime_field_float, datetime)
+        assert isinstance(self.datetime_field_str_formatted, datetime)
+        assert isinstance(self.datetime_field_str_int, datetime)
+        assert isinstance(self.datetime_field_date, datetime)
+        assert isinstance(self.timedelta_field, timedelta)
+        assert isinstance(self.path_field, Path)
+        assert isinstance(self.uuid_field, uuid.UUID)
+        assert isinstance(self.ip_field, IPv4Address)
+        assert self.datetime_field == dt
+        assert self.datetime_field_int == dtz
+        assert self.datetime_field_float == dtz
+        assert self.datetime_field_str_formatted == dtz
+        assert self.datetime_field_str_int == dtz
+        assert self.datetime_field_date == datetime(2000, 1, 2)
+        assert self.time_field == time(3, 4, 5)
+        assert self.time_field_str == time(3, 4, 5, tzinfo=timezone.utc)
+        assert self.date_field == date(2000, 1, 2)
+        assert self.timedelta_field == timedelta(days=1, hours=2)
+        assert self.path_field == Path("test/path")
+        assert self.uuid_field == uuid.UUID("12345678-1234-5678-1234-567812345678")
+        assert self.ip_field == IPv4Address("127.0.0.1")
+
+
+def make_special_types_object() -> SpecialTypesModel:
+    return SpecialTypesModel(
+        datetime_field=datetime(2000, 1, 2, 3, 4, 5),
+        # 946800245
+        datetime_field_int=946782245,  # type: ignore
+        datetime_field_float=946782245.0,  # type: ignore
+        datetime_field_str_formatted="2000-01-02T03:04:05Z",  # type: ignore
+        datetime_field_str_int="946782245",  # type: ignore
+        datetime_field_date=datetime(2000, 1, 2),
+        time_field=time(3, 4, 5),
+        time_field_str="03:04:05Z",  # type: ignore
+        date_field=date(2000, 1, 2),
+        timedelta_field=timedelta(days=1, hours=2),
+        path_field=Path("test/path"),
+        uuid_field=uuid.UUID("12345678-1234-5678-1234-567812345678"),
+        ip_field=IPv4Address("127.0.0.1"),
+    )

--- a/tests/contrib/pydantic/models_2.py
+++ b/tests/contrib/pydantic/models_2.py
@@ -92,7 +92,6 @@ class StandardTypesModel(BaseModel):
     pattern_field: Pattern
     hashable_field: Hashable
     any_field: Any
-    # callable_field: Callable
 
     def _check_instance(self) -> None:
         # Boolean checks
@@ -158,7 +157,6 @@ class StandardTypesModel(BaseModel):
         assert isinstance(self.hashable_field, Hashable)
         assert self.hashable_field == "test"
         assert self.any_field == "anything goes"
-        # assert callable(self.callable_field)
 
 
 def make_standard_types_object() -> StandardTypesModel:
@@ -199,7 +197,6 @@ def make_standard_types_object() -> StandardTypesModel:
         pattern_field=re.compile(r"\d+"),
         hashable_field="test",
         any_field="anything goes",
-        # callable_field=lambda x: x,
     )
 
 

--- a/tests/contrib/pydantic/models_2.py
+++ b/tests/contrib/pydantic/models_2.py
@@ -84,7 +84,7 @@ class StandardTypesModel(BaseModel):
 
     # Mappings
     dict_field: dict
-    # defaultdict_field: collections.defaultdict
+    defaultdict_field: collections.defaultdict[str, int]
     counter_field: collections.Counter
     typed_dict_field: UserTypedDict
 
@@ -144,8 +144,8 @@ class StandardTypesModel(BaseModel):
         # Mapping checks
         assert isinstance(self.dict_field, dict)
         assert self.dict_field == {"a": 1, "b": 2}
-        # assert isinstance(self.defaultdict_field, collections.defaultdict)
-        # assert dict(self.defaultdict_field) == {"a": 1, "b": 2}
+        assert isinstance(self.defaultdict_field, collections.defaultdict)
+        assert dict(self.defaultdict_field) == {"a": 1, "b": 2}
         assert isinstance(self.counter_field, collections.Counter)
         assert dict(self.counter_field) == {"a": 1, "b": 2}
         assert isinstance(self.typed_dict_field, dict)
@@ -190,7 +190,7 @@ def make_standard_types_object() -> StandardTypesModel:
         sequence_field=[1, 2, 3],
         # Mappings
         dict_field={"a": 1, "b": 2},
-        # defaultdict_field=collections.defaultdict(int, {"a": 1, "b": 2}),
+        defaultdict_field=collections.defaultdict(int, {"a": 1, "b": 2}),
         counter_field=collections.Counter({"a": 1, "b": 2}),
         typed_dict_field={"name": "username", "id": 7},
         # Other Types

--- a/tests/contrib/pydantic/models_2.py
+++ b/tests/contrib/pydantic/models_2.py
@@ -2,11 +2,7 @@ import collections
 import decimal
 import fractions
 import re
-import uuid
-from datetime import date, datetime, time, timedelta, timezone
 from enum import Enum, IntEnum
-from ipaddress import IPv4Address
-from pathlib import Path
 from typing import (
     Any,
     Dict,
@@ -245,68 +241,4 @@ def make_complex_types_object() -> ComplexTypesModel:
         union_field="string_or_int",
         optional_field="present",
         named_tuple_field=Point(x=1, y=2),
-    )
-
-
-class SpecialTypesModel(BaseModel):
-    datetime_field: datetime
-    datetime_field_int: datetime
-    datetime_field_float: datetime
-    datetime_field_str_formatted: datetime
-    datetime_field_str_int: datetime
-    datetime_field_date: datetime
-
-    time_field: time
-    time_field_str: time
-
-    date_field: date
-    timedelta_field: timedelta
-    path_field: Path
-    uuid_field: uuid.UUID
-    ip_field: IPv4Address
-
-    def _check_instance(self) -> None:
-        dt = datetime(2000, 1, 2, 3, 4, 5)
-        dtz = datetime(2000, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
-        assert isinstance(self.datetime_field, datetime)
-        assert isinstance(self.datetime_field_int, datetime)
-        assert isinstance(self.datetime_field_float, datetime)
-        assert isinstance(self.datetime_field_str_formatted, datetime)
-        assert isinstance(self.datetime_field_str_int, datetime)
-        assert isinstance(self.datetime_field_date, datetime)
-        assert isinstance(self.timedelta_field, timedelta)
-        assert isinstance(self.path_field, Path)
-        assert isinstance(self.uuid_field, uuid.UUID)
-        assert isinstance(self.ip_field, IPv4Address)
-        assert self.datetime_field == dt
-        assert self.datetime_field_int == dtz
-        assert self.datetime_field_float == dtz
-        assert self.datetime_field_str_formatted == dtz
-        assert self.datetime_field_str_int == dtz
-        assert self.datetime_field_date == datetime(2000, 1, 2)
-        assert self.time_field == time(3, 4, 5)
-        assert self.time_field_str == time(3, 4, 5, tzinfo=timezone.utc)
-        assert self.date_field == date(2000, 1, 2)
-        assert self.timedelta_field == timedelta(days=1, hours=2)
-        assert self.path_field == Path("test/path")
-        assert self.uuid_field == uuid.UUID("12345678-1234-5678-1234-567812345678")
-        assert self.ip_field == IPv4Address("127.0.0.1")
-
-
-def make_special_types_object() -> SpecialTypesModel:
-    return SpecialTypesModel(
-        datetime_field=datetime(2000, 1, 2, 3, 4, 5),
-        # 946800245
-        datetime_field_int=946782245,  # type: ignore
-        datetime_field_float=946782245.0,  # type: ignore
-        datetime_field_str_formatted="2000-01-02T03:04:05Z",  # type: ignore
-        datetime_field_str_int="946782245",  # type: ignore
-        datetime_field_date=datetime(2000, 1, 2),
-        time_field=time(3, 4, 5),
-        time_field_str="03:04:05Z",  # type: ignore
-        date_field=date(2000, 1, 2),
-        timedelta_field=timedelta(days=1, hours=2),
-        path_field=Path("test/path"),
-        uuid_field=uuid.UUID("12345678-1234-5678-1234-567812345678"),
-        ip_field=IPv4Address("127.0.0.1"),
     )

--- a/tests/contrib/pydantic/test_pydantic.py
+++ b/tests/contrib/pydantic/test_pydantic.py
@@ -1,0 +1,205 @@
+import dataclasses
+import uuid
+
+from pydantic import BaseModel
+
+from temporalio.client import Client
+from temporalio.contrib.pydantic import pydantic_data_converter
+from temporalio.worker import Worker
+from tests.contrib.pydantic.models import (
+    make_dataclass_objects,
+    make_list_of_pydantic_objects,
+)
+from tests.contrib.pydantic.workflows import (
+    CloneObjectsWorkflow,
+    ComplexCustomTypeWorkflow,
+    ComplexCustomUnionTypeWorkflow,
+    DatetimeUsageWorkflow,
+    InstantiateModelsWorkflow,
+    PydanticModelUsageWorkflow,
+    RoundTripObjectsWorkflow,
+    clone_objects,
+    pydantic_models_activity,
+)
+
+
+async def test_instantiation_outside_sandbox():
+    make_list_of_pydantic_objects()
+
+
+async def test_instantiation_inside_sandbox(client: Client):
+    new_config = client.config()
+    new_config["data_converter"] = pydantic_data_converter
+    client = Client(**new_config)
+    task_queue_name = str(uuid.uuid4())
+
+    async with Worker(
+        client,
+        task_queue=task_queue_name,
+        workflows=[InstantiateModelsWorkflow],
+    ):
+        await client.execute_workflow(
+            InstantiateModelsWorkflow.run,
+            id=str(uuid.uuid4()),
+            task_queue=task_queue_name,
+        )
+
+
+async def test_round_trip_pydantic_objects(client: Client):
+    new_config = client.config()
+    new_config["data_converter"] = pydantic_data_converter
+    client = Client(**new_config)
+    task_queue_name = str(uuid.uuid4())
+
+    orig_objects = make_list_of_pydantic_objects()
+
+    async with Worker(
+        client,
+        task_queue=task_queue_name,
+        workflows=[RoundTripObjectsWorkflow],
+        activities=[pydantic_models_activity],
+    ):
+        returned_objects = await client.execute_workflow(
+            RoundTripObjectsWorkflow.run,
+            orig_objects,
+            id=str(uuid.uuid4()),
+            task_queue=task_queue_name,
+        )
+    assert returned_objects == orig_objects
+    for o in returned_objects:
+        o._check_instance()
+
+
+async def test_clone_objects_outside_sandbox():
+    clone_objects(make_list_of_pydantic_objects())
+
+
+async def test_clone_objects_in_sandbox(client: Client):
+    new_config = client.config()
+    new_config["data_converter"] = pydantic_data_converter
+    client = Client(**new_config)
+    task_queue_name = str(uuid.uuid4())
+
+    orig_objects = make_list_of_pydantic_objects()
+
+    async with Worker(
+        client,
+        task_queue=task_queue_name,
+        workflows=[CloneObjectsWorkflow],
+    ):
+        returned_objects = await client.execute_workflow(
+            CloneObjectsWorkflow.run,
+            orig_objects,
+            id=str(uuid.uuid4()),
+            task_queue=task_queue_name,
+        )
+    assert returned_objects == orig_objects
+    for o in returned_objects:
+        o._check_instance()
+
+
+async def test_complex_custom_type(client: Client):
+    new_config = client.config()
+    new_config["data_converter"] = pydantic_data_converter
+    client = Client(**new_config)
+    task_queue_name = str(uuid.uuid4())
+
+    orig_dataclass_objects = make_dataclass_objects()
+    orig_pydantic_objects = make_list_of_pydantic_objects()
+
+    async with Worker(
+        client,
+        task_queue=task_queue_name,
+        workflows=[ComplexCustomTypeWorkflow],
+        activities=[pydantic_models_activity],
+    ):
+        (
+            returned_dataclass_objects,
+            returned_pydantic_objects,
+        ) = await client.execute_workflow(
+            ComplexCustomTypeWorkflow.run,
+            (orig_dataclass_objects, orig_pydantic_objects),
+            id=str(uuid.uuid4()),
+            task_queue=task_queue_name,
+        )
+    assert orig_dataclass_objects == returned_dataclass_objects
+    assert orig_pydantic_objects == returned_pydantic_objects
+    for o in returned_pydantic_objects:
+        o._check_instance()
+
+
+async def test_complex_custom_union_type(client: Client):
+    new_config = client.config()
+    new_config["data_converter"] = pydantic_data_converter
+    client = Client(**new_config)
+    task_queue_name = str(uuid.uuid4())
+
+    orig_dataclass_objects = make_dataclass_objects()
+    orig_pydantic_objects = make_list_of_pydantic_objects()
+    orig_objects = orig_dataclass_objects + orig_pydantic_objects
+    import random
+
+    random.shuffle(orig_objects)
+
+    async with Worker(
+        client,
+        task_queue=task_queue_name,
+        workflows=[ComplexCustomUnionTypeWorkflow],
+        activities=[pydantic_models_activity],
+    ):
+        returned_objects = await client.execute_workflow(
+            ComplexCustomUnionTypeWorkflow.run,
+            orig_objects,
+            id=str(uuid.uuid4()),
+            task_queue=task_queue_name,
+        )
+    returned_dataclass_objects, returned_pydantic_objects = [], []
+    for o in returned_objects:
+        if dataclasses.is_dataclass(o):
+            returned_dataclass_objects.append(o)
+        elif isinstance(o, BaseModel):
+            returned_pydantic_objects.append(o)
+        else:
+            raise TypeError(f"Unexpected type: {type(o)}")
+    assert sorted(orig_dataclass_objects) == sorted(returned_dataclass_objects)
+    assert sorted(orig_pydantic_objects, key=lambda o: o.__class__.__name__) == sorted(
+        returned_pydantic_objects, key=lambda o: o.__class__.__name__
+    )
+    for o in returned_pydantic_objects:
+        o._check_instance()
+
+
+async def test_pydantic_model_usage_in_workflow(client: Client):
+    new_config = client.config()
+    new_config["data_converter"] = pydantic_data_converter
+    client = Client(**new_config)
+    task_queue_name = str(uuid.uuid4())
+
+    async with Worker(
+        client,
+        task_queue=task_queue_name,
+        workflows=[PydanticModelUsageWorkflow],
+    ):
+        await client.execute_workflow(
+            PydanticModelUsageWorkflow.run,
+            id=str(uuid.uuid4()),
+            task_queue=task_queue_name,
+        )
+
+
+async def test_datetime_usage_in_workflow(client: Client):
+    new_config = client.config()
+    new_config["data_converter"] = pydantic_data_converter
+    client = Client(**new_config)
+    task_queue_name = str(uuid.uuid4())
+
+    async with Worker(
+        client,
+        task_queue=task_queue_name,
+        workflows=[DatetimeUsageWorkflow],
+    ):
+        await client.execute_workflow(
+            DatetimeUsageWorkflow.run,
+            id=str(uuid.uuid4()),
+            task_queue=task_queue_name,
+        )

--- a/tests/contrib/pydantic/test_pydantic.py
+++ b/tests/contrib/pydantic/test_pydantic.py
@@ -82,7 +82,15 @@ async def test_round_trip_misc_objects(client: Client):
     client = Client(**new_config)
     task_queue_name = str(uuid.uuid4())
 
-    orig_objects = (datetime(2025, 1, 2, 3, 4, 5), uuid.uuid4())
+    orig_objects = (
+        7,
+        "7",
+        {"7": 7.0},
+        [{"7": 7.0}],
+        ({"7": 7.0},),
+        datetime(2025, 1, 2, 3, 4, 5),
+        uuid.uuid4(),
+    )
 
     async with Worker(
         client,

--- a/tests/contrib/pydantic/test_pydantic.py
+++ b/tests/contrib/pydantic/test_pydantic.py
@@ -153,7 +153,8 @@ async def test_complex_custom_union_type(client: Client):
             id=str(uuid.uuid4()),
             task_queue=task_queue_name,
         )
-    returned_dataclass_objects, returned_pydantic_objects = [], []
+    returned_dataclass_objects = []
+    returned_pydantic_objects: list[BaseModel] = []
     for o in returned_objects:
         if dataclasses.is_dataclass(o):
             returned_dataclass_objects.append(o)
@@ -161,12 +162,14 @@ async def test_complex_custom_union_type(client: Client):
             returned_pydantic_objects.append(o)
         else:
             raise TypeError(f"Unexpected type: {type(o)}")
-    assert sorted(orig_dataclass_objects) == sorted(returned_dataclass_objects)
+    assert sorted(orig_dataclass_objects, key=lambda o: o.__class__.__name__) == sorted(
+        returned_dataclass_objects, key=lambda o: o.__class__.__name__
+    )
     assert sorted(orig_pydantic_objects, key=lambda o: o.__class__.__name__) == sorted(
         returned_pydantic_objects, key=lambda o: o.__class__.__name__
     )
-    for o in returned_pydantic_objects:
-        o._check_instance()
+    for o2 in returned_pydantic_objects:
+        o2._check_instance()  # type: ignore
 
 
 async def test_pydantic_model_usage_in_workflow(client: Client):

--- a/tests/contrib/pydantic/test_pydantic.py
+++ b/tests/contrib/pydantic/test_pydantic.py
@@ -26,7 +26,6 @@ from tests.contrib.pydantic.workflows import (
     PydanticModelWithStrictFieldWorkflow,
     RoundTripMiscObjectsWorkflow,
     RoundTripPydanticObjectsWorkflow,
-    ValidationErrorWorkflow,
     _test_pydantic_model_with_strict_field,
     clone_objects,
     misc_objects_activity,
@@ -315,11 +314,11 @@ async def test_validation_error(client: Client):
     async with Worker(
         client,
         task_queue=task_queue_name,
-        workflows=[ValidationErrorWorkflow],
+        workflows=[NoTypeAnnotationsWorkflow],
     ):
         with pytest.raises(pydantic.ValidationError):
             await client.execute_workflow(
-                "ValidationErrorWorkflow",
+                "NoTypeAnnotationsWorkflow",
                 "not-an-int",
                 id=str(uuid.uuid4()),
                 task_queue=task_queue_name,

--- a/tests/contrib/pydantic/workflows.py
+++ b/tests/contrib/pydantic/workflows.py
@@ -8,12 +8,13 @@ from temporalio import workflow
 
 with workflow.unsafe.imports_passed_through():
     from tests.contrib.pydantic.activities import pydantic_models_activity
-    from tests.contrib.pydantic.models import (
-        ComplexCustomType,
-        ComplexCustomUnionType,
-        PydanticModels,
-        make_list_of_pydantic_objects,
-    )
+
+from tests.contrib.pydantic.models import (
+    ComplexCustomType,
+    ComplexCustomUnionType,
+    PydanticModels,
+    make_list_of_pydantic_objects,
+)
 
 
 def clone_objects(objects: List[PydanticModels]) -> List[PydanticModels]:

--- a/tests/contrib/pydantic/workflows.py
+++ b/tests/contrib/pydantic/workflows.py
@@ -56,7 +56,26 @@ class RoundTripPydanticObjectsWorkflow:
 @workflow.defn
 class RoundTripMiscObjectsWorkflow:
     @workflow.run
-    async def run(self, objects: tuple[datetime, UUID]) -> tuple[datetime, UUID]:
+    async def run(
+        self,
+        objects: tuple[
+            int,
+            str,
+            dict[str, float],
+            list[dict[str, float]],
+            tuple[dict[str, float]],
+            datetime,
+            UUID,
+        ],
+    ) -> tuple[
+        int,
+        str,
+        dict[str, float],
+        list[dict[str, float]],
+        tuple[dict[str, float]],
+        datetime,
+        UUID,
+    ]:
         return await workflow.execute_activity(
             misc_objects_activity,
             objects,

--- a/tests/contrib/pydantic/workflows.py
+++ b/tests/contrib/pydantic/workflows.py
@@ -173,3 +173,10 @@ class NoTypeAnnotationsWorkflow:
     @workflow.run
     async def run(self, arg):
         return arg
+
+
+@workflow.defn
+class ValidationErrorWorkflow:
+    @workflow.run
+    async def run(self, arg):
+        return arg

--- a/tests/contrib/pydantic/workflows.py
+++ b/tests/contrib/pydantic/workflows.py
@@ -173,10 +173,3 @@ class NoTypeAnnotationsWorkflow:
     @workflow.run
     async def run(self, arg):
         return arg
-
-
-@workflow.defn
-class ValidationErrorWorkflow:
-    @workflow.run
-    async def run(self, arg):
-        return arg

--- a/tests/contrib/pydantic/workflows.py
+++ b/tests/contrib/pydantic/workflows.py
@@ -1,0 +1,111 @@
+import dataclasses
+from datetime import datetime, timedelta
+from typing import List
+
+from pydantic import BaseModel, create_model
+
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from tests.contrib.pydantic.activities import pydantic_models_activity
+    from tests.contrib.pydantic.models import (
+        ComplexCustomType,
+        ComplexCustomUnionType,
+        PydanticModels,
+        make_list_of_pydantic_objects,
+    )
+
+
+def clone_objects(objects: List[PydanticModels]) -> List[PydanticModels]:
+    new_objects = []
+    for o in objects:
+        fields = {}
+        for name, f in o.model_fields.items():
+            fields[name] = (f.annotation, f)
+        model = create_model(o.__class__.__name__, **fields)  # type: ignore
+        new_objects.append(model(**o.model_dump(by_alias=True)))
+    for old, new in zip(objects, new_objects):
+        assert old.model_dump() == new.model_dump()
+    return new_objects
+
+
+@workflow.defn
+class InstantiateModelsWorkflow:
+    @workflow.run
+    async def run(self) -> None:
+        make_list_of_pydantic_objects()
+
+
+@workflow.defn
+class RoundTripObjectsWorkflow:
+    @workflow.run
+    async def run(self, objects: List[PydanticModels]) -> List[PydanticModels]:
+        return await workflow.execute_activity(
+            pydantic_models_activity,
+            objects,
+            start_to_close_timeout=timedelta(minutes=1),
+        )
+
+
+@workflow.defn
+class CloneObjectsWorkflow:
+    @workflow.run
+    async def run(self, objects: List[PydanticModels]) -> List[PydanticModels]:
+        return clone_objects(objects)
+
+
+@workflow.defn
+class ComplexCustomUnionTypeWorkflow:
+    @workflow.run
+    async def run(
+        self,
+        input: ComplexCustomUnionType,
+    ) -> ComplexCustomUnionType:
+        data_classes = []
+        pydantic_objects: List[PydanticModels] = []
+        for o in input:
+            if dataclasses.is_dataclass(o):
+                data_classes.append(o)
+            elif isinstance(o, BaseModel):
+                pydantic_objects.append(o)
+            else:
+                raise TypeError(f"Unexpected type: {type(o)}")
+        pydantic_objects = await workflow.execute_activity(
+            pydantic_models_activity,
+            pydantic_objects,
+            start_to_close_timeout=timedelta(minutes=1),
+        )
+        return data_classes + pydantic_objects  # type: ignore
+
+
+@workflow.defn
+class ComplexCustomTypeWorkflow:
+    @workflow.run
+    async def run(
+        self,
+        input: ComplexCustomType,
+    ) -> ComplexCustomType:
+        data_classes, pydantic_objects = input
+        pydantic_objects = await workflow.execute_activity(
+            pydantic_models_activity,
+            pydantic_objects,
+            start_to_close_timeout=timedelta(minutes=1),
+        )
+        return data_classes, pydantic_objects
+
+
+@workflow.defn
+class PydanticModelUsageWorkflow:
+    @workflow.run
+    async def run(self) -> None:
+        for o in make_list_of_pydantic_objects():
+            o._check_instance()
+
+
+@workflow.defn
+class DatetimeUsageWorkflow:
+    @workflow.run
+    async def run(self) -> None:
+        dt = workflow.now()
+        assert isinstance(dt, datetime)
+        assert issubclass(dt.__class__, datetime)

--- a/tests/contrib/pydantic/workflows.py
+++ b/tests/contrib/pydantic/workflows.py
@@ -166,3 +166,10 @@ class PydanticModelWithStrictFieldWorkflow:
         self, obj: PydanticModelWithStrictField
     ) -> PydanticModelWithStrictField:
         return _test_pydantic_model_with_strict_field(obj)
+
+
+@workflow.defn
+class NoTypeAnnotationsWorkflow:
+    @workflow.run
+    async def run(self, arg):
+        return arg

--- a/tests/contrib/pydantic/workflows.py
+++ b/tests/contrib/pydantic/workflows.py
@@ -13,6 +13,7 @@ from tests.contrib.pydantic.models import (
     ComplexCustomType,
     ComplexCustomUnionType,
     PydanticModels,
+    PydanticModelWithStrictField,
     make_list_of_pydantic_objects,
 )
 
@@ -110,3 +111,24 @@ class DatetimeUsageWorkflow:
         dt = workflow.now()
         assert isinstance(dt, datetime)
         assert issubclass(dt.__class__, datetime)
+
+
+def _test_pydantic_model_with_strict_field(
+    obj: PydanticModelWithStrictField,
+):
+    roundtripped = PydanticModelWithStrictField.model_validate(obj.model_dump())
+    assert roundtripped == obj
+    roundtripped2 = PydanticModelWithStrictField.model_validate_json(
+        obj.model_dump_json()
+    )
+    assert roundtripped2 == obj
+    return roundtripped
+
+
+@workflow.defn
+class PydanticModelWithStrictFieldWorkflow:
+    @workflow.run
+    async def run(
+        self, obj: PydanticModelWithStrictField
+    ) -> PydanticModelWithStrictField:
+        return _test_pydantic_model_with_strict_field(obj)

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -49,6 +49,8 @@ class NumberEnum(IntEnum):
 class StandardTypesModel(BaseModel):
     # Boolean
     bool_field: bool
+    bool_field_int: bool
+    bool_field_str: bool
 
     # Numbers
     int_field: int
@@ -91,6 +93,10 @@ class StandardTypesModel(BaseModel):
         # Boolean checks
         assert isinstance(self.bool_field, bool)
         assert self.bool_field is True
+        assert isinstance(self.bool_field_int, bool)
+        assert self.bool_field_int is True
+        assert isinstance(self.bool_field_str, bool)
+        assert self.bool_field_str is True
 
         # Number checks
         assert isinstance(self.int_field, int)
@@ -152,6 +158,8 @@ def make_standard_types_object() -> StandardTypesModel:
     return StandardTypesModel(
         # Boolean
         bool_field=True,
+        bool_field_int=1,  # type: ignore
+        bool_field_str="true",  # type: ignore
         # Numbers
         int_field=42,
         float_field=3.14,
@@ -484,6 +492,7 @@ def make_pydantic_timedelta_object() -> PydanticTimedeltaModel:
 
 
 HeterogeneousPydanticModels = Union[
+    StandardTypesModel,
     ComplexTypesModel,
     SpecialTypesModel,
     ParentModel,

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -198,7 +198,8 @@ def make_standard_types_object() -> StandardTypesModel:
         str_enum_field=FruitEnum.apple,
         int_enum_field=NumberEnum.one,
         # Collections
-        list_field=[1, 2, 3],
+        # these cast input to list, tuple, set, etc.
+        list_field={1, 2, 3},  # type: ignore
         tuple_field=(1, 2, 3),
         set_field={1, 2, 3},
         frozenset_field=frozenset([1, 2, 3]),

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -653,7 +653,7 @@ def clone_objects(objects: List[PydanticModels]) -> List[PydanticModels]:
         fields = {}
         for name, f in o.model_fields.items():
             fields[name] = (f.annotation, f)
-        model = create_model(o.__class__.__name__, **fields)
+        model = create_model(o.__class__.__name__, **fields)  # type: ignore
         new_objects.append(model(**o.model_dump(by_alias=True)))
     for old, new in zip(objects, new_objects):
         assert old.model_dump() == new.model_dump()
@@ -811,7 +811,8 @@ class ComplexCustomUnionTypeWorkflow:
         self,
         input: ComplexCustomUnionType,
     ) -> ComplexCustomUnionType:
-        data_classes, pydantic_objects = [], []
+        data_classes = []
+        pydantic_objects: List[PydanticModels] = []
         for o in input:
             if dataclasses.is_dataclass(o):
                 data_classes.append(o)
@@ -824,7 +825,7 @@ class ComplexCustomUnionTypeWorkflow:
             pydantic_objects,
             start_to_close_timeout=timedelta(minutes=1),
         )
-        return data_classes + pydantic_objects
+        return data_classes + pydantic_objects  # type: ignore
 
 
 async def test_complex_custom_union_type(client: Client):

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -535,7 +535,7 @@ HeterogeneousPydanticModels = Union[
 ]
 
 
-HomogeneousPydanticModels = SpecialTypesModel
+HomogeneousPydanticModels = StandardTypesModel
 
 
 def _assert_datetime_validity(dt: datetime):
@@ -554,7 +554,7 @@ def _assert_timedelta_validity(td: timedelta):
 
 
 def make_homogeneous_list_of_pydantic_objects() -> List[HomogeneousPydanticModels]:
-    objects = [make_special_types_object()]
+    objects = [make_standard_types_object()]
     for o in objects:
         o._check_instance()
     return objects

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -2,7 +2,7 @@ import dataclasses
 import uuid
 from datetime import date, datetime, timedelta
 from ipaddress import IPv4Address
-from typing import Annotated, Any, List, Sequence, Tuple, TypeVar, Union
+from typing import Annotated, Any, List, Sequence, Tuple, TypeVar, Union, get_type_hints
 
 from annotated_types import Len
 from pydantic import BaseModel, Field, WithJsonSchema
@@ -36,6 +36,20 @@ class PydanticModel(BaseModel):
         assert self.str_short_sequence == ["my-string-1", "my-string-2"]
         assert isinstance(self.union_field, str)
         assert self.union_field == "my-string"
+
+        assert get_type_hints(self) == {
+            "ip_field": IPv4Address,
+            "string_field_assigned_field": str,
+            "string_field_with_default": str,
+            "annotated_list_of_str": List[str],
+            "str_short_sequence": List[str],
+            # TODO: why not
+            #     "annotated_list_of_str": Annotated[
+            #         List[str], Field(), WithJsonSchema({"extra": "data"})
+            #     ],
+            #     "str_short_sequence": ShortSequence[List[str]],
+            "union_field": Union[int, str],
+        }
 
 
 class PydanticDatetimeModel(BaseModel):

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -37,7 +37,7 @@ class BasicTypesModel(BaseModel):
     bytes_field: bytes
     none_field: None
 
-    def _check_instance(self):
+    def _check_instance(self) -> None:
         assert isinstance(self.int_field, int)
         assert isinstance(self.float_field, float)
         assert isinstance(self.str_field, str)
@@ -70,7 +70,7 @@ class ComplexTypesModel(BaseModel):
     union_field: Union[str, int]
     optional_field: Optional[str]
 
-    def _check_instance(self):
+    def _check_instance(self) -> None:
         assert isinstance(self.list_field, list)
         assert isinstance(self.dict_field, dict)
         assert isinstance(self.set_field, set)
@@ -104,7 +104,7 @@ class SpecialTypesModel(BaseModel):
     uuid_field: uuid.UUID
     ip_field: IPv4Address
 
-    def _check_instance(self):
+    def _check_instance(self) -> None:
         assert isinstance(self.datetime_field, datetime)
         assert isinstance(self.date_field, date)
         assert isinstance(self.timedelta_field, timedelta)
@@ -139,7 +139,7 @@ class ParentModel(BaseModel):
     child: ChildModel
     children: List[ChildModel]
 
-    def _check_instance(self):
+    def _check_instance(self) -> None:
         assert isinstance(self.child, ChildModel)
         assert isinstance(self.children, list)
         assert all(isinstance(child, ChildModel) for child in self.children)
@@ -170,7 +170,7 @@ class FieldFeaturesModel(BaseModel):
     field_with_constraints: int = Field(gt=0, lt=100)
     field_with_alias: str = Field(alias="different_name")
 
-    def _check_instance(self):
+    def _check_instance(self) -> None:
         assert isinstance(self.field_with_default, str)
         assert isinstance(self.field_with_factory, datetime)
         assert isinstance(self.field_with_constraints, int)
@@ -191,7 +191,7 @@ class AnnotatedFieldsModel(BaseModel):
     max_length_str: Annotated[str, Len(max_length=10)]
     custom_json: Annotated[Dict[str, Any], WithJsonSchema({"extra": "data"})]
 
-    def _check_instance(self):
+    def _check_instance(self) -> None:
         assert isinstance(self.max_length_str, str)
         assert isinstance(self.custom_json, dict)
         assert len(self.max_length_str) <= 10
@@ -213,7 +213,7 @@ class GenericModel(BaseModel, Generic[T]):
     value: T
     values: List[T]
 
-    def _check_instance(self):
+    def _check_instance(self) -> None:
         assert isinstance(self.value, str)
         assert isinstance(self.values, list)
         assert all(isinstance(v, str) for v in self.values)
@@ -367,7 +367,7 @@ PydanticModels = Union[
     ParentModel,
     FieldFeaturesModel,
     AnnotatedFieldsModel,
-    GenericModel,
+    GenericModel[Any],
     PydanticDatetimeModel,
     PydanticDateModel,
     PydanticTimedeltaModel,
@@ -410,8 +410,8 @@ def make_heterogeneous_list_of_pydantic_objects() -> List[PydanticModels]:
         make_pydantic_timedelta_object(),
     ]
     for o in objects:
-        o._check_instance()
-    return objects
+        o._check_instance()  # type: ignore
+    return objects  # type: ignore
 
 
 @activity.defn

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -24,6 +24,7 @@ class PydanticModel(BaseModel):
         List[str], Field(), WithJsonSchema({"extra": "data"})
     ]
     str_short_sequence: ShortSequence[List[str]]
+    union_field: Union[int, str]
 
     def _check_instance(self):
         assert isinstance(self.ip_field, IPv4Address)
@@ -33,6 +34,8 @@ class PydanticModel(BaseModel):
         assert isinstance(self.str_short_sequence, list)
         assert self.annotated_list_of_str == ["my-string-1", "my-string-2"]
         assert self.str_short_sequence == ["my-string-1", "my-string-2"]
+        assert isinstance(self.union_field, str)
+        assert self.union_field == "my-string"
 
 
 class PydanticDatetimeModel(BaseModel):
@@ -155,6 +158,7 @@ def make_homogeneous_list_of_pydantic_objects() -> List[PydanticModel]:
             string_field_assigned_field="my-string",
             annotated_list_of_str=["my-string-1", "my-string-2"],
             str_short_sequence=["my-string-1", "my-string-2"],
+            union_field="my-string",
         ),
     ]
 
@@ -166,6 +170,7 @@ def make_heterogenous_list_of_pydantic_objects() -> List[PydanticModels]:
             string_field_assigned_field="my-string",
             annotated_list_of_str=["my-string-1", "my-string-2"],
             str_short_sequence=["my-string-1", "my-string-2"],
+            union_field="my-string",
         ),
         PydanticDatetimeModel(
             datetime_field=datetime(2000, 1, 2, 3, 4, 5),

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -15,6 +15,7 @@ from typing import (
     Generic,
     Hashable,
     List,
+    NamedTuple,
     Optional,
     Pattern,
     Sequence,
@@ -193,6 +194,11 @@ def make_standard_types_object() -> StandardTypesModel:
     )
 
 
+class Point(NamedTuple):
+    x: int
+    y: int
+
+
 class ComplexTypesModel(BaseModel):
     list_field: List[str]
     dict_field: Dict[str, int]
@@ -200,6 +206,7 @@ class ComplexTypesModel(BaseModel):
     tuple_field: Tuple[str, int]
     union_field: Union[str, int]
     optional_field: Optional[str]
+    named_tuple_field: Point
 
     def _check_instance(self) -> None:
         assert isinstance(self.list_field, list)
@@ -214,6 +221,7 @@ class ComplexTypesModel(BaseModel):
         assert self.tuple_field == ("hello", 42)
         assert self.union_field == "string_or_int"
         assert self.optional_field == "present"
+        assert self.named_tuple_field == Point(x=1, y=2)
 
 
 def make_complex_types_object() -> ComplexTypesModel:
@@ -224,6 +232,7 @@ def make_complex_types_object() -> ComplexTypesModel:
         tuple_field=("hello", 42),
         union_field="string_or_int",
         optional_field="present",
+        named_tuple_field=Point(x=1, y=2),
     )
 
 

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -1,4 +1,3 @@
-import array
 import collections
 import dataclasses
 import decimal
@@ -12,7 +11,6 @@ from pathlib import Path
 from typing import (
     Annotated,
     Any,
-    Callable,
     Dict,
     Generic,
     Hashable,
@@ -76,18 +74,18 @@ class StandardTypesModel(BaseModel):
     set_field: set
     frozenset_field: frozenset
     deque_field: collections.deque
-    array_field: array.array
+    # array_field: array.array
 
     # Mappings
     dict_field: dict
-    defaultdict_field: collections.defaultdict
+    # defaultdict_field: collections.defaultdict
     counter_field: collections.Counter
 
     # Other Types
     pattern_field: Pattern
     hashable_field: Hashable
     any_field: Any
-    callable_field: Callable
+    # callable_field: Callable
 
     def _check_instance(self) -> None:
         # Boolean checks
@@ -130,14 +128,14 @@ class StandardTypesModel(BaseModel):
         assert self.frozenset_field == frozenset([1, 2, 3])
         assert isinstance(self.deque_field, collections.deque)
         assert list(self.deque_field) == [1, 2, 3]
-        assert isinstance(self.array_field, array.array)
-        assert list(self.array_field) == [1, 2, 3]
+        # assert isinstance(self.array_field, array.array)
+        # assert list(self.array_field) == [1, 2, 3]
 
         # Mapping checks
         assert isinstance(self.dict_field, dict)
         assert self.dict_field == {"a": 1, "b": 2}
-        assert isinstance(self.defaultdict_field, collections.defaultdict)
-        assert dict(self.defaultdict_field) == {"a": 1, "b": 2}
+        # assert isinstance(self.defaultdict_field, collections.defaultdict)
+        # assert dict(self.defaultdict_field) == {"a": 1, "b": 2}
         assert isinstance(self.counter_field, collections.Counter)
         assert dict(self.counter_field) == {"a": 1, "b": 2}
 
@@ -147,7 +145,7 @@ class StandardTypesModel(BaseModel):
         assert isinstance(self.hashable_field, Hashable)
         assert self.hashable_field == "test"
         assert self.any_field == "anything goes"
-        assert callable(self.callable_field)
+        # assert callable(self.callable_field)
 
 
 def make_standard_types_object() -> StandardTypesModel:
@@ -174,16 +172,16 @@ def make_standard_types_object() -> StandardTypesModel:
         set_field={1, 2, 3},
         frozenset_field=frozenset([1, 2, 3]),
         deque_field=collections.deque([1, 2, 3]),
-        array_field=array.array("i", [1, 2, 3]),
+        # array_field=array.array("i", [1, 2, 3]),
         # Mappings
         dict_field={"a": 1, "b": 2},
-        defaultdict_field=collections.defaultdict(int, {"a": 1, "b": 2}),
+        # defaultdict_field=collections.defaultdict(int, {"a": 1, "b": 2}),
         counter_field=collections.Counter({"a": 1, "b": 2}),
         # Other Types
         pattern_field=re.compile(r"\d+"),
         hashable_field="test",
         any_field="anything goes",
-        callable_field=lambda x: x,
+        # callable_field=lambda x: x,
     )
 
 

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -233,6 +233,7 @@ class SpecialTypesModel(BaseModel):
     datetime_field_float: datetime
     datetime_field_str_formatted: datetime
     datetime_field_str_int: datetime
+    datetime_field_date: datetime
     date_field: date
     timedelta_field: timedelta
     path_field: Path
@@ -247,7 +248,7 @@ class SpecialTypesModel(BaseModel):
         assert isinstance(self.datetime_field_float, datetime)
         assert isinstance(self.datetime_field_str_formatted, datetime)
         assert isinstance(self.datetime_field_str_int, datetime)
-        assert isinstance(self.date_field, date)
+        assert isinstance(self.datetime_field_date, datetime)
         assert isinstance(self.timedelta_field, timedelta)
         assert isinstance(self.path_field, Path)
         assert isinstance(self.uuid_field, uuid.UUID)
@@ -257,6 +258,7 @@ class SpecialTypesModel(BaseModel):
         assert self.datetime_field_float == dtz
         assert self.datetime_field_str_formatted == dtz
         assert self.datetime_field_str_int == dtz
+        assert self.datetime_field_date == datetime(2000, 1, 2)
         assert self.date_field == date(2000, 1, 2)
         assert self.timedelta_field == timedelta(days=1, hours=2)
         assert self.path_field == Path("test/path")
@@ -272,6 +274,7 @@ def make_special_types_object() -> SpecialTypesModel:
         datetime_field_float=946782245.0,  # type: ignore
         datetime_field_str_formatted="2000-01-02T03:04:05Z",  # type: ignore
         datetime_field_str_int="946782245",  # type: ignore
+        datetime_field_date=datetime(2000, 1, 2),
         date_field=date(2000, 1, 2),
         timedelta_field=timedelta(days=1, hours=2),
         path_field=Path("test/path"),

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -1,15 +1,24 @@
+import array
+import collections
 import dataclasses
+import decimal
+import fractions
+import re
 import uuid
 from datetime import date, datetime, timedelta
+from enum import Enum, IntEnum
 from ipaddress import IPv4Address
 from pathlib import Path
 from typing import (
     Annotated,
     Any,
+    Callable,
     Dict,
     Generic,
+    Hashable,
     List,
     Optional,
+    Pattern,
     Sequence,
     Set,
     Tuple,
@@ -29,36 +38,152 @@ SequenceType = TypeVar("SequenceType", bound=Sequence[Any])
 ShortSequence = Annotated[SequenceType, Len(max_length=2)]
 
 
-class BasicTypesModel(BaseModel):
+class StandardTypesModel(BaseModel):
+    # Boolean
+    bool_field: bool
+
+    # Numbers
     int_field: int
     float_field: float
+    decimal_field: decimal.Decimal
+    complex_field: complex
+    fraction_field: fractions.Fraction
+
+    # Strings and Bytes
     str_field: str
-    bool_field: bool
     bytes_field: bytes
+
+    # None
     none_field: None
 
+    # Enums
+    str_enum_field: Enum
+    int_enum_field: IntEnum
+
+    # Collections
+    list_field: list
+    tuple_field: tuple
+    set_field: set
+    frozenset_field: frozenset
+    deque_field: collections.deque
+    array_field: array.array
+
+    # Mappings
+    dict_field: dict
+    defaultdict_field: collections.defaultdict
+    counter_field: collections.Counter
+
+    # Other Types
+    pattern_field: Pattern
+    hashable_field: Hashable
+    any_field: Any
+    callable_field: Callable
+
     def _check_instance(self) -> None:
-        assert isinstance(self.int_field, int)
-        assert isinstance(self.float_field, float)
-        assert isinstance(self.str_field, str)
+        # Boolean checks
         assert isinstance(self.bool_field, bool)
-        assert isinstance(self.bytes_field, bytes)
-        assert self.none_field is None
-        assert self.int_field == 42
-        assert self.float_field == 3.14
-        assert self.str_field == "hello"
         assert self.bool_field is True
+
+        # Number checks
+        assert isinstance(self.int_field, int)
+        assert self.int_field == 42
+        assert isinstance(self.float_field, float)
+        assert self.float_field == 3.14
+        assert isinstance(self.decimal_field, decimal.Decimal)
+        assert self.decimal_field == decimal.Decimal("3.14")
+        assert isinstance(self.complex_field, complex)
+        assert self.complex_field == complex(1, 2)
+        assert isinstance(self.fraction_field, fractions.Fraction)
+        assert self.fraction_field == fractions.Fraction(22, 7)
+
+        # String and Bytes checks
+        assert isinstance(self.str_field, str)
+        assert self.str_field == "hello"
+        assert isinstance(self.bytes_field, bytes)
         assert self.bytes_field == b"world"
 
+        # None check
+        assert self.none_field is None
 
-def make_basic_types_object() -> BasicTypesModel:
-    return BasicTypesModel(
+        # Enum checks
+        assert isinstance(self.str_enum_field, Enum)
+        assert isinstance(self.int_enum_field, IntEnum)
+
+        # Collection checks
+        assert isinstance(self.list_field, list)
+        assert self.list_field == [1, 2, 3]
+        assert isinstance(self.tuple_field, tuple)
+        assert self.tuple_field == (1, 2, 3)
+        assert isinstance(self.set_field, set)
+        assert self.set_field == {1, 2, 3}
+        assert isinstance(self.frozenset_field, frozenset)
+        assert self.frozenset_field == frozenset([1, 2, 3])
+        assert isinstance(self.deque_field, collections.deque)
+        assert list(self.deque_field) == [1, 2, 3]
+        assert isinstance(self.array_field, array.array)
+        assert list(self.array_field) == [1, 2, 3]
+
+        # Mapping checks
+        assert isinstance(self.dict_field, dict)
+        assert self.dict_field == {"a": 1, "b": 2}
+        assert isinstance(self.defaultdict_field, collections.defaultdict)
+        assert dict(self.defaultdict_field) == {"a": 1, "b": 2}
+        assert isinstance(self.counter_field, collections.Counter)
+        assert dict(self.counter_field) == {"a": 1, "b": 2}
+
+        # Other type checks
+        assert isinstance(self.pattern_field, Pattern)
+        assert self.pattern_field.pattern == r"\d+"
+        assert isinstance(self.hashable_field, Hashable)
+        assert self.hashable_field == "test"
+        assert self.any_field == "anything goes"
+        assert callable(self.callable_field)
+
+
+class FruitEnum(str, Enum):
+    apple = "apple"
+    banana = "banana"
+
+
+class NumberEnum(IntEnum):
+    one = 1
+    two = 2
+
+
+def make_standard_types_object() -> StandardTypesModel:
+    return StandardTypesModel(
+        # Boolean
+        bool_field=True,
+        # Numbers
         int_field=42,
         float_field=3.14,
+        decimal_field=decimal.Decimal("3.14"),
+        complex_field=complex(1, 2),
+        fraction_field=fractions.Fraction(22, 7),
+        # Strings and Bytes
         str_field="hello",
-        bool_field=True,
         bytes_field=b"world",
+        # None
         none_field=None,
+        # Enums
+        str_enum_field=FruitEnum.apple,
+        int_enum_field=NumberEnum.one,
+        # Collections
+        list_field=[1, 2, 3],
+        tuple_field=(1, 2, 3),
+        set_field={1, 2, 3},
+        frozenset_field=frozenset([1, 2, 3]),
+        deque_field=collections.deque([1, 2, 3]),
+        array_field=array.array("i", [1, 2, 3]),
+        # Mappings
+        dict_field={"a": 1, "b": 2},
+        defaultdict_field=collections.defaultdict(int, {"a": 1, "b": 2}),
+        counter_field=collections.Counter({"a": 1, "b": 2}),
+        # Other Types
+        pattern_field=re.compile(r"\d+"),
+        hashable_field="test",
+        any_field="anything goes",
+        callable_field=lambda x: x,
     )
 
 
@@ -361,7 +486,6 @@ def make_pydantic_timedelta_object() -> PydanticTimedeltaModel:
 
 
 PydanticModels = Union[
-    BasicTypesModel,
     ComplexTypesModel,
     SpecialTypesModel,
     ParentModel,
@@ -398,7 +522,7 @@ def make_homogeneous_list_of_pydantic_objects() -> List[PydanticDatetimeModel]:
 
 def make_heterogeneous_list_of_pydantic_objects() -> List[PydanticModels]:
     objects = [
-        make_basic_types_object(),
+        make_standard_types_object(),
         make_complex_types_object(),
         make_special_types_object(),
         make_nested_object(),

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -4,7 +4,7 @@ import decimal
 import fractions
 import re
 import uuid
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from enum import Enum, IntEnum
 from ipaddress import IPv4Address
 from pathlib import Path
@@ -234,6 +234,10 @@ class SpecialTypesModel(BaseModel):
     datetime_field_str_formatted: datetime
     datetime_field_str_int: datetime
     datetime_field_date: datetime
+
+    time_field: time
+    time_field_str: time
+
     date_field: date
     timedelta_field: timedelta
     path_field: Path
@@ -259,6 +263,8 @@ class SpecialTypesModel(BaseModel):
         assert self.datetime_field_str_formatted == dtz
         assert self.datetime_field_str_int == dtz
         assert self.datetime_field_date == datetime(2000, 1, 2)
+        assert self.time_field == time(3, 4, 5)
+        assert self.time_field_str == time(3, 4, 5, tzinfo=timezone.utc)
         assert self.date_field == date(2000, 1, 2)
         assert self.timedelta_field == timedelta(days=1, hours=2)
         assert self.path_field == Path("test/path")
@@ -275,6 +281,8 @@ def make_special_types_object() -> SpecialTypesModel:
         datetime_field_str_formatted="2000-01-02T03:04:05Z",  # type: ignore
         datetime_field_str_int="946782245",  # type: ignore
         datetime_field_date=datetime(2000, 1, 2),
+        time_field=time(3, 4, 5),
+        time_field_str="03:04:05Z",  # type: ignore
         date_field=date(2000, 1, 2),
         timedelta_field=timedelta(days=1, hours=2),
         path_field=Path("test/path"),

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -422,6 +422,24 @@ def make_generic_string_object() -> GenericModel[str]:
     )
 
 
+class UnionModel(BaseModel):
+    simple_union_field: Union[str, int]
+    proxied_union_field: Union[datetime, Path]
+
+    def _check_instance(self) -> None:
+        assert isinstance(self.simple_union_field, str)
+        assert self.simple_union_field == "string_or_int"
+        assert isinstance(self.proxied_union_field, Path)
+        assert self.proxied_union_field == Path("test/path")
+
+
+def make_union_object() -> UnionModel:
+    return UnionModel(
+        simple_union_field="string_or_int",
+        proxied_union_field=Path("test/path"),
+    )
+
+
 class PydanticDatetimeModel(BaseModel):
     datetime_field: datetime
     datetime_field_assigned_field: datetime = Field()
@@ -562,6 +580,7 @@ PydanticModels = Union[
     FieldFeaturesModel,
     AnnotatedFieldsModel,
     GenericModel[Any],
+    UnionModel,
     PydanticDatetimeModel,
     PydanticDateModel,
     PydanticTimedeltaModel,
@@ -592,6 +611,7 @@ def make_list_of_pydantic_objects() -> List[PydanticModels]:
         make_field_features_object(),
         make_annotated_fields_object(),
         make_generic_string_object(),
+        make_union_object(),
         make_pydantic_datetime_object(),
         make_pydantic_date_object(),
         make_pydantic_timedelta_object(),

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -27,6 +27,7 @@ from typing import (
 
 from annotated_types import Len
 from pydantic import BaseModel, Field, WithJsonSchema
+from typing_extensions import TypedDict
 
 from temporalio import activity, workflow
 from temporalio.client import Client
@@ -45,6 +46,11 @@ class FruitEnum(str, Enum):
 class NumberEnum(IntEnum):
     one = 1
     two = 2
+
+
+class UserTypedDict(TypedDict):
+    name: str
+    id: int
 
 
 class StandardTypesModel(BaseModel):
@@ -84,6 +90,7 @@ class StandardTypesModel(BaseModel):
     dict_field: dict
     # defaultdict_field: collections.defaultdict
     counter_field: collections.Counter
+    typed_dict_field: UserTypedDict
 
     # Other Types
     pattern_field: Pattern
@@ -146,6 +153,8 @@ class StandardTypesModel(BaseModel):
         # assert dict(self.defaultdict_field) == {"a": 1, "b": 2}
         assert isinstance(self.counter_field, collections.Counter)
         assert dict(self.counter_field) == {"a": 1, "b": 2}
+        assert isinstance(self.typed_dict_field, dict)
+        assert self.typed_dict_field == {"name": "username", "id": 7}
 
         # Other type checks
         assert isinstance(self.pattern_field, Pattern)
@@ -188,6 +197,7 @@ def make_standard_types_object() -> StandardTypesModel:
         dict_field={"a": 1, "b": 2},
         # defaultdict_field=collections.defaultdict(int, {"a": 1, "b": 2}),
         counter_field=collections.Counter({"a": 1, "b": 2}),
+        typed_dict_field={"name": "username", "id": 7},
         # Other Types
         pattern_field=re.compile(r"\d+"),
         hashable_field="test",

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -77,6 +77,7 @@ class StandardTypesModel(BaseModel):
     set_field: set
     frozenset_field: frozenset
     deque_field: collections.deque
+    sequence_field: Sequence[int]
     # array_field: array.array
 
     # Mappings
@@ -135,6 +136,8 @@ class StandardTypesModel(BaseModel):
         assert self.frozenset_field == frozenset([1, 2, 3])
         assert isinstance(self.deque_field, collections.deque)
         assert list(self.deque_field) == [1, 2, 3]
+        assert isinstance(self.sequence_field, tuple)
+        assert list(self.sequence_field) == [1, 2, 3]
         # assert isinstance(self.array_field, array.array)
         # assert list(self.array_field) == [1, 2, 3]
 
@@ -181,6 +184,7 @@ def make_standard_types_object() -> StandardTypesModel:
         set_field={1, 2, 3},
         frozenset_field=frozenset([1, 2, 3]),
         deque_field=collections.deque([1, 2, 3]),
+        sequence_field=(1, 2, 3),
         # array_field=array.array("i", [1, 2, 3]),
         # Mappings
         dict_field={"a": 1, "b": 2},

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -78,7 +78,7 @@ class StandardTypesModel(BaseModel):
     frozenset_field: frozenset
     deque_field: collections.deque
     sequence_field: Sequence[int]
-    # array_field: array.array
+    # Iterable[int] supported but not tested since original vs round-tripped do not compare equal
 
     # Mappings
     dict_field: dict
@@ -136,10 +136,8 @@ class StandardTypesModel(BaseModel):
         assert self.frozenset_field == frozenset([1, 2, 3])
         assert isinstance(self.deque_field, collections.deque)
         assert list(self.deque_field) == [1, 2, 3]
-        assert isinstance(self.sequence_field, tuple)
+        assert isinstance(self.sequence_field, list)
         assert list(self.sequence_field) == [1, 2, 3]
-        # assert isinstance(self.array_field, array.array)
-        # assert list(self.array_field) == [1, 2, 3]
 
         # Mapping checks
         assert isinstance(self.dict_field, dict)
@@ -184,8 +182,8 @@ def make_standard_types_object() -> StandardTypesModel:
         set_field={1, 2, 3},
         frozenset_field=frozenset([1, 2, 3]),
         deque_field=collections.deque([1, 2, 3]),
-        sequence_field=(1, 2, 3),
-        # array_field=array.array("i", [1, 2, 3]),
+        # other sequence types are converted to list, as documented
+        sequence_field=[1, 2, 3],
         # Mappings
         dict_field={"a": 1, "b": 2},
         # defaultdict_field=collections.defaultdict(int, {"a": 1, "b": 2}),

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -4,7 +4,7 @@ import decimal
 import fractions
 import re
 import uuid
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from enum import Enum, IntEnum
 from ipaddress import IPv4Address
 from pathlib import Path
@@ -229,6 +229,10 @@ def make_complex_types_object() -> ComplexTypesModel:
 
 class SpecialTypesModel(BaseModel):
     datetime_field: datetime
+    datetime_field_int: datetime
+    datetime_field_float: datetime
+    datetime_field_str_formatted: datetime
+    datetime_field_str_int: datetime
     date_field: date
     timedelta_field: timedelta
     path_field: Path
@@ -236,13 +240,23 @@ class SpecialTypesModel(BaseModel):
     ip_field: IPv4Address
 
     def _check_instance(self) -> None:
+        dt = datetime(2000, 1, 2, 3, 4, 5)
+        dtz = datetime(2000, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
         assert isinstance(self.datetime_field, datetime)
+        assert isinstance(self.datetime_field_int, datetime)
+        assert isinstance(self.datetime_field_float, datetime)
+        assert isinstance(self.datetime_field_str_formatted, datetime)
+        assert isinstance(self.datetime_field_str_int, datetime)
         assert isinstance(self.date_field, date)
         assert isinstance(self.timedelta_field, timedelta)
         assert isinstance(self.path_field, Path)
         assert isinstance(self.uuid_field, uuid.UUID)
         assert isinstance(self.ip_field, IPv4Address)
-        assert self.datetime_field == datetime(2000, 1, 2, 3, 4, 5)
+        assert self.datetime_field == dt
+        assert self.datetime_field_int == dtz
+        assert self.datetime_field_float == dtz
+        assert self.datetime_field_str_formatted == dtz
+        assert self.datetime_field_str_int == dtz
         assert self.date_field == date(2000, 1, 2)
         assert self.timedelta_field == timedelta(days=1, hours=2)
         assert self.path_field == Path("test/path")
@@ -253,6 +267,11 @@ class SpecialTypesModel(BaseModel):
 def make_special_types_object() -> SpecialTypesModel:
     return SpecialTypesModel(
         datetime_field=datetime(2000, 1, 2, 3, 4, 5),
+        # 946800245
+        datetime_field_int=946782245,  # type: ignore
+        datetime_field_float=946782245.0,  # type: ignore
+        datetime_field_str_formatted="2000-01-02T03:04:05Z",  # type: ignore
+        datetime_field_str_int="946782245",  # type: ignore
         date_field=date(2000, 1, 2),
         timedelta_field=timedelta(days=1, hours=2),
         path_field=Path("test/path"),

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -694,7 +694,7 @@ async def test_round_trip_pydantic_objects(client: Client):
     client = Client(**new_config)
     task_queue_name = str(uuid.uuid4())
 
-    orig_pydantic_objects = make_list_of_pydantic_objects()
+    orig_objects = make_list_of_pydantic_objects()
 
     async with Worker(
         client,
@@ -702,14 +702,14 @@ async def test_round_trip_pydantic_objects(client: Client):
         workflows=[RoundTripObjectsWorkflow],
         activities=[pydantic_models_activity],
     ):
-        round_tripped_pydantic_objects = await client.execute_workflow(
+        returned_objects = await client.execute_workflow(
             RoundTripObjectsWorkflow.run,
-            orig_pydantic_objects,
+            orig_objects,
             id=str(uuid.uuid4()),
             task_queue=task_queue_name,
         )
-    assert orig_pydantic_objects == round_tripped_pydantic_objects
-    for o in round_tripped_pydantic_objects:
+    assert returned_objects == orig_objects
+    for o in returned_objects:
         o._check_instance()
 
 
@@ -723,21 +723,21 @@ async def test_clone_objects_in_sandbox(client: Client):
     client = Client(**new_config)
     task_queue_name = str(uuid.uuid4())
 
-    orig_pydantic_objects = make_list_of_pydantic_objects()
+    orig_objects = make_list_of_pydantic_objects()
 
     async with Worker(
         client,
         task_queue=task_queue_name,
         workflows=[CloneObjectsWorkflow],
     ):
-        round_tripped_pydantic_objects = await client.execute_workflow(
+        returned_objects = await client.execute_workflow(
             CloneObjectsWorkflow.run,
-            orig_pydantic_objects,
+            orig_objects,
             id=str(uuid.uuid4()),
             task_queue=task_queue_name,
         )
-    assert round_tripped_pydantic_objects == orig_pydantic_objects
-    for o in round_tripped_pydantic_objects:
+    assert returned_objects == orig_objects
+    for o in returned_objects:
         o._check_instance()
 
 
@@ -786,17 +786,17 @@ async def test_complex_custom_type(client: Client):
         activities=[pydantic_models_activity],
     ):
         (
-            round_tripped_dataclass_objects,
-            round_tripped_pydantic_objects,
+            returned_dataclass_objects,
+            returned_pydantic_objects,
         ) = await client.execute_workflow(
             ComplexCustomTypeWorkflow.run,
             (orig_dataclass_objects, orig_pydantic_objects),
             id=str(uuid.uuid4()),
             task_queue=task_queue_name,
         )
-    assert orig_dataclass_objects == round_tripped_dataclass_objects
-    assert orig_pydantic_objects == round_tripped_pydantic_objects
-    for o in round_tripped_pydantic_objects:
+    assert orig_dataclass_objects == returned_dataclass_objects
+    assert orig_pydantic_objects == returned_pydantic_objects
+    for o in returned_pydantic_objects:
         o._check_instance()
 
 
@@ -845,25 +845,25 @@ async def test_complex_custom_union_type(client: Client):
         workflows=[ComplexCustomUnionTypeWorkflow],
         activities=[pydantic_models_activity],
     ):
-        round_tripped_objects = await client.execute_workflow(
+        returned_objects = await client.execute_workflow(
             ComplexCustomUnionTypeWorkflow.run,
             orig_objects,
             id=str(uuid.uuid4()),
             task_queue=task_queue_name,
         )
-    round_tripped_dataclass_objects, round_tripped_pydantic_objects = [], []
-    for o in round_tripped_objects:
+    returned_dataclass_objects, returned_pydantic_objects = [], []
+    for o in returned_objects:
         if isinstance(o, MyDataClass):
-            round_tripped_dataclass_objects.append(o)
+            returned_dataclass_objects.append(o)
         elif isinstance(o, BaseModel):
-            round_tripped_pydantic_objects.append(o)
+            returned_pydantic_objects.append(o)
         else:
             raise TypeError(f"Unexpected type: {type(o)}")
-    assert sorted(orig_dataclass_objects) == sorted(round_tripped_dataclass_objects)
+    assert sorted(orig_dataclass_objects) == sorted(returned_dataclass_objects)
     assert sorted(orig_pydantic_objects, key=lambda o: o.__class__.__name__) == sorted(
-        round_tripped_pydantic_objects, key=lambda o: o.__class__.__name__
+        returned_pydantic_objects, key=lambda o: o.__class__.__name__
     )
-    for o in round_tripped_pydantic_objects:
+    for o in returned_pydantic_objects:
         o._check_instance()
 
 

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -2,6 +2,7 @@ import dataclasses
 import uuid
 from datetime import date, datetime, timedelta
 from ipaddress import IPv4Address
+from pathlib import Path
 from typing import (
     Annotated,
     Any,
@@ -100,7 +101,7 @@ class SpecialTypesModel(BaseModel):
     datetime_field: datetime
     date_field: date
     timedelta_field: timedelta
-    # path_field: Path
+    path_field: Path
     uuid_field: uuid.UUID
     ip_field: IPv4Address
 
@@ -108,13 +109,13 @@ class SpecialTypesModel(BaseModel):
         assert isinstance(self.datetime_field, datetime)
         assert isinstance(self.date_field, date)
         assert isinstance(self.timedelta_field, timedelta)
-        # assert isinstance(self.path_field, Path)
+        assert isinstance(self.path_field, Path)
         assert isinstance(self.uuid_field, uuid.UUID)
         assert isinstance(self.ip_field, IPv4Address)
         assert self.datetime_field == datetime(2000, 1, 2, 3, 4, 5)
         assert self.date_field == date(2000, 1, 2)
         assert self.timedelta_field == timedelta(days=1, hours=2)
-        # assert self.path_field == Path("test/path")
+        assert self.path_field == Path("test/path")
         assert self.uuid_field == uuid.UUID("12345678-1234-5678-1234-567812345678")
         assert self.ip_field == IPv4Address("127.0.0.1")
 
@@ -124,7 +125,7 @@ def make_special_types_object() -> SpecialTypesModel:
         datetime_field=datetime(2000, 1, 2, 3, 4, 5),
         date_field=date(2000, 1, 2),
         timedelta_field=timedelta(days=1, hours=2),
-        # path_field=Path("test/path"),
+        path_field=Path("test/path"),
         uuid_field=uuid.UUID("12345678-1234-5678-1234-567812345678"),
         ip_field=IPv4Address("127.0.0.1"),
     )

--- a/tests/contrib/test_pydantic.py
+++ b/tests/contrib/test_pydantic.py
@@ -505,7 +505,7 @@ HeterogeneousPydanticModels = Union[
 ]
 
 
-HomogeneousPydanticModels = StandardTypesModel
+HomogeneousPydanticModels = SpecialTypesModel
 
 
 def _assert_datetime_validity(dt: datetime):
@@ -524,7 +524,7 @@ def _assert_timedelta_validity(td: timedelta):
 
 
 def make_homogeneous_list_of_pydantic_objects() -> List[HomogeneousPydanticModels]:
-    objects = [make_standard_types_object()]
+    objects = [make_special_types_object()]
     for o in objects:
         o._check_instance()
     return objects

--- a/tests/worker/workflow_sandbox/test_restrictions.py
+++ b/tests/worker/workflow_sandbox/test_restrictions.py
@@ -91,8 +91,9 @@ def test_restricted_proxy_dunder_methods():
     assert isinstance(format(restricted_path, ""), str)
     restricted_path_obj = restricted_path("test/path")
     assert type(restricted_path_obj) is _RestrictedProxy
-    assert format(restricted_path_obj, "") == "test/path"
-    assert f"{restricted_path_obj}" == "test/path"
+    expected_path = str(pathlib.PurePath("test/path"))
+    assert format(restricted_path_obj, "") == expected_path
+    assert f"{restricted_path_obj}" == expected_path
 
 
 def test_workflow_sandbox_restricted_proxy():

--- a/tests/worker/workflow_sandbox/test_restrictions.py
+++ b/tests/worker/workflow_sandbox/test_restrictions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pathlib
 import sys
 from dataclasses import dataclass
 from typing import ClassVar, Dict, Optional
@@ -28,7 +29,7 @@ def test_workflow_sandbox_stdlib_module_names():
         if len(code_lines[-1]) > 80:
             code_lines.append("")
         code_lines[-1] += mod_name
-    code = f'_stdlib_module_names = (\n    "' + '"\n    "'.join(code_lines) + '"\n)'
+    code = '_stdlib_module_names = (\n    "' + '"\n    "'.join(code_lines) + '"\n)'
     # TODO(cretz): Point releases may add modules :-(
     assert (
         actual_names == _stdlib_module_names
@@ -54,6 +55,44 @@ class RestrictableObject:
 
 
 RestrictableObject.qux = RestrictableObject(foo=RestrictableObject(bar=70), bar=80)
+
+
+class RestrictableClass:
+    def __str__(self):
+        return "__str__"
+
+    def __repr__(self):
+        return "__repr__"
+
+    def __format__(self, __format_spec: str) -> str:
+        return "__format__"
+
+
+def test_restricted_proxy_dunder_methods():
+    restricted_class = _RestrictedProxy(
+        "RestrictableClass",
+        RestrictableClass,
+        RestrictionContext(),
+        SandboxMatcher(),
+    )
+    restricted_obj = restricted_class()
+    assert type(restricted_obj) is _RestrictedProxy
+    assert str(restricted_obj) == "__str__"
+    assert repr(restricted_obj) == "__repr__"
+    assert format(restricted_obj, "") == "__format__"
+    assert f"{restricted_obj}" == "__format__"
+
+    restricted_path = _RestrictedProxy(
+        "Path",
+        pathlib.Path,
+        RestrictionContext(),
+        SandboxMatcher(),
+    )
+    assert isinstance(format(restricted_path, ""), str)
+    restricted_path_obj = restricted_path("test/path")
+    assert type(restricted_path_obj) is _RestrictedProxy
+    assert format(restricted_path_obj, "") == "test/path"
+    assert f"{restricted_path_obj}" == "test/path"
 
 
 def test_workflow_sandbox_restricted_proxy():

--- a/tests/worker/workflow_sandbox/test_runner.py
+++ b/tests/worker/workflow_sandbox/test_runner.py
@@ -14,7 +14,6 @@ from typing import Callable, Dict, List, Optional, Sequence, Set, Type
 
 import pytest
 
-import temporalio.worker.workflow_sandbox._restrictions
 from temporalio import activity, workflow
 from temporalio.client import Client, WorkflowFailureError, WorkflowHandle
 from temporalio.exceptions import ApplicationError
@@ -262,10 +261,6 @@ async def test_workflow_sandbox_restrictions(client: Client):
 class DateOperatorWorkflow:
     @workflow.run
     async def run(self) -> int:
-        assert (
-            type(date(2010, 1, 20))
-            == temporalio.worker.workflow_sandbox._restrictions._RestrictedProxy
-        )
         return (date(2010, 1, 20) - date(2010, 1, 1)).days
 
 


### PR DESCRIPTION
Fixes https://github.com/temporalio/sdk-python/issues/621, https://github.com/temporalio/sdk-python/issues/496

- Provide official pydantic support in a new module `temporalio.contrib.pydantic`.
- This support is based on `v2`, but we do retain the existing code that should allow `v1` to still be used.
- Due to our wrapping of the `datetime.datetime` class, and `datetime.datetime` instances, with proxy objects, we have to unwrap proxied objects to allow pydantic to work correctly.

See also https://github.com/temporalio/sdk-python/issues/627, https://github.com/temporalio/sdk-python/issues/207

TODO:
- [x] manually test `v1` usage via sample

Accompanying samples PR: https://github.com/temporalio/samples-python/pull/163
