### PR TITLE
Fix docstring for `workflow.defn`'s `dynamic` argument

### DIFF
--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -129,7 +129,7 @@ def defn(
             cannot be set if dynamic is set.
         sandboxed: Whether the workflow should run in a sandbox. Default is
             true.
-        dynamic: If true, this activity will be dynamic. Dynamic workflows have
+        dynamic: If true, this workflow will be dynamic. Dynamic workflows have
             to accept a single 'Sequence[RawValue]' parameter. This cannot be
             set to true if name is present.
         failure_exception_types: The types of exceptions that, if a


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

This CL fix the docstring for the `dynamic` argument of the `workflow.defn` function, replacing one occurrence of `activity` by `workflow` to better reflect the usage of such attribute. I assume that was leftover of some copy'n'paste.

## Why?

`workflow.defn` is used to decorate a workflow class, not an activity.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here --> ✅
   None

3. How was this tested: ✅
   No tests necessary, I guess.
<!--- Please describe how you tested your changes/how we can test them -->

5. Any docs updates needed? ✅
   All good here too.
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

Valeu pelo Temporal, turma! Ele faz miséria! <3 