### PR TITLE
Fixing indent issue with kwargs["extra"]

### DIFF
--- a/temporalio/workflow/_sandbox.py
+++ b/temporalio/workflow/_sandbox.py
@@ -268,7 +268,7 @@ class LoggerAdapter(logging.LoggerAdapter):
                 else None,
             )
 
-        kwargs["extra"] = {**extra, **(kwargs.get("extra") or {})}
+            kwargs["extra"] = {**extra, **(kwargs.get("extra") or {})}
         if msg_extra:
             msg = f"{msg} ({msg_extra})"
         return msg, kwargs

--- a/temporalio/workflow/_sandbox.py
+++ b/temporalio/workflow/_sandbox.py
@@ -269,8 +269,8 @@ class LoggerAdapter(logging.LoggerAdapter):
             )
 
             kwargs["extra"] = {**extra, **(kwargs.get("extra") or {})}
-        if msg_extra:
-            msg = f"{msg} ({msg_extra})"
+            if msg_extra:
+                msg = f"{msg} ({msg_extra})"
         return msg, kwargs
 
     def log(

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -2242,8 +2242,27 @@ class LoggingWorkflow:
         return self._last_signal
 
 
-async def test_workflow_logging(client: Client):
-    workflow.logger.full_workflow_info_on_extra = True
+@pytest.mark.parametrize(
+    "with_workflow_info",
+    [True, False],
+)
+async def test_workflow_logging(client: Client, with_workflow_info: bool):
+    orig_on_message = workflow.logger.workflow_info_on_message
+    orig_on_extra = workflow.logger.workflow_info_on_extra
+    orig_full_on_extra = workflow.logger.full_workflow_info_on_extra
+
+    try:
+        workflow.logger.workflow_info_on_message = with_workflow_info
+        workflow.logger.workflow_info_on_extra = with_workflow_info
+        workflow.logger.full_workflow_info_on_extra = with_workflow_info
+        await _do_workflow_logging_test(client, with_workflow_info)
+    finally:
+        workflow.logger.workflow_info_on_message = orig_on_message
+        workflow.logger.workflow_info_on_extra = orig_on_extra
+        workflow.logger.full_workflow_info_on_extra = orig_full_on_extra
+
+
+async def _do_workflow_logging_test(client: Client, with_workflow_info: bool):
     with LogCapturer().logs_captured(
         workflow.logger.base_logger, activity.logger.base_logger
     ) as capturer:
@@ -2270,31 +2289,43 @@ async def test_workflow_logging(client: Client):
             assert "signal 2" == await handle.query(LoggingWorkflow.last_signal)
 
         # Confirm logs were produced
-        assert capturer.find_log("Signal: signal 1 ({'attempt':")
+        assert capturer.find_log("Signal: signal 1")
         assert capturer.find_log("Signal: signal 2")
         assert capturer.find_log("Update: update 1")
         assert capturer.find_log("Update: update 2")
         assert capturer.find_log("Query called")
         assert not capturer.find_log("Signal: signal 3")
-        # Also make sure it has some workflow info and correct funcName
-        record = capturer.find_log("Signal: signal 1")
-        assert (
-            record
-            and record.__dict__["temporal_workflow"]["workflow_type"]
-            == "LoggingWorkflow"
-            and record.funcName == "my_signal"
-        )
-        # Since we enabled full info, make sure it's there
-        assert isinstance(record.__dict__["workflow_info"], workflow.Info)
-        # Check the log emitted by the update execution.
-        record = capturer.find_log("Update: update 1")
-        assert (
-            record
-            and record.__dict__["temporal_workflow"]["update_id"] == "update-1"
-            and record.__dict__["temporal_workflow"]["update_name"] == "my_update"
-            and "'update_id': 'update-1'" in record.message
-            and "'update_name': 'my_update'" in record.message
-        )
+
+        if with_workflow_info:
+            record = capturer.find_log("Signal: signal 1 ({'attempt':")
+            assert (
+                record
+                and record.__dict__["temporal_workflow"]["workflow_type"]
+                == "LoggingWorkflow"
+                and record.funcName == "my_signal"
+            )
+            # Since we enabled full info, make sure it's there
+            assert isinstance(record.__dict__["workflow_info"], workflow.Info)
+
+            # Check the log emitted by the update execution.
+            record = capturer.find_log("Update: update 1")
+            assert (
+                record
+                and record.__dict__["temporal_workflow"]["update_id"] == "update-1"
+                and record.__dict__["temporal_workflow"]["update_name"] == "my_update"
+                and "'update_id': 'update-1'" in record.message
+                and "'update_name': 'my_update'" in record.message
+            )
+        else:
+            record = capturer.find_log("Signal: signal 1")
+            assert record and "temporal_workflow" not in record.__dict__
+            assert record and "workflow_info" not in record.__dict__
+
+            record = capturer.find_log("Update: update 1")
+            assert record and "temporal_workflow" not in record.__dict__
+            assert record and "workflow_info" not in record.__dict__
+            assert "'update_id': 'update-1'" not in record.message
+            assert "'update_name': 'my_update'" not in record.message
 
         # Clear queue and start a new one with more signals
         capturer.log_queue.queue.clear()


### PR DESCRIPTION
## What was changed
Fixing the indent the setting of `kwargs["extra"]` in the process method.

## Why?
When you set `workflow.logger.workflow_info_on_extra = False` it caused the Workflow to fail with the error

```
  File "/Users/masonegger/Code/Temporal/edu-102-python-code/venv/lib/python3.13/site-packages/temporalio/worker/_workflow_instance.py", line 391, in activate
    self._run_once(check_conditions=index == 1 or index == 2)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/Users/masonegger/Code/Temporal/edu-102-python-code/venv/lib/python3.13/site-packages/temporalio/worker/_workflow_instance.py", line 1857, in _run_once
    raise self._current_activation_error

  File "/Users/masonegger/Code/Temporal/edu-102-python-code/venv/lib/python3.13/site-packages/temporalio/worker/_workflow_instance.py", line 1875, in _run_top_level_workflow_function
    await coro

  File "/Users/masonegger/Code/Temporal/edu-102-python-code/venv/lib/python3.13/site-packages/temporalio/worker/_workflow_instance.py", line 872, in run_workflow
    result = await self._inbound.execute_workflow(input)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/Users/masonegger/Code/Temporal/edu-102-python-code/venv/lib/python3.13/site-packages/temporalio/worker/_workflow_instance.py", line 2256, in execute_workflow
    return await input.run_fn(*args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/Users/masonegger/Code/Temporal/edu-102-python-code/exercises/durable-execution/solution/workflow.py", line 24, in run
    workflow.logger.info(f"TranslationWorkflow invoked with")
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/logging/__init__.py", line 1906, in info
    self.log(INFO, msg, *args, **kwargs)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/logging/__init__.py", line 1943, in log
    msg, kwargs = self.process(msg, kwargs)
                  ~~~~~~~~~~~~^^^^^^^^^^^^^

  File "/Users/masonegger/Code/Temporal/edu-102-python-code/venv/lib/python3.13/site-packages/temporalio/workflow.py", line 1364, in process
    kwargs["extra"] = {**extra, **(kwargs.get("extra") or {})}
                         ^^^^^
```
