### PR TITLE
Improve workflow task deadlock and eviction

### DIFF
--- a/temporalio/worker/_worker.py
+++ b/temporalio/worker/_worker.py
@@ -109,9 +109,10 @@ class Worker:
             workflow_task_executor: Thread pool executor for workflow tasks. If
                 this is not present, a new
                 :py:class:`concurrent.futures.ThreadPoolExecutor` will be
-                created with ``max_workers`` set to ``max(os.cpu_count(), 4)``.
-                The default one will be properly shutdown, but if one is
-                provided, the caller is responsible for shutting it down after
+                created with ``max_workers`` set to
+                ``max_concurrent_workflow_tasks`` if it is present, or 500
+                otherwise. The default one will be properly shutdown, but if one
+                is provided, the caller is responsible for shutting it down after
                 the worker is shut down.
             workflow_runner: Runner for workflows.
             unsandboxed_workflow_runner: Runner for workflows that opt-out of
@@ -312,6 +313,7 @@ class Worker:
                 task_queue=task_queue,
                 workflows=workflows,
                 workflow_task_executor=workflow_task_executor,
+                max_concurrent_workflow_tasks=max_concurrent_workflow_tasks,
                 workflow_runner=workflow_runner,
                 unsandboxed_workflow_runner=unsandboxed_workflow_runner,
                 data_converter=client_config["data_converter"],

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -44,6 +44,23 @@ def new_worker(
     )
 
 
+async def assert_eventually(
+    fn: Callable[[], Awaitable],
+    *,
+    timeout: timedelta = timedelta(seconds=10),
+    interval: timedelta = timedelta(milliseconds=200),
+) -> None:
+    start_sec = time.monotonic()
+    while True:
+        try:
+            await fn()
+            return
+        except AssertionError:
+            if timedelta(seconds=time.monotonic() - start_sec) >= timeout:
+                raise
+        await asyncio.sleep(interval.total_seconds())
+
+
 T = TypeVar("T")
 
 
@@ -54,16 +71,26 @@ async def assert_eq_eventually(
     timeout: timedelta = timedelta(seconds=10),
     interval: timedelta = timedelta(milliseconds=200),
 ) -> None:
-    start_sec = time.monotonic()
-    last_value = None
-    while timedelta(seconds=time.monotonic() - start_sec) < timeout:
-        last_value = await fn()
-        if expected == last_value:
-            return
-        await asyncio.sleep(interval.total_seconds())
-    assert (
-        expected == last_value
-    ), f"timed out waiting for equal, asserted against last value of {last_value}"
+    async def check() -> None:
+        assert expected == await fn()
+
+    await assert_eventually(check, timeout=timeout, interval=interval)
+
+
+async def assert_task_fail_eventually(
+    handle: WorkflowHandle, *, message_contains: Optional[str] = None
+) -> None:
+    async def check() -> None:
+        async for evt in handle.fetch_history_events():
+            if evt.HasField("workflow_task_failed_event_attributes") and (
+                not message_contains
+                or message_contains
+                in evt.workflow_task_failed_event_attributes.failure.message
+            ):
+                return
+        assert False, "Task failure not present"
+
+    await assert_eventually(check)
 
 
 async def worker_versioning_enabled(client: Client) -> bool:


### PR DESCRIPTION
## What was changed

TL;DR - Fixed issue where on deadlock and/or eviction fail, slot/thread could never recover and thread pool could starve even if issues resolved themselves later. Also gave deadlocked threads a bit of a poke to unstick them.

---

There are issues where deadlocking or eviction-swallowing code eats up both workflow task slots and workflow executor threads. This issue makes some changes to help these situations.

Before this PR (i.e. today as of this writing), we have the following behavior:

* Default workflow task thread pool max size is `max(os.cpu_count(), 4)` because we naively assumed in original development that workflow tasks are CPU bound, no need for more threads than CPU (but they can be IO in these deadlock cases)
* When a deadlock is detected and we respond to Core saying it is deadlocked and the workflow task thread is hung (or maybe it finishes at some point, we don't care). Core gives us an eviction which we try to process it (on a separate workflow task thread from the pool since that other thread hasn't been returned to the pool) by cancelling all tasks, but not all tasks get cancelled because one is hung. Therefore the slot is never returned, the thread is never reusable, and eventually the worker can run out of slots.
* When an eviction occurs, all outstanding asyncio tasks are canceled so they can be gracefully collected (because if you don't GC wakes them up in other workflow threads, scary, which we fixed in #499). But if a user swallows an eviction today (e.g. catching asyncio cancel exception which is a base exception and then doing more accidentally blocking work), we log an exception and then just never return an eviction response to Core so it can't accept any more work for the run ID. This means a worker could never shut down because it had outstanding work that was never resolevd.

Problems with this:

* Threads being less than slots means all threads could be consumed while we're still accepting work, causing it to be enqueued on the thread pool causing those to hit deadlock timeout (even though they never started)
* Deadlock that eventually is resolved does not free up the thread
* Eviction that is eventually resolved does not free up the slot and does not make the run ID available for more work

With this PR the behavior now is:

* Default workflow task thread pool max size is now `max_concurrent_workflow_tasks` or `500` if unset (e.g. using workflow tuner explicitly). This makes sure that deadlocks that eat threads don't affect other workflow tasks.
* When a deadlock detected, we do advanced [PyThreadState_SetAsyncExc](https://docs.python.org/3/c-api/init.html#c.PyThreadState_SetAsyncExc) C call similar to sync activities to attempt to unstick it. This works for spinning loops and many IO things, but it doesn't work for things like `time.sleep()` or `threading.Event`'s `wait()` which are reactive. Still, this improves our ability to interrupt some stuck Python code. It technically could cause user issues if they were expecting their Python not to be interrupted even after deadlock timeout, but we don't support code running successfully after deadlock timeout.
* On eviction, if there was a deadlocked task (it comes right after deadlock because deadlock is wft fail which causes eviction), we wait on it forever because we must have the thread unstuck to evict. This allows bad workflow code that happens to complete itself after the 2s deadlock timeout to properly complete and give resources back.
* On eviction, we try to run the eviction (i.e. task teardown) process on a thread, continually, forever until it succeeds. We give a descriptive error if it times out (same timeout as deadlock) because that usually means it is swallowing the eviction exceptions (task cancel or our own workflow-being-deleted-can't-run-workflow-call error). Running continually (with a 2s sleep between each attempt) allows eviction that eventually succeeds to clear up and allow a worker to shut down if it can. We still log on worker shutdown if there were any evictions that are still trying to be processed since they can prevent workflow shutdown from completing (by intention).

## Checklist

1. Closes #784