### PR TITLE
Check that intended python version is being used

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -30,6 +30,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
 
       # Install Rust locally for non-Linux (Linux uses an internal docker
       # command to build with cibuildwheel which uses rustup install defined

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -30,9 +30,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
 
       # Install Rust locally for non-Linux (Linux uses an internal docker
       # command to build with cibuildwheel which uses rustup install defined
@@ -44,7 +41,7 @@ jobs:
         with:
           workspaces: temporalio/bridge -> target
       - uses: astral-sh/setup-uv@v5
-      - run: uv sync --all-extras
+      - run: uv sync --all-extras --python 3.13
 
       # Add the source dist only for Linux x64 for now
       - if: ${{ matrix.package-suffix == 'linux-amd64' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: temporalio/bridge -> target
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
       - uses: arduino/setup-protoc@v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,19 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: astral-sh/setup-uv@v5
       - run: uv tool install poethepoet
+      - run: uv --preview python install --default ${{ matrix.python }}
       - run: uv sync --all-extras --python ${{ matrix.python }}
       - name: Check python version
         shell: bash
         run: |
+          actual=$(uv run python -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
+          if [[ "$actual" != "${{ 3.13 }}" ]]; then
+            echo "Python version in use by uv ($actual) does not match intended version (${{ matrix.python }})"
+            exit 1
+          fi
           actual=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
           if [[ "$actual" != "${{ 3.13 }}" ]]; then
-            echo "Python version in use ($actual) does not match intended version (${{ matrix.python }})"
+            echo "Python version on PATH ($actual) does not match intended version (${{ matrix.python }})"
             exit 1
           fi
       - run: poe bridge-lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           TEMPORAL_TEST_PROTO3: 1
         run: |
           uv add --python 3.9 "protobuf<4"
-          uv sync --all-extras
+          uv sync --all-extras --python 3.9
           poe build-develop
           poe gen-protos
           poe format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,12 @@ jobs:
         shell: bash
         run: |
           actual=$(uv run python -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
-          if [[ "$actual" != "${{ 3.13 }}" ]]; then
+          if [[ "$actual" != "${{ matrix.python }}" ]]; then
             echo "Python version in use by uv ($actual) does not match intended version (${{ matrix.python }})"
             exit 1
           fi
           actual=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
-          if [[ "$actual" != "${{ 3.13 }}" ]]; then
+          if [[ "$actual" != "${{ matrix.python }}" ]]; then
             echo "Python version on PATH ($actual) does not match intended version (${{ matrix.python }})"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: temporalio/bridge -> target
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
       - uses: arduino/setup-protoc@v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed
@@ -48,7 +45,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: astral-sh/setup-uv@v5
       - run: uv tool install poethepoet
-      - run: uv sync --all-extras
+      - run: uv sync --all-extras --python ${{ matrix.python }}
       - name: Check python version
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,14 @@ jobs:
       - uses: astral-sh/setup-uv@v5
       - run: uv tool install poethepoet
       - run: uv sync --all-extras
+      - name: Check python version
+        shell: bash
+        run: |
+          actual=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
+          if [[ "$actual" != "${{ matrix.python }}" ]]; then
+            echo "Python version in use ($actual) does not match intended version (${{ matrix.python }})"
+            exit 1
+          fi
       - run: poe bridge-lint
         if: ${{ matrix.clippyLinter }}
       - run: poe lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         shell: bash
         run: |
           actual=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
-          if [[ "$actual" != "${{ matrix.python }}" ]]; then
+          if [[ "$actual" != "${{ 3.13 }}" ]]; then
             echo "Python version in use ($actual) does not match intended version (${{ matrix.python }})"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: astral-sh/setup-uv@v5
       - run: uv tool install poethepoet
-      - run: uv --preview python install --default ${{ matrix.python }}
       - run: uv sync --all-extras --python ${{ matrix.python }}
       - name: Check python version
         shell: bash

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -35,9 +35,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: temporalio/bridge -> target
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
       - uses: arduino/setup-protoc@v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed
@@ -47,7 +44,7 @@ jobs:
       - uses: astral-sh/setup-uv@v5
       # Build
       - run: uv tool install poethepoet
-      - run: uv sync --all-extras
+      - run: uv sync --all-extras --python 3.13
       - run: poe build-develop-with-release
       
       # Run a bunch of bench tests. We run multiple times since results vary.

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -35,6 +35,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: temporalio/bridge -> target
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
       - uses: arduino/setup-protoc@v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed

--- a/README.md
+++ b/README.md
@@ -1544,7 +1544,7 @@ poe test -s --log-cli-level=DEBUG -k test_sync_activity_thread_cancel_caught
 #### Proto Generation and Testing
 
 To allow for backwards compatibility, protobuf code is generated on the 3.x series of the protobuf library. To generate
-protobuf code, you must be on Python <= 3.10, and then run `uv add "protobuf<4"` + `uv sync --all-extras`. Then the
+protobuf code, run `uv add "protobuf<4" --python 3.10` + `uv sync --all-extras --python 3.10`. Then the
 protobuf files can be generated via `poe gen-protos`. Tests can be run for protobuf version 3 by setting the
 `TEMPORAL_TEST_PROTO3` env var to `1` prior to running tests.
 


### PR DESCRIPTION
This PR changes GitHub actions CI jobs as follows:

- Where a specific python version is intended, specify the version when using `uv sync`.

- We continue to use `setup-python` in the github actions to set the python version on `$PATH`. A more `uv`-native way to do this may become available but I think is not currently available. Perhaps `uv python install` in the future. Also in the future, we can investigate uv caching: see https://github.com/astral-sh/setup-uv?tab=readme-ov-file#enable-caching and discussion in https://github.com/actions/setup-python/issues/822.

One reason I made this PR was to double-check that we were indeed running tests against the intended python versions, despite not specifying the version in `uv sync`. I've confirmed that we were (see https://github.com/temporalio/sdk-python/pull/809). Presumably because `uv` uses the python interpreter installed by the `setup-python` action. Nevertheless, it seems good to be explicit in the `uv` commands, especially since, as described above, I think we will eventually move away from `setup-python`.