### PR TITLE
[IGNORE] Improve test flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   # Build and test the project
   build-lint-test:
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -16,7 +17,8 @@ jobs:
         os: [ubuntu-latest, ubuntu-arm, macos-intel, macos-arm, windows-latest]
         include:
           # On 3.9 there is a problem with import errors caused by pytests' loader that surface due
-          # to a bug in CPython, so we avoid using the assert rewriter.
+          # to a bug in CPython (https://github.com/python/cpython/issues/91351), so we avoid using
+          # the assert rewriter.
           - python: "3.9"
             pytestExtraArgs: "--assert=plain"
           - os: ubuntu-latest
@@ -31,6 +33,12 @@ jobs:
             runsOn: ubuntu-24.04-arm64-2-core
           - os: macos-intel
             runsOn: macos-13
+          # On 3.13.3 there is some issue with macOS intel where it hangs after pytest with some
+          # test that may have a worker that cannot properly shutdown, but it does not occur on
+          # other versions, platforms, etc. See https://github.com/temporalio/sdk-python/issues/834.
+          - os: macos-intel
+            python: "3.13"
+            pythonOverride: "3.13.2"
           - os: macos-arm
             runsOn: macos-latest
     runs-on: ${{ matrix.runsOn || matrix.os }}
@@ -44,7 +52,7 @@ jobs:
           workspaces: temporalio/bridge -> target
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.pythonOverride || matrix.python }}
       - uses: arduino/setup-protoc@v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed
@@ -59,12 +67,15 @@ jobs:
       - run: poe build-develop
       - run: mkdir junit-xml
       - run: poe test ${{matrix.pytestExtraArgs}} -s --junit-xml=junit-xml/${{ matrix.python }}--${{ matrix.os }}.xml
+        timeout-minutes: 10
       # Time skipping doesn't yet support ARM
       - if: ${{ !endsWith(matrix.os, '-arm') }}
         run: poe test ${{matrix.pytestExtraArgs}} -s --workflow-environment time-skipping --junit-xml=junit-xml/${{ matrix.python }}--${{ matrix.os }}--time-skipping.xml
+        timeout-minutes: 10
       # Check cloud if proper target and not on fork
       - if: ${{ matrix.cloudTestTarget && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-python') }}
         run: poe test ${{matrix.pytestExtraArgs}} -s -k test_cloud_client --junit-xml=junit-xml/${{ matrix.python }}--${{ matrix.os }}--cloud.xml
+        timeout-minutes: 10
         env:
           TEMPORAL_CLIENT_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLIENT_CLOUD_API_KEY }}
           TEMPORAL_CLIENT_CLOUD_API_VERSION: 2024-05-13-00
@@ -94,6 +105,7 @@ jobs:
           poe format
           [[ -z $(git status --porcelain temporalio) ]] || (git diff temporalio; echo "Protos changed"; exit 1)
           poe test -s
+        timeout-minutes: 10
 
       # Do docs stuff (only on one host)
       - name: Build API docs

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# TODO: Change back to "default" after next CLI release
+DEV_SERVER_DOWNLOAD_VERSION = "v1.3.1-persistence-fix.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ from typing import AsyncGenerator
 import pytest
 import pytest_asyncio
 
+from . import DEV_SERVER_DOWNLOAD_VERSION
+
 # If there is an integration test environment variable set, we must remove the
 # first path from the sys.path so we can import the wheel instead
 if os.getenv("TEMPORAL_INTEGRATION_TEST"):
@@ -114,8 +116,7 @@ async def env(env_type: str) -> AsyncGenerator[WorkflowEnvironment, None]:
                 "--dynamic-config-value",
                 "system.enableDeploymentVersions=true",
             ],
-            # TODO: Remove after next CLI release
-            dev_server_download_version="v1.3.1-priority.0",
+            dev_server_download_version=DEV_SERVER_DOWNLOAD_VERSION,
         )
     elif env_type == "time-skipping":
         env = await WorkflowEnvironment.start_time_skipping()
@@ -139,11 +140,11 @@ async def worker(
     await worker.close()
 
 
-# There is an issue on Windows 3.9 tests in GitHub actions where even though all
-# tests pass, an unclear outer area is killing the process with a bad exit code.
-# This windows-only hook forcefully kills the process as success when the exit
-# code from pytest is a success.
-if sys.version_info < (3, 10) and sys.platform == "win32":
+# There is an issue on 3.9 tests in GitHub actions where even though all tests
+# pass, an unclear outer area is killing the process with a bad exit code. This
+# hook forcefully kills the process as success when the exit code from pytest
+# is a success.
+if sys.version_info < (3, 10):
 
     @pytest.hookimpl(hookwrapper=True, trylast=True)
     def pytest_cmdline_main(config):

--- a/tests/contrib/test_opentelemetry.py
+++ b/tests/contrib/test_opentelemetry.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Iterable, List, Optional
 
-import pytest
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -20,6 +19,11 @@ from temporalio.contrib.opentelemetry import TracingInterceptor
 from temporalio.contrib.opentelemetry import workflow as otel_workflow
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+# Passing through because Python 3.9 has an import bug at
+# https://github.com/python/cpython/issues/91351
+with workflow.unsafe.imports_passed_through():
+    import pytest
 
 
 @dataclass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,6 @@ from unittest import mock
 
 import google.protobuf.any_pb2
 import google.protobuf.message
-import pytest
 from google.protobuf import json_format
 
 import temporalio.api.common.v1
@@ -105,6 +104,11 @@ from tests.helpers.worker import (
     KSSleepAction,
     KSWorkflowParams,
 )
+
+# Passing through because Python 3.9 has an import bug at
+# https://github.com/python/cpython/issues/91351
+with workflow.unsafe.imports_passed_through():
+    import pytest
 
 
 async def test_start_id_reuse(

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -2,10 +2,13 @@ import inspect
 import itertools
 from typing import Sequence
 
-import pytest
-
 from temporalio import workflow
 from temporalio.common import RawValue, VersioningBehavior
+
+# Passing through because Python 3.9 has an import bug at
+# https://github.com/python/cpython/issues/91351
+with workflow.unsafe.imports_passed_through():
+    import pytest
 
 
 class GoodDefnBase:

--- a/tests/testing/test_workflow.py
+++ b/tests/testing/test_workflow.py
@@ -6,8 +6,6 @@ from datetime import datetime, timedelta, timezone
 from time import monotonic
 from typing import Any, List, Optional, Union
 
-import pytest
-
 from temporalio import activity, workflow
 from temporalio.client import (
     Client,
@@ -31,7 +29,13 @@ from temporalio.exceptions import (
     TimeoutType,
 )
 from temporalio.testing import WorkflowEnvironment
+from tests import DEV_SERVER_DOWNLOAD_VERSION
 from tests.helpers import new_worker
+
+# Passing through because Python 3.9 has an import bug at
+# https://github.com/python/cpython/issues/91351
+with workflow.unsafe.imports_passed_through():
+    import pytest
 
 
 @workflow.defn
@@ -306,7 +310,8 @@ async def test_search_attributes_on_dev_server(
             float_attr,
             bool_attr,
             datetime_attr,
-        ]
+        ],
+        dev_server_download_version=DEV_SERVER_DOWNLOAD_VERSION,
     ) as env:
         handle = await env.client.start_workflow(
             "some-workflow",

--- a/tests/worker/test_activity.py
+++ b/tests/worker/test_activity.py
@@ -15,8 +15,6 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, List, NoReturn, Optional, Sequence, Type
 
-import pytest
-
 from temporalio import activity, workflow
 from temporalio.client import (
     AsyncActivityHandle,
@@ -47,6 +45,12 @@ from tests.helpers.worker import (
     KSExecuteActivityAction,
     KSWorkflowParams,
 )
+
+# Passing through because Python 3.9 has an import bug at
+# https://github.com/python/cpython/issues/91351
+with workflow.unsafe.imports_passed_through():
+    import pytest
+
 
 _default_shared_state_manager = SharedStateManager.create_from_multiprocessing(
     multiprocessing.Manager()

--- a/tests/worker/test_interceptor.py
+++ b/tests/worker/test_interceptor.py
@@ -3,8 +3,6 @@ import uuid
 from datetime import timedelta
 from typing import Any, Callable, List, NoReturn, Optional, Tuple, Type
 
-import pytest
-
 from temporalio import activity, workflow
 from temporalio.client import Client, WorkflowUpdateFailedError
 from temporalio.exceptions import ApplicationError
@@ -29,6 +27,11 @@ from temporalio.worker import (
     WorkflowInterceptorClassInput,
     WorkflowOutboundInterceptor,
 )
+
+# Passing through because Python 3.9 has an import bug at
+# https://github.com/python/cpython/issues/91351
+with workflow.unsafe.imports_passed_through():
+    import pytest
 
 interceptor_traces: List[Tuple[str, Any]] = []
 

--- a/tests/worker/test_replayer.py
+++ b/tests/worker/test_replayer.py
@@ -6,8 +6,6 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Any, Dict, Optional, Type
 
-import pytest
-
 from temporalio import activity, workflow
 from temporalio.client import Client, WorkflowFailureError, WorkflowHistory
 from temporalio.exceptions import ApplicationError
@@ -25,6 +23,11 @@ from tests.worker.test_workflow import (
     ActivityAndSignalsWhileWorkflowDown,
     SignalsActivitiesTimersUpdatesTracingWorkflow,
 )
+
+# Passing through because Python 3.9 has an import bug at
+# https://github.com/python/cpython/issues/91351
+with workflow.unsafe.imports_passed_through():
+    import pytest
 
 
 @activity.defn

--- a/tests/worker/test_update_with_start.py
+++ b/tests/worker/test_update_with_start.py
@@ -8,8 +8,6 @@ from enum import Enum
 from typing import Any, Iterator, Mapping, Optional
 from unittest.mock import patch
 
-import pytest
-
 import temporalio.api.common.v1
 import temporalio.api.workflowservice.v1
 from temporalio import activity, workflow
@@ -32,6 +30,11 @@ from temporalio.testing import WorkflowEnvironment
 from tests.helpers import (
     new_worker,
 )
+
+# Passing through because Python 3.9 has an import bug at
+# https://github.com/python/cpython/issues/91351
+with workflow.unsafe.imports_passed_through():
+    import pytest
 
 
 @activity.defn

--- a/tests/worker/test_worker.py
+++ b/tests/worker/test_worker.py
@@ -7,8 +7,6 @@ import uuid
 from datetime import timedelta
 from typing import Any, Awaitable, Callable, Optional, Sequence
 
-import pytest
-
 import temporalio.api.enums.v1
 import temporalio.worker._worker
 from temporalio import activity, workflow
@@ -44,6 +42,11 @@ from temporalio.worker import (
 )
 from temporalio.workflow import VersioningIntent
 from tests.helpers import assert_eventually, new_worker, worker_versioning_enabled
+
+# Passing through because Python 3.9 has an import bug at
+# https://github.com/python/cpython/issues/91351
+with workflow.unsafe.imports_passed_through():
+    import pytest
 
 
 def test_load_default_worker_binary_id():

--- a/tests/worker/workflow_sandbox/test_runner.py
+++ b/tests/worker/workflow_sandbox/test_runner.py
@@ -12,8 +12,6 @@ from datetime import date, datetime, timedelta
 from enum import IntEnum
 from typing import Callable, Dict, List, Optional, Sequence, Set, Type
 
-import pytest
-
 from temporalio import activity, workflow
 from temporalio.client import Client, WorkflowFailureError, WorkflowHandle
 from temporalio.exceptions import ApplicationError
@@ -27,6 +25,12 @@ from temporalio.worker.workflow_sandbox import (
 from tests.helpers import assert_eq_eventually
 from tests.worker.workflow_sandbox.testmodules import stateful_module
 from tests.worker.workflow_sandbox.testmodules.proto import SomeMessage
+
+# Passing through because Python 3.9 has an import bug at
+# https://github.com/python/cpython/issues/91351
+with workflow.unsafe.imports_passed_through():
+    import pytest
+
 
 global_state = ["global orig"]
 # We just access os.name in here to show we _can_. It's access-restricted at


### PR DESCRIPTION
## What was changed

* Added GH timeouts for entire workflow and for specific test runs
* Set macos intel to use 3.13.2 instead of default 3.13 (which is 3.13.3) because the newest released last week was failing, see #834
* Moved all dev servers to `v1.3.1-persistence-fix.0` version of CLI dev server to get https://github.com/temporalio/cli/pull/784
* macOS on 3.9, like Windows, rarely had a failure exit code post pytest-success, so we enabled same code as Windows to allow it to succeed. We believe this is caused by #300.
* In Python 3.9 still got import errors triggered by CPython bug https://github.com/python/cpython/issues/91351 when importing pytest into sandbox, so we pass through pytest imports in tests


There are still flakes, such as #300 and some server side persistence failures we are investigating. But this issue solves many common ones for now.
