### PR TITLE
Data converter non-string keys

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -373,8 +373,12 @@ def test_json_type_hints():
     # just accepting any dict.
     ok(MyTypedDictNotTotal, {"foo": "bar"})
     ok(MyTypedDict, {"foo": "bar", "blah": "meh"})
-    # Note, dicts can't have int key in JSON
-    fail(Dict[int, str], {1: "2"})
+
+    # Non-string dict keys are supported
+    ok(Dict[int, str], {1: "1"})
+    ok(Dict[float, str], {1.0: "1"})
+    ok(Dict[bool, str], {True: "1"})
+    ok(Dict[None, str], {None: "1"})
 
     # Alias
     ok(MyDataClassAlias, MyDataClass("foo", 5, SerializableEnum.FOO))


### PR DESCRIPTION
Before this PR, workflows and activities could not return dicts with non-string keys. E.g. something as simple as this fails:

```python
    @workflow.run
    async def run(self, name: str) -> dict[int, str]:
        return {1: "a"}
```
```
TypeError: Failed converting key 1 on dict[int, str]
```

This is surprising to users because a pervasive feature of the Python SDK is that type annotations are used to make the data converter do the right thing: the type annotation should be "honored" there.

The behavior happens because (1) we default to json/plain encoding, (2) in JSON keys must be strings, (3) the Python JSON encoder accepts str, int, float, bool, None dict keys, silently encoding them as valid JSON string representations, (4) although the type annotation is typically present (either from a type annotation in workflow/activity code) or less commonly because a user supplied the return_type argument) to "fix" the key type, our data converter doesn't do that. But JSON encoding is an implementation detail of the Python SDK.

The SDK's `pydantic_data_converter` has no problem with dict types like that above. This PR makes our default data converter support them also.