### PR TITLE
Change LoggerAdapter extra field to accomodate to OpenTelemetry

### DIFF
--- a/temporalio/activity.py
+++ b/temporalio/activity.py
@@ -459,13 +459,11 @@ class LoggerAdapter(logging.LoggerAdapter):
                     msg = f"{msg} ({context.logger_details})"
                 if self.activity_info_on_extra:
                     # Extra can be absent or None, this handles both
-                    extra = kwargs.get("extra", None) or {}
-                    extra["temporal_activity"] = context.logger_details
+                    extra = {**kwargs.get("extra", {}), **context.logger_details()}
                     kwargs["extra"] = extra
                 if self.full_activity_info_on_extra:
                     # Extra can be absent or None, this handles both
-                    extra = kwargs.get("extra", None) or {}
-                    extra["activity_info"] = context.info()
+                    extra = {**kwargs.get("extra", {}), **context.info()}
                     kwargs["extra"] = extra
         return (msg, kwargs)
 

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -1398,16 +1398,16 @@ class LoggerAdapter(logging.LoggerAdapter):
                 if self.workflow_info_on_message:
                     msg_extra.update(workflow_details)
                 if self.workflow_info_on_extra:
-                    extra["temporal_workflow"] = workflow_details
+                    extra.update(workflow_details)
                 if self.full_workflow_info_on_extra:
-                    extra["workflow_info"] = runtime.workflow_info()
+                    extra.update(runtime.workflow_info())
             update_info = current_update_info()
             if update_info:
                 update_details = update_info._logger_details
                 if self.workflow_info_on_message:
                     msg_extra.update(update_details)
                 if self.workflow_info_on_extra:
-                    extra.setdefault("temporal_workflow", {}).update(update_details)
+                    extra = update_details
 
         kwargs["extra"] = {**extra, **(kwargs.get("extra") or {})}
         if msg_extra:


### PR DESCRIPTION
## What was changed
Logger adapter's extra field format; flatten the "temporal_activity/activity_info/temporal_workflow/workflow_info" in extra fields.

## Why?
To accomodate to opentelemetry format, because opentelemetry's attributes only takes (bool, str, bytes, int, float)
