### PR TITLE
Fix incorrectly set legacy build id options

### DIFF
--- a/temporalio/bridge/src/worker.rs
+++ b/temporalio/bridge/src/worker.rs
@@ -108,7 +108,7 @@ pub enum WorkerVersioningStrategy {
 
 #[derive(FromPyObject)]
 pub struct WorkerVersioningNone {
-    pub build_id: String,
+    pub build_id_no_versioning: String,
 }
 
 /// Recreates [temporal_sdk_core_api::worker::WorkerDeploymentOptions]
@@ -122,7 +122,7 @@ pub struct WorkerDeploymentOptions {
 
 #[derive(FromPyObject)]
 pub struct LegacyBuildIdBased {
-    pub build_id: String,
+    pub build_id_with_versioning: String,
 }
 
 /// Recreates [temporal_sdk_core_api::worker::WorkerDeploymentVersion]
@@ -803,7 +803,7 @@ fn convert_versioning_strategy(
     match strategy {
         WorkerVersioningStrategy::None(vn) => {
             temporal_sdk_core_api::worker::WorkerVersioningStrategy::None {
-                build_id: vn.build_id,
+                build_id: vn.build_id_no_versioning,
             }
         }
         WorkerVersioningStrategy::DeploymentBased(options) => {
@@ -825,7 +825,7 @@ fn convert_versioning_strategy(
         }
         WorkerVersioningStrategy::LegacyBuildIdBased(lb) => {
             temporal_sdk_core_api::worker::WorkerVersioningStrategy::LegacyBuildIdBased {
-                build_id: lb.build_id,
+                build_id: lb.build_id_with_versioning,
             }
         }
     }

--- a/temporalio/bridge/worker.py
+++ b/temporalio/bridge/worker.py
@@ -106,14 +106,14 @@ class WorkerDeploymentOptions:
 class WorkerVersioningStrategyNone:
     """Python representation of the Rust struct for configuring a worker versioning strategy None."""
 
-    build_id: str
+    build_id_no_versioning: str
 
 
 @dataclass
 class WorkerVersioningStrategyLegacyBuildIdBased:
     """Python representation of the Rust struct for configuring a worker versioning strategy legacy Build ID-based."""
 
-    build_id: str
+    build_id_with_versioning: str
 
 
 WorkerVersioningStrategy: TypeAlias = Union[

--- a/temporalio/worker/_replayer.py
+++ b/temporalio/worker/_replayer.py
@@ -251,7 +251,8 @@ class Replayer:
                     max_task_queue_activities_per_second=None,
                     graceful_shutdown_period_millis=0,
                     versioning_strategy=temporalio.bridge.worker.WorkerVersioningStrategyNone(
-                        build_id=self._config["build_id"] or load_default_build_id(),
+                        build_id_no_versioning=self._config["build_id"]
+                        or load_default_build_id(),
                     ),
                     workflow_task_poller_behavior=temporalio.bridge.worker.PollerBehaviorSimpleMaximum(
                         1

--- a/temporalio/worker/_worker.py
+++ b/temporalio/worker/_worker.py
@@ -448,13 +448,13 @@ class Worker:
             build_id = build_id or load_default_build_id()
             versioning_strategy = (
                 temporalio.bridge.worker.WorkerVersioningStrategyLegacyBuildIdBased(
-                    build_id=build_id
+                    build_id_with_versioning=build_id
                 )
             )
         else:
             build_id = build_id or load_default_build_id()
             versioning_strategy = temporalio.bridge.worker.WorkerVersioningStrategyNone(
-                build_id=build_id
+                build_id_no_versioning=build_id
             )
 
         if max_concurrent_workflow_task_polls:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,29 +11,29 @@ from . import DEV_SERVER_DOWNLOAD_VERSION
 # If there is an integration test environment variable set, we must remove the
 # first path from the sys.path so we can import the wheel instead
 if os.getenv("TEMPORAL_INTEGRATION_TEST"):
-    assert sys.path[0] == os.getcwd(), (
-        "Expected first sys.path to be the current working dir"
-    )
+    assert (
+        sys.path[0] == os.getcwd()
+    ), "Expected first sys.path to be the current working dir"
     sys.path.pop(0)
     # Import temporalio and confirm it is prefixed with virtual env
     import temporalio
 
-    assert temporalio.__file__.startswith(sys.prefix), (
-        f"Expected {temporalio.__file__} to be in {sys.prefix}"
-    )
+    assert temporalio.__file__.startswith(
+        sys.prefix
+    ), f"Expected {temporalio.__file__} to be in {sys.prefix}"
 
 # Unless specifically overridden, we expect tests to run under protobuf 4.x/5.x lib
 import google.protobuf
 
 protobuf_version = google.protobuf.__version__
 if os.getenv("TEMPORAL_TEST_PROTO3"):
-    assert protobuf_version.startswith("3."), (
-        f"Expected protobuf 3.x, got {protobuf_version}"
-    )
+    assert protobuf_version.startswith(
+        "3."
+    ), f"Expected protobuf 3.x, got {protobuf_version}"
 else:
-    assert protobuf_version.startswith("4.") or protobuf_version.startswith("5."), (
-        f"Expected protobuf 4.x/5.x, got {protobuf_version}"
-    )
+    assert protobuf_version.startswith("4.") or protobuf_version.startswith(
+        "5."
+    ), f"Expected protobuf 4.x/5.x, got {protobuf_version}"
 
 from temporalio.client import Client
 from temporalio.testing import WorkflowEnvironment

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,18 +140,16 @@ async def worker(
     await worker.close()
 
 
-# There is an issue on 3.9 tests in GitHub actions where even though all tests
+# There is an issue in tests sometimes in GitHub actions where even though all tests
 # pass, an unclear outer area is killing the process with a bad exit code. This
 # hook forcefully kills the process as success when the exit code from pytest
 # is a success.
-if sys.version_info < (3, 10):
-
-    @pytest.hookimpl(hookwrapper=True, trylast=True)
-    def pytest_cmdline_main(config):
-        result = yield
-        if result.get_result() == 0:
-            os._exit(0)
-        return result.get_result()
+@pytest.hookimpl(hookwrapper=True, trylast=True)
+def pytest_cmdline_main(config):
+    result = yield
+    if result.get_result() == 0:
+        os._exit(0)
+    return result.get_result()
 
 
 CONTINUE_AS_NEW_SUGGEST_HISTORY_COUNT = 50

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,29 +11,29 @@ from . import DEV_SERVER_DOWNLOAD_VERSION
 # If there is an integration test environment variable set, we must remove the
 # first path from the sys.path so we can import the wheel instead
 if os.getenv("TEMPORAL_INTEGRATION_TEST"):
-    assert (
-        sys.path[0] == os.getcwd()
-    ), "Expected first sys.path to be the current working dir"
+    assert sys.path[0] == os.getcwd(), (
+        "Expected first sys.path to be the current working dir"
+    )
     sys.path.pop(0)
     # Import temporalio and confirm it is prefixed with virtual env
     import temporalio
 
-    assert temporalio.__file__.startswith(
-        sys.prefix
-    ), f"Expected {temporalio.__file__} to be in {sys.prefix}"
+    assert temporalio.__file__.startswith(sys.prefix), (
+        f"Expected {temporalio.__file__} to be in {sys.prefix}"
+    )
 
 # Unless specifically overridden, we expect tests to run under protobuf 4.x/5.x lib
 import google.protobuf
 
 protobuf_version = google.protobuf.__version__
 if os.getenv("TEMPORAL_TEST_PROTO3"):
-    assert protobuf_version.startswith(
-        "3."
-    ), f"Expected protobuf 3.x, got {protobuf_version}"
+    assert protobuf_version.startswith("3."), (
+        f"Expected protobuf 3.x, got {protobuf_version}"
+    )
 else:
-    assert protobuf_version.startswith("4.") or protobuf_version.startswith(
-        "5."
-    ), f"Expected protobuf 4.x/5.x, got {protobuf_version}"
+    assert protobuf_version.startswith("4.") or protobuf_version.startswith("5."), (
+        f"Expected protobuf 4.x/5.x, got {protobuf_version}"
+    )
 
 from temporalio.client import Client
 from temporalio.testing import WorkflowEnvironment
@@ -110,9 +110,9 @@ async def env(env_type: str) -> AsyncGenerator[WorkflowEnvironment, None]:
                 "--dynamic-config-value",
                 "frontend.enableExecuteMultiOperation=true",
                 "--dynamic-config-value",
-                "frontend.enableVersioningWorkflowAPIs=true",
+                "frontend.workerVersioningWorkflowAPIs=true",
                 "--dynamic-config-value",
-                "frontend.enableVersioningDataAPIs=true",
+                "frontend.workerVersioningDataAPIs=true",
                 "--dynamic-config-value",
                 "system.enableDeploymentVersions=true",
             ],


### PR DESCRIPTION
Fixes bug which was causing v2 versioning to be broken. Also fixes wrong dynamic config causing test to get skipped.