### PR TITLE
Fixed serialization of `typing.Literal`

### DIFF
--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -35,12 +35,12 @@ from typing import (
     get_type_hints,
     overload,
 )
-import typing_extensions
 
 import google.protobuf.duration_pb2
 import google.protobuf.json_format
 import google.protobuf.message
 import google.protobuf.symbol_database
+import typing_extensions
 
 import temporalio.api.common.v1
 import temporalio.api.enums.v1

--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -23,6 +23,7 @@ from typing import (
     ClassVar,
     Dict,
     List,
+    Literal,
     Mapping,
     NewType,
     Optional,
@@ -34,12 +35,12 @@ from typing import (
     get_type_hints,
     overload,
 )
+import typing_extensions
 
 import google.protobuf.duration_pb2
 import google.protobuf.json_format
 import google.protobuf.message
 import google.protobuf.symbol_database
-from typing_extensions import Literal
 
 import temporalio.api.common.v1
 import temporalio.api.enums.v1
@@ -1424,7 +1425,7 @@ def value_to_type(
     type_args: Tuple = getattr(hint, "__args__", ())
 
     # Literal
-    if origin is Literal:
+    if origin is Literal or origin is typing_extensions.Literal:
         if value not in type_args:
             raise TypeError(f"Value {value} not in literal values {type_args}")
         return value

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -16,6 +16,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Mapping,
     MutableMapping,
     NewType,
@@ -31,12 +32,12 @@ from uuid import UUID, uuid4
 
 import pydantic
 import pytest
-from typing_extensions import Literal, TypedDict
+import typing_extensions
+from typing_extensions import TypedDict
 
 import temporalio.api.common.v1
 import temporalio.common
 from temporalio.api.common.v1 import Payload, Payloads
-from temporalio.api.common.v1 import Payload as AnotherNameForPayload
 from temporalio.api.failure.v1 import Failure
 from temporalio.common import RawValue
 from temporalio.converter import (
@@ -311,6 +312,9 @@ def test_json_type_hints():
     ok(Literal["foo"], "foo")
     ok(Literal["foo", False], False)
     fail(Literal["foo", "bar"], "baz")
+    ok(typing_extensions.Literal["foo"], "foo")
+    ok(typing_extensions.Literal["foo", False], False)
+    fail(typing_extensions.Literal["foo", "bar"], "baz")
 
     # Dataclass
     ok(MyDataClass, MyDataClass("foo", 5, SerializableEnum.FOO))


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Fixed the converter so that both `typing.Literal` and `typing_extensions.Literal` type hints are handled correctly. Previously only `typing_extensions.Literal` worked as expected.

## Checklist
<!--- add/delete as needed --->

1. Closes #852 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
`tests/test_converter.py::test_json_type_hints` was updated with new checks.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No