### PR TITLE
💥 Breaking Change - Make static_details and static_summary lazy on the workflow description

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "."
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "python.testing.pytestArgs": [
-        "."
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}

--- a/temporalio/client.py
+++ b/temporalio/client.py
@@ -2926,21 +2926,23 @@ class WorkflowExecutionDescription(WorkflowExecution):
 
     raw_description: temporalio.api.workflowservice.v1.DescribeWorkflowExecutionResponse
     """Underlying protobuf description."""
-    
+
     _static_summary: Optional[str] = None
     _static_details: Optional[str] = None
     _metadata_decoded: bool = False
 
     async def static_summary(self) -> Optional[str]:
         """Gets the single-line fixed summary for this workflow execution that may appear in
-        UI/CLI. This can be in single-line Temporal markdown format."""
+        UI/CLI. This can be in single-line Temporal markdown format.
+        """
         if not self._metadata_decoded:
             await self._decode_metadata()
         return self._static_summary
 
     async def static_details(self) -> Optional[str]:
         """Gets the general fixed details for this workflow execution that may appear in UI/CLI.
-        This can be in Temporal markdown format and can span multiple lines."""
+        This can be in Temporal markdown format and can span multiple lines.
+        """
         if not self._metadata_decoded:
             await self._decode_metadata()
         return self._static_details
@@ -2948,8 +2950,7 @@ class WorkflowExecutionDescription(WorkflowExecution):
     async def _decode_metadata(self) -> None:
         """Internal method to decode metadata lazily."""
         self._static_summary, self._static_details = await _decode_user_metadata(
-            self.data_converter,
-            self.raw_description.execution_config.user_metadata
+            self.data_converter, self.raw_description.execution_config.user_metadata
         )
         self._metadata_decoded = True
 

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -6394,8 +6394,8 @@ async def test_user_metadata_is_set(client: Client, env: WorkflowEnvironment):
         assert timer_summs == {"hi!", "timer2"}
 
         describe_r = await handle.describe()
-        assert describe_r.static_summary == "cool workflow bro"
-        assert describe_r.static_details == "xtremely detailed"
+        assert await describe_r.static_summary() == "cool workflow bro"
+        assert await describe_r.static_details() == "xtremely detailed"
 
 
 @workflow.defn


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Make static_details and static_summary lazy on the workflow description

## Why?
Converting these fields can be expensive and is only necessary if the client requests these details. 

## Checklist
<!--- add/delete as needed --->

1. Closes #840 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
Yes, breaking change in the API
