### PR TITLE
Do not wrap workflow-failure exceptions from converters in workflows

### DIFF
--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -1774,6 +1774,8 @@ class _WorkflowInstanceImpl(
             # Don't wrap payload conversion errors that would fail the workflow
             raise
         except Exception as err:
+            if self._is_workflow_failure_exception(err):
+                raise
             raise RuntimeError("Failed decoding arguments") from err
 
     def _instantiate_workflow_object(self) -> Any:

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -5163,14 +5163,15 @@ async def test_workflow_failure_types_configured(client: Client):
         )
 
 
+class Foo(pydantic.BaseModel):
+    bar: str
+
+
 @workflow.defn(failure_exception_types=[pydantic.ValidationError])
 class FailOnBadPydanticInputWorkflow:
     @workflow.run
-    async def run(self, params: dict[str, Any]) -> None:
-        class Foo(pydantic.BaseModel):
-            bar: str
-
-        _ = Foo.model_validate(params)
+    async def run(self, params: Foo) -> None:
+        pass
 
 
 async def test_workflow_fail_on_bad_pydantic_input(client: Client):

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -5169,6 +5169,7 @@ class FailOnBadPydanticInputWorkflow:
     async def run(self, params: dict[str, Any]) -> None:
         class Foo(pydantic.BaseModel):
             bar: str
+
         _ = Foo.model_validate(params)
 
 

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -36,6 +36,7 @@ from typing import (
 )
 from urllib.request import urlopen
 
+import pydantic
 from google.protobuf.timestamp_pb2 import Timestamp
 from typing_extensions import Literal, Protocol, runtime_checkable
 
@@ -5162,6 +5163,28 @@ async def test_workflow_failure_types_configured(client: Client):
         )
 
 
+@workflow.defn(failure_exception_types=[pydantic.ValidationError])
+class FailOnBadPydanticInputWorkflow:
+    @workflow.run
+    async def run(self, params: dict[str, Any]) -> None:
+        class Foo(pydantic.BaseModel):
+            bar: str
+        _ = Foo.model_validate(params)
+
+
+async def test_workflow_fail_on_bad_pydantic_input(client: Client):
+    async with new_worker(client, FailOnBadPydanticInputWorkflow) as worker:
+        with pytest.raises(WorkflowFailureError) as err:
+            await client.execute_workflow(
+                "FailOnBadPydanticInputWorkflow",
+                {"bar": 123},  # This should fail validation
+                id=f"wf-{uuid.uuid4()}",
+                task_queue=worker.task_queue,
+            )
+    assert isinstance(err.value.cause, ApplicationError)
+    assert "1 validation error for Foo" in err.value.cause.message
+
+
 @workflow.defn(failure_exception_types=[Exception])
 class FailOnBadInputWorkflow:
     @workflow.run
@@ -5179,7 +5202,7 @@ async def test_workflow_fail_on_bad_input(client: Client):
                 task_queue=worker.task_queue,
             )
     assert isinstance(err.value.cause, ApplicationError)
-    assert "Failed decoding arguments" in err.value.cause.message
+    assert "Expected value to be str, was <class 'int'>" in err.value.cause.message
 
 
 @workflow.defn


### PR DESCRIPTION
## What was changed
Fail workflow upon ```pydantic.ValidationError``` when using the ```pydantic_data_converter```, so that the user can pass that specific exception type to ```workflow_failure_exception_types``` in order for the workflow to fail instead of keeping it running, since there is no way that such a workflow will ever complete with an incorrect payload.

## Checklist
1. Closes [[Feature Request] Fail workflow upon pydantic.ValidationError when using the pydantic_data_converter #815](https://github.com/temporalio/sdk-python/issues/815)

2. How was this tested:
```tests/worker/test_workflow::test_workflow_fail_on_bad_input``` was updated to check the right exception message.
```test/worker/test_workflow::test_workflow_fail_on_bad_pydantic_input``` was added to check that the workflow indeed fails when a Pydantic model can't be validated.

3. Any docs updates needed?
No.
