### PR TITLE
Handle case where in_workflow is called in a synchronous activity

### DIFF
--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -642,7 +642,12 @@ class _Runtime(ABC):
 
     @staticmethod
     def maybe_current() -> Optional[_Runtime]:
-        return getattr(asyncio.get_running_loop(), "__temporal_workflow_runtime", None)
+        try:
+            return getattr(
+                asyncio.get_running_loop(), "__temporal_workflow_runtime", None
+            )
+        except RuntimeError:
+            return None
 
     @staticmethod
     def set_on_loop(
@@ -940,10 +945,7 @@ def instance() -> Any:
 
 def in_workflow() -> bool:
     """Whether the code is currently running in a workflow."""
-    try:
-        return _Runtime.maybe_current() is not None
-    except RuntimeError:
-        return False
+    return _Runtime.maybe_current() is not None
 
 
 def memo() -> Mapping[str, Any]:

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -940,7 +940,10 @@ def instance() -> Any:
 
 def in_workflow() -> bool:
     """Whether the code is currently running in a workflow."""
-    return _Runtime.maybe_current() is not None
+    try:
+        return _Runtime.maybe_current() is not None
+    except RuntimeError:
+        return False
 
 
 def memo() -> Mapping[str, Any]:

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -7988,6 +7988,7 @@ class UseInWorkflow:
             use_in_workflow, schedule_to_close_timeout=timedelta(seconds=10)
         )
 
+
 async def test_in_workflow_sync(client: Client):
     async with new_worker(
         client,
@@ -8001,4 +8002,3 @@ async def test_in_workflow_sync(client: Client):
             task_queue=worker.task_queue,
             execution_timeout=timedelta(minutes=1),
         )
-

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -7976,7 +7976,7 @@ async def test_quick_activity_swallows_cancellation(client: Client):
 
 
 @activity.defn
-def use_in_workflow():
+def use_in_workflow() -> bool:
     return workflow.in_workflow()
 
 
@@ -7987,6 +7987,7 @@ class UseInWorkflow:
         res = await workflow.execute_activity(
             use_in_workflow, schedule_to_close_timeout=timedelta(seconds=10)
         )
+        return res
 
 
 async def test_in_workflow_sync(client: Client):
@@ -7996,9 +7997,10 @@ async def test_in_workflow_sync(client: Client):
         activities=[use_in_workflow],
         activity_executor=concurrent.futures.ThreadPoolExecutor(max_workers=1),
     ) as worker:
-        await client.execute_workflow(
+        res = await client.execute_workflow(
             UseInWorkflow.run,
             id=f"test_in_workflow_sync",
             task_queue=worker.task_queue,
             execution_timeout=timedelta(minutes=1),
         )
+        assert not res

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -7975,7 +7975,6 @@ async def test_quick_activity_swallows_cancellation(client: Client):
         temporalio.worker._workflow_instance._raise_on_cancelling_completed_activity_override = False
 
 
-        
 @activity.defn
 def use_in_workflow() -> bool:
     return workflow.in_workflow()
@@ -8006,7 +8005,7 @@ async def test_in_workflow_sync(client: Client):
         )
         assert not res
 
-        
+
 class SignalInterceptor(temporalio.worker.Interceptor):
     def workflow_interceptor_class(
         self, input: temporalio.worker.WorkflowInterceptorClassInput
@@ -8035,4 +8034,3 @@ async def test_signal_handler_in_interceptor(client: Client):
             id=f"workflow-{uuid.uuid4()}",
             task_queue=worker.task_queue,
         )
-


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Catch runtime error if asynio loop doesn't exist, returning False in `workflow.in_workflow`

## Why?
Result of `workflow.in_workflow` should be available inside sync activities

## Checklist
<!--- add/delete as needed --->

1. Closes #878 

2. How was this tested:
New workflow test

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
