### PR TITLE
Update pyo3 to 0.25 and convert to pyo3-async-runtimes

### DIFF
--- a/temporalio/bridge/Cargo.lock
+++ b/temporalio/bridge/Cargo.lock
@@ -874,12 +874,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -1783,7 +1777,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "itertools",
  "log",
  "multimap",
@@ -1840,7 +1834,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07b8bf115b70a7aa5af1fd5d6e9418492e9ccb6e4785e858c938e28d132a884b"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "prost",
  "prost-build",
  "prost-types",
@@ -1887,16 +1881,15 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "f239d656363bcee73afef85277f1b281e8ac6212a1d42aa90e55b90ed43c47a4"
 dependencies = [
  "anyhow",
- "cfg-if",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -1905,10 +1898,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyo3-asyncio"
-version = "0.20.0"
+name = "pyo3-async-runtimes"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea6b68e93db3622f3bb3bf363246cf948ed5375afe7abff98ccbdd50b184995"
+checksum = "d73cc6b1b7d8b3cef02101d37390dbdfe7e450dfea14921cae80a9534ba59ef2"
 dependencies = [
  "futures",
  "once_cell",
@@ -1919,9 +1912,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "755ea671a1c34044fa165247aaf6f419ca39caa6003aee791a0df2713d8f1b6d"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1929,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "fc95a2e67091e44791d4ea300ff744be5293f394f1bafd9f78c080814d35956e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1939,9 +1932,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "a179641d1b93920829a62f15e87c0ed791b6c8db2271ba0fd7c2686090510214"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1951,11 +1944,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "9dff85ebcaab8c441b0e3f7ae40a6963ecea8a9f5e74f647e33fcf5ec9a1e89e"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -1964,9 +1957,9 @@ dependencies = [
 
 [[package]]
 name = "pythonize"
-version = "0.20.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd1c3ef39c725d63db5f9bc455461bafd80540cb7824c61afb823501921a850"
+checksum = "597907139a488b22573158793aa7539df36ae863eba300c75f3a0d65fc475e27"
 dependencies = [
  "pyo3",
  "serde",
@@ -2612,9 +2605,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"
@@ -2668,7 +2661,7 @@ dependencies = [
  "log",
  "prost",
  "pyo3",
- "pyo3-asyncio",
+ "pyo3-async-runtimes",
  "pythonize",
  "temporal-client",
  "temporal-sdk-core",

--- a/temporalio/bridge/Cargo.toml
+++ b/temporalio/bridge/Cargo.toml
@@ -21,9 +21,9 @@ async-trait = "0.1"
 futures = "0.3"
 log = "0.4"
 prost = "0.13"
-pyo3 = { version = "0.20", features = ["extension-module", "abi3-py39", "anyhow"] }
-pyo3-asyncio = { version = "0.20", features = ["tokio-runtime"] }
-pythonize = "0.20"
+pyo3 = { version = "0.25", features = ["extension-module", "abi3-py39", "anyhow"] }
+pyo3-async-runtimes = { version = "0.25", features = ["tokio-runtime"] }
+pythonize = "0.25"
 temporal-client = { version = "0.1.0", path = "./sdk-core/client" }
 temporal-sdk-core = { version = "0.1.0", path = "./sdk-core/core", features = ["ephemeral-server"] }
 temporal-sdk-core-api = { version = "0.1.0", path = "./sdk-core/core-api" }

--- a/temporalio/bridge/src/client.rs
+++ b/temporalio/bridge/src/client.rs
@@ -80,7 +80,7 @@ pub fn connect_client<'a>(
     py: Python<'a>,
     runtime_ref: &runtime::RuntimeRef,
     config: ClientConfig,
-) -> PyResult<&'a PyAny> {
+) -> PyResult<Bound<'a, PyAny>> {
     let opts: ClientOptions = config.try_into()?;
     let runtime = runtime_ref.runtime.clone();
     runtime_ref.runtime.future_into_py(py, async move {
@@ -126,7 +126,7 @@ impl ClientRef {
         self.retry_client.get_client().set_api_key(api_key);
     }
 
-    fn call_workflow_service<'p>(&self, py: Python<'p>, call: RpcCall) -> PyResult<&'p PyAny> {
+    fn call_workflow_service<'p>(&self, py: Python<'p>, call: RpcCall) -> PyResult<Bound<'p, PyAny>> {
         let mut retry_client = self.retry_client.clone();
         self.runtime.future_into_py(py, async move {
             let bytes = match call.rpc.as_str() {
@@ -362,11 +362,11 @@ impl ClientRef {
                 }
             }?;
             let bytes: &[u8] = &bytes;
-            Ok(Python::with_gil(|py| bytes.into_py(py)))
+            Python::with_gil(|py| Ok(bytes.into_pyobject(py)?.unbind()))
         })
     }
 
-    fn call_operator_service<'p>(&self, py: Python<'p>, call: RpcCall) -> PyResult<&'p PyAny> {
+    fn call_operator_service<'p>(&self, py: Python<'p>, call: RpcCall) -> PyResult<Bound<'p, PyAny>> {
         use temporal_client::OperatorService;
 
         let mut retry_client = self.retry_client.clone();
@@ -404,11 +404,11 @@ impl ClientRef {
                 }
             }?;
             let bytes: &[u8] = &bytes;
-            Ok(Python::with_gil(|py| bytes.into_py(py)))
+            Python::with_gil(|py| Ok(bytes.into_pyobject(py)?.unbind()))
         })
     }
 
-    fn call_cloud_service<'p>(&self, py: Python<'p>, call: RpcCall) -> PyResult<&'p PyAny> {
+    fn call_cloud_service<'p>(&self, py: Python<'p>, call: RpcCall) -> PyResult<Bound<'p, PyAny>> {
         use temporal_client::CloudService;
 
         let mut retry_client = self.retry_client.clone();
@@ -467,11 +467,11 @@ impl ClientRef {
                 }
             }?;
             let bytes: &[u8] = &bytes;
-            Ok(Python::with_gil(|py| bytes.into_py(py)))
+            Python::with_gil(|py| Ok(bytes.into_pyobject(py)?.unbind()))
         })
     }
 
-    fn call_test_service<'p>(&self, py: Python<'p>, call: RpcCall) -> PyResult<&'p PyAny> {
+    fn call_test_service<'p>(&self, py: Python<'p>, call: RpcCall) -> PyResult<Bound<'p, PyAny>> {
         let mut retry_client = self.retry_client.clone();
         self.runtime.future_into_py(py, async move {
             let bytes = match call.rpc.as_str() {
@@ -491,11 +491,11 @@ impl ClientRef {
                 }
             }?;
             let bytes: &[u8] = &bytes;
-            Ok(Python::with_gil(|py| bytes.into_py(py)))
+            Python::with_gil(|py| Ok(bytes.into_pyobject(py)?.unbind()))
         })
     }
 
-    fn call_health_service<'p>(&self, py: Python<'p>, call: RpcCall) -> PyResult<&'p PyAny> {
+    fn call_health_service<'p>(&self, py: Python<'p>, call: RpcCall) -> PyResult<Bound<'p, PyAny>> {
         let mut retry_client = self.retry_client.clone();
         self.runtime.future_into_py(py, async move {
             let bytes = match call.rpc.as_str() {
@@ -508,7 +508,7 @@ impl ClientRef {
                 }
             }?;
             let bytes: &[u8] = &bytes;
-            Ok(Python::with_gil(|py| bytes.into_py(py)))
+            Python::with_gil(|py| Ok(bytes.into_pyobject(py)?.unbind()))
         })
     }
 }
@@ -539,13 +539,13 @@ where
     match res {
         Ok(resp) => Ok(resp.get_ref().encode_to_vec()),
         Err(err) => {
-            Err(Python::with_gil(move |py| {
+            Python::with_gil(move |py| {
                 // Create tuple of "status", "message", and optional "details"
                 let code = err.code() as u32;
                 let message = err.message().to_owned();
-                let details = err.details().into_py(py);
-                RPCError::new_err((code, message, details))
-            }))
+                let details = err.details().into_pyobject(py)?.unbind();
+                Err(RPCError::new_err((code, message, details)))
+            })
         }
     }
 }

--- a/temporalio/bridge/src/lib.rs
+++ b/temporalio/bridge/src/lib.rs
@@ -8,7 +8,7 @@ mod testing;
 mod worker;
 
 #[pymodule]
-fn temporal_sdk_bridge(py: Python, m: &PyModule) -> PyResult<()> {
+fn temporal_sdk_bridge(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Client stuff
     m.add("RPCError", py.get_type::<client::RPCError>())?;
     m.add_class::<client::ClientRef>()?;
@@ -62,7 +62,7 @@ fn connect_client<'a>(
     py: Python<'a>,
     runtime_ref: &runtime::RuntimeRef,
     config: client::ClientConfig,
-) -> PyResult<&'a PyAny> {
+) -> PyResult<Bound<'a, PyAny>> {
     client::connect_client(py, runtime_ref, config)
 }
 
@@ -77,7 +77,7 @@ fn init_runtime(telemetry_config: runtime::TelemetryConfig) -> PyResult<runtime:
 }
 
 #[pyfunction]
-fn raise_in_thread(py: Python, thread_id: std::os::raw::c_long, exc: &PyAny) -> bool {
+fn raise_in_thread(py: Python, thread_id: std::os::raw::c_long, exc: &Bound<'_, PyAny>) -> bool {
     runtime::raise_in_thread(py, thread_id, exc)
 }
 
@@ -86,7 +86,7 @@ fn start_dev_server<'a>(
     py: Python<'a>,
     runtime_ref: &runtime::RuntimeRef,
     config: testing::DevServerConfig,
-) -> PyResult<&'a PyAny> {
+) -> PyResult<Bound<'a, PyAny>> {
     testing::start_dev_server(py, runtime_ref, config)
 }
 
@@ -95,7 +95,7 @@ fn start_test_server<'a>(
     py: Python<'a>,
     runtime_ref: &runtime::RuntimeRef,
     config: testing::TestServerConfig,
-) -> PyResult<&'a PyAny> {
+) -> PyResult<Bound<'a, PyAny>> {
     testing::start_test_server(py, runtime_ref, config)
 }
 
@@ -113,6 +113,6 @@ fn new_replay_worker<'a>(
     py: Python<'a>,
     runtime_ref: &runtime::RuntimeRef,
     config: worker::WorkerConfig,
-) -> PyResult<&'a PyTuple> {
+) -> PyResult<Bound<'a, PyTuple>> {
     worker::new_replay_worker(py, runtime_ref, config)
 }

--- a/temporalio/bridge/src/metric.rs
+++ b/temporalio/bridge/src/metric.rs
@@ -273,21 +273,11 @@ pub struct BufferedMetricUpdate {
     pub attributes: Py<PyDict>,
 }
 
-#[derive(Clone)]
+#[derive(IntoPyObject, Clone)]
 pub enum BufferedMetricUpdateValue {
     U64(u64),
     U128(u128),
     F64(f64),
-}
-
-impl IntoPy<PyObject> for BufferedMetricUpdateValue {
-    fn into_py(self, py: Python) -> PyObject {
-        match self {
-            BufferedMetricUpdateValue::U64(v) => v.into_py(py),
-            BufferedMetricUpdateValue::U128(v) => v.into_py(py),
-            BufferedMetricUpdateValue::F64(v) => v.into_py(py),
-        }
-    }
 }
 
 // WARNING: This must match temporalio.runtime.BufferedMetric protocol
@@ -304,10 +294,10 @@ pub struct BufferedMetric {
 }
 
 #[derive(Debug)]
-struct BufferedMetricAttributes(Py<PyDict>);
+struct BufferedMetricAttributes(Arc<Py<PyDict>>);
 
 #[derive(Clone, Debug)]
-pub struct BufferedMetricRef(Py<BufferedMetric>);
+pub struct BufferedMetricRef(Arc<Py<BufferedMetric>>);
 
 impl BufferInstrumentRef for BufferedMetricRef {}
 
@@ -341,7 +331,7 @@ fn convert_metric_event(
             kind,
         } => {
             let buffered_ref = BufferedMetricRef(
-                Py::new(
+                Arc::new(Py::new(
                     py,
                     BufferedMetric {
                         name: params.name.to_string(),
@@ -371,7 +361,7 @@ fn convert_metric_event(
                     },
                 )
                 .expect("Unable to create buffered metric"),
-            );
+            ));
             populate_into.set(Arc::new(buffered_ref)).unwrap();
             None
         }
@@ -390,14 +380,14 @@ fn convert_metric_event(
                     .downcast::<BufferedMetricAttributes>()
                     .expect("Unable to downcast to expected buffered metric attributes")
                     .0
-                    .as_ref(py)
+                    .bind(py)
                     .copy()
                     .expect("Failed to copy metric attribute dictionary")
                     .into(),
                 None => PyDict::new(py).into(),
             };
             // Add attributes
-            let new_attrs = new_attrs_ref.as_ref(py);
+            let new_attrs = new_attrs_ref.bind(py);
             for kv in attributes.into_iter() {
                 match kv.value {
                     metrics::MetricValue::String(v) => new_attrs.set_item(kv.key, v),
@@ -409,7 +399,7 @@ fn convert_metric_event(
             }
             // Put on lazy ref
             populate_into
-                .set(Arc::new(BufferedMetricAttributes(new_attrs_ref)))
+                .set(Arc::new(BufferedMetricAttributes(Arc::new(new_attrs_ref))))
                 .expect("Unable to set buffered metric attributes on reference");
             None
         }
@@ -419,7 +409,7 @@ fn convert_metric_event(
             attributes,
             update,
         } => Some(BufferedMetricUpdate {
-            metric: instrument.get().clone().0.clone(),
+            metric: instrument.get().clone().0.clone_ref(py),
             value: match update {
                 metrics::MetricUpdateVal::Duration(v) if durations_as_seconds => {
                     BufferedMetricUpdateValue::F64(v.as_secs_f64())
@@ -439,7 +429,7 @@ fn convert_metric_event(
                 .downcast::<BufferedMetricAttributes>()
                 .expect("Unable to downcast to expected buffered metric attributes")
                 .0
-                .clone(),
+                .clone_ref(py),
         }),
     }
 }

--- a/temporalio/bridge/src/testing.rs
+++ b/temporalio/bridge/src/testing.rs
@@ -46,7 +46,7 @@ pub fn start_dev_server<'a>(
     py: Python<'a>,
     runtime_ref: &runtime::RuntimeRef,
     config: DevServerConfig,
-) -> PyResult<&'a PyAny> {
+) -> PyResult<Bound<'a, PyAny>> {
     let opts: ephemeral_server::TemporalDevServerConfig = config.try_into()?;
     let runtime = runtime_ref.runtime.clone();
     runtime_ref.runtime.future_into_py(py, async move {
@@ -63,7 +63,7 @@ pub fn start_test_server<'a>(
     py: Python<'a>,
     runtime_ref: &runtime::RuntimeRef,
     config: TestServerConfig,
-) -> PyResult<&'a PyAny> {
+) -> PyResult<Bound<'a, PyAny>> {
     let opts: ephemeral_server::TestServerConfig = config.try_into()?;
     let runtime = runtime_ref.runtime.clone();
     runtime_ref.runtime.future_into_py(py, async move {
@@ -96,7 +96,7 @@ impl EphemeralServerRef {
         Ok(server.has_test_service)
     }
 
-    fn shutdown<'p>(&mut self, py: Python<'p>) -> PyResult<&'p PyAny> {
+    fn shutdown<'p>(&mut self, py: Python<'p>) -> PyResult<Bound<'p, PyAny>> {
         let server = self.server.take();
         self.runtime.future_into_py(py, async move {
             if let Some(mut server) = server {

--- a/temporalio/bridge/src/worker.rs
+++ b/temporalio/bridge/src/worker.rs
@@ -5,7 +5,7 @@ use log::error;
 use prost::Message;
 use pyo3::exceptions::{PyException, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyDict, PyTuple};
+use pyo3::types::{PyBytes, PyTuple};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::marker::PhantomData;
@@ -36,7 +36,7 @@ pub struct WorkerRef {
     /// Set upon the call to `validate`, with the task locals for the event loop at that time, which
     /// is whatever event loop the user is running their worker in. This loop might be needed by
     /// other rust-created threads that want to run async python code.
-    event_loop_task_locals: Arc<OnceLock<pyo3_asyncio::TaskLocals>>,
+    event_loop_task_locals: Arc<OnceLock<pyo3_async_runtimes::TaskLocals>>,
     runtime: runtime::Runtime,
 }
 
@@ -126,20 +126,10 @@ pub struct LegacyBuildIdBased {
 }
 
 /// Recreates [temporal_sdk_core_api::worker::WorkerDeploymentVersion]
-#[derive(FromPyObject, Clone)]
+#[derive(FromPyObject, IntoPyObject, Clone)]
 pub struct WorkerDeploymentVersion {
     pub deployment_name: String,
     pub build_id: String,
-}
-
-impl IntoPy<Py<PyAny>> for WorkerDeploymentVersion {
-    fn into_py(self, py: Python) -> Py<PyAny> {
-        let dict = PyDict::new(py);
-        dict.set_item("deployment_name", self.deployment_name)
-            .unwrap();
-        dict.set_item("build_id", self.build_id).unwrap();
-        dict.into()
-    }
 }
 
 impl From<temporal_sdk_core_api::worker::WorkerDeploymentVersion> for WorkerDeploymentVersion {
@@ -262,38 +252,38 @@ pub struct SlotReleaseCtx {
     permit: PyObject,
 }
 
-fn slot_info_to_py_obj(py: Python<'_>, info: SlotInfo) -> PyObject {
-    match info {
+fn slot_info_to_py_obj<'py>(py: Python<'py>, info: SlotInfo) -> PyResult<Bound<'py, PyAny>> {
+    Ok(match info {
         SlotInfo::Workflow(w) => WorkflowSlotInfo {
             workflow_type: w.workflow_type.clone(),
             is_sticky: w.is_sticky,
         }
-        .into_py(py),
+        .into_pyobject(py)?.into_any(),
         SlotInfo::Activity(a) => ActivitySlotInfo {
             activity_type: a.activity_type.clone(),
         }
-        .into_py(py),
+        .into_pyobject(py)?.into_any(),
         SlotInfo::LocalActivity(a) => LocalActivitySlotInfo {
             activity_type: a.activity_type.clone(),
         }
-        .into_py(py),
+        .into_pyobject(py)?.into_any(),
         SlotInfo::Nexus(n) => NexusSlotInfo {
             service: n.service.clone(),
             operation: n.operation.clone(),
         }
-        .into_py(py),
-    }
+        .into_pyobject(py)?.into_any(),
+    })
 }
 
 #[pyclass]
 #[derive(Clone)]
 pub struct CustomSlotSupplier {
-    inner: PyObject,
+    inner: Arc<PyObject>,
 }
 
 struct CustomSlotSupplierOfType<SK: SlotKind> {
-    inner: PyObject,
-    event_loop_task_locals: Arc<OnceLock<pyo3_asyncio::TaskLocals>>,
+    inner: Arc<PyObject>,
+    event_loop_task_locals: Arc<OnceLock<pyo3_async_runtimes::TaskLocals>>,
     _phantom: PhantomData<SK>,
 }
 
@@ -301,7 +291,7 @@ struct CustomSlotSupplierOfType<SK: SlotKind> {
 impl CustomSlotSupplier {
     #[new]
     fn new(inner: PyObject) -> Self {
-        CustomSlotSupplier { inner }
+        CustomSlotSupplier { inner: Arc::new(inner) }
     }
 }
 
@@ -353,7 +343,7 @@ impl<SK: SlotKind + Send + Sync> SlotSupplierTrait for CustomSlotSupplierOfType<
             let stored_task = Arc::new(OnceLock::new());
             let _task_canceller = TaskCanceller::new(stored_task.clone());
             let pypermit = match Python::with_gil(|py| {
-                let py_obj = self.inner.as_ref(py);
+                let py_obj = self.inner.bind(py);
                 let called = py_obj.call_method1(
                     "reserve_slot",
                     (
@@ -365,7 +355,7 @@ impl<SK: SlotKind + Send + Sync> SlotSupplierTrait for CustomSlotSupplierOfType<
                     .event_loop_task_locals
                     .get()
                     .expect("task locals must be set");
-                pyo3_asyncio::into_future_with_locals(tl, called)
+                pyo3_async_runtimes::into_future_with_locals(tl, called)
             }) {
                 Ok(f) => f,
                 Err(e) => {
@@ -391,7 +381,7 @@ impl<SK: SlotKind + Send + Sync> SlotSupplierTrait for CustomSlotSupplierOfType<
 
     fn try_reserve_slot(&self, ctx: &dyn SlotReservationContext) -> Option<SlotSupplierPermit> {
         Python::with_gil(|py| {
-            let py_obj = self.inner.as_ref(py);
+            let py_obj = self.inner.bind(py);
             let pa = py_obj.call_method1(
                 "try_reserve_slot",
                 (SlotReserveCtx::from_ctx(SK::kind(), ctx),),
@@ -400,7 +390,7 @@ impl<SK: SlotKind + Send + Sync> SlotSupplierTrait for CustomSlotSupplierOfType<
             if pa.is_none() {
                 return Ok(None);
             }
-            PyResult::Ok(Some(SlotSupplierPermit::with_user_data(pa.into_py(py))))
+            PyResult::Ok(Some(SlotSupplierPermit::with_user_data(pa.into_pyobject(py)?.unbind())))
         })
         .unwrap_or_else(|e| {
             error!(
@@ -416,13 +406,13 @@ impl<SK: SlotKind + Send + Sync> SlotSupplierTrait for CustomSlotSupplierOfType<
             let permit = ctx
                 .permit()
                 .user_data::<PyObject>()
-                .cloned()
+                .map(|o| o.clone_ref(py))
                 .unwrap_or_else(|| py.None());
-            let py_obj = self.inner.as_ref(py);
+            let py_obj = self.inner.bind(py);
             py_obj.call_method1(
                 "mark_slot_used",
                 (SlotMarkUsedCtx {
-                    slot_info: slot_info_to_py_obj(py, ctx.info().downcast()),
+                    slot_info: slot_info_to_py_obj(py, ctx.info().downcast())?.unbind(),
                     permit,
                 },),
             )?;
@@ -440,13 +430,18 @@ impl<SK: SlotKind + Send + Sync> SlotSupplierTrait for CustomSlotSupplierOfType<
             let permit = ctx
                 .permit()
                 .user_data::<PyObject>()
-                .cloned()
+                .map(|o| o.clone_ref(py))
                 .unwrap_or_else(|| py.None());
-            let py_obj = self.inner.as_ref(py);
+            let py_obj = self.inner.bind(py);
+            let slot_info = if let Some(info) = ctx.info() {
+                Some(slot_info_to_py_obj(py, info.downcast())?.unbind())
+            } else {
+                None
+            };
             py_obj.call_method1(
                 "release_slot",
                 (SlotReleaseCtx {
-                    slot_info: ctx.info().map(|i| slot_info_to_py_obj(py, i.downcast())),
+                    slot_info,
                     permit,
                 },),
             )?;
@@ -504,7 +499,7 @@ pub fn new_replay_worker<'a>(
     py: Python<'a>,
     runtime_ref: &runtime::RuntimeRef,
     config: WorkerConfig,
-) -> PyResult<&'a PyTuple> {
+) -> PyResult<Bound<'a, PyTuple>> {
     enter_sync!(runtime_ref.runtime);
     let event_loop_task_locals = Arc::new(OnceLock::new());
     let config = convert_worker_config(config, event_loop_task_locals.clone())?;
@@ -520,17 +515,17 @@ pub fn new_replay_worker<'a>(
     };
     Ok(PyTuple::new(
         py,
-        [worker.into_py(py), history_pusher.into_py(py)],
-    ))
+        [worker.into_pyobject(py)?.into_any(), history_pusher.into_pyobject(py)?.into_any()],
+    )?)
 }
 
 #[pymethods]
 impl WorkerRef {
-    fn validate<'p>(&self, py: Python<'p>) -> PyResult<&'p PyAny> {
+    fn validate<'p>(&self, py: Python<'p>) -> PyResult<Bound<PyAny,'p>> {
         let worker = self.worker.as_ref().unwrap().clone();
         // Set custom slot supplier task locals so they can run futures.
         // Event loop is assumed to be running at this point.
-        let task_locals = pyo3_asyncio::TaskLocals::with_running_loop(py)?.copy_context(py)?;
+        let task_locals = pyo3_async_runtimes::TaskLocals::with_running_loop(py)?.copy_context(py)?;
         self.event_loop_task_locals
             .set(task_locals)
             .expect("must only be set once");
@@ -544,7 +539,7 @@ impl WorkerRef {
         })
     }
 
-    fn poll_workflow_activation<'p>(&self, py: Python<'p>) -> PyResult<&'p PyAny> {
+    fn poll_workflow_activation<'p>(&self, py: Python<'p>) -> PyResult<Bound<'p, PyAny>> {
         let worker = self.worker.as_ref().unwrap().clone();
         self.runtime.future_into_py(py, async move {
             let bytes = match worker.poll_workflow_activation().await {
@@ -553,11 +548,11 @@ impl WorkerRef {
                 Err(err) => return Err(PyRuntimeError::new_err(format!("Poll failure: {}", err))),
             };
             let bytes: &[u8] = &bytes;
-            Ok(Python::with_gil(|py| bytes.into_py(py)))
+            Python::with_gil(|py| Ok(bytes.into_pyobject(py)?.unbind()))
         })
     }
 
-    fn poll_activity_task<'p>(&self, py: Python<'p>) -> PyResult<&'p PyAny> {
+    fn poll_activity_task<'p>(&self, py: Python<'p>) -> PyResult<Bound<'p, PyAny>> {
         let worker = self.worker.as_ref().unwrap().clone();
         self.runtime.future_into_py(py, async move {
             let bytes = match worker.poll_activity_task().await {
@@ -566,15 +561,15 @@ impl WorkerRef {
                 Err(err) => return Err(PyRuntimeError::new_err(format!("Poll failure: {}", err))),
             };
             let bytes: &[u8] = &bytes;
-            Ok(Python::with_gil(|py| bytes.into_py(py)))
+            Python::with_gil(|py| Ok(bytes.into_pyobject(py)?.unbind()))
         })
     }
 
     fn complete_workflow_activation<'p>(
         &self,
         py: Python<'p>,
-        proto: &PyBytes,
-    ) -> PyResult<&'p PyAny> {
+        proto: &Bound<'_, PyBytes>,
+    ) -> PyResult<Bound<'p, PyAny>> {
         let worker = self.worker.as_ref().unwrap().clone();
         let completion = WorkflowActivationCompletion::decode(proto.as_bytes())
             .map_err(|err| PyValueError::new_err(format!("Invalid proto: {}", err)))?;
@@ -587,7 +582,7 @@ impl WorkerRef {
         })
     }
 
-    fn complete_activity_task<'p>(&self, py: Python<'p>, proto: &PyBytes) -> PyResult<&'p PyAny> {
+    fn complete_activity_task<'p>(&self, py: Python<'p>, proto: &Bound<'_, PyBytes>) -> PyResult<Bound<'p, PyAny>> {
         let worker = self.worker.as_ref().unwrap().clone();
         let completion = ActivityTaskCompletion::decode(proto.as_bytes())
             .map_err(|err| PyValueError::new_err(format!("Invalid proto: {}", err)))?;
@@ -600,7 +595,7 @@ impl WorkerRef {
         })
     }
 
-    fn record_activity_heartbeat(&self, proto: &PyBytes) -> PyResult<()> {
+    fn record_activity_heartbeat(&self, proto: &Bound<'_, PyBytes>) -> PyResult<()> {
         enter_sync!(self.runtime);
         let heartbeat = ActivityHeartbeat::decode(proto.as_bytes())
             .map_err(|err| PyValueError::new_err(format!("Invalid proto: {}", err)))?;
@@ -633,7 +628,7 @@ impl WorkerRef {
         Ok(())
     }
 
-    fn finalize_shutdown<'p>(&mut self, py: Python<'p>) -> PyResult<&'p PyAny> {
+    fn finalize_shutdown<'p>(&mut self, py: Python<'p>) -> PyResult<Bound<'p, PyAny>> {
         // Take the worker out of the option and leave None. This should be the
         // only reference remaining to the worker so try_unwrap will work.
         let worker = Arc::try_unwrap(self.worker.take().unwrap()).map_err(|arc| {
@@ -651,7 +646,7 @@ impl WorkerRef {
 
 fn convert_worker_config(
     conf: WorkerConfig,
-    task_locals: Arc<OnceLock<pyo3_asyncio::TaskLocals>>,
+    task_locals: Arc<OnceLock<pyo3_async_runtimes::TaskLocals>>,
 ) -> PyResult<temporal_sdk_core::WorkerConfig> {
     let converted_tuner = convert_tuner_holder(conf.tuner, task_locals)?;
     let converted_versioning_strategy = convert_versioning_strategy(conf.versioning_strategy);
@@ -703,7 +698,7 @@ fn convert_worker_config(
 
 fn convert_tuner_holder(
     holder: TunerHolder,
-    task_locals: Arc<OnceLock<pyo3_asyncio::TaskLocals>>,
+    task_locals: Arc<OnceLock<pyo3_async_runtimes::TaskLocals>>,
 ) -> PyResult<temporal_sdk_core::TunerHolder> {
     // Verify all resource-based options are the same if any are set
     let maybe_wf_resource_opts =
@@ -774,7 +769,7 @@ fn convert_tuner_holder(
 
 fn convert_slot_supplier<SK: SlotKind + Send + Sync + 'static>(
     supplier: SlotSupplier,
-    task_locals: Arc<OnceLock<pyo3_asyncio::TaskLocals>>,
+    task_locals: Arc<OnceLock<pyo3_async_runtimes::TaskLocals>>,
 ) -> PyResult<temporal_sdk_core::SlotSupplierOptions<SK>> {
     Ok(match supplier {
         SlotSupplier::FixedSize(fs) => temporal_sdk_core::SlotSupplierOptions::FixedSize {
@@ -857,8 +852,8 @@ impl HistoryPusher {
         &self,
         py: Python<'p>,
         workflow_id: &str,
-        history_proto: &PyBytes,
-    ) -> PyResult<&'p PyAny> {
+        history_proto: &Bound<'_, PyBytes>,
+    ) -> PyResult<Bound<'p, PyAny>> {
         let history = History::decode(history_proto.as_bytes())
             .map_err(|err| PyValueError::new_err(format!("Invalid proto: {}", err)))?;
         let wfid = workflow_id.to_string();


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Update pyo3 to 0.25 and convert to pyo3-async-runtimes

## Why?
pyo3-asyncio is abandoned, and pyo3 0.25 contains support for python 3.14

## Checklist
<!--- add/delete as needed --->

1. Closes #816 

2. How was this tested:
Regression tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
