### PR TITLE
Deprecate VersioningIntent

### DIFF
--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -2194,6 +2194,7 @@ def start_activity(
             need to. Contact Temporal before setting this value.
         versioning_intent: When using the Worker Versioning feature, specifies whether this Activity
             should run on a worker with a compatible Build Id or not.
+            Deprecated: Use Worker Deployment versioning instead.
         summary: A single-line fixed summary for this activity that may appear in UI/CLI.
             This can be in single-line Temporal markdown format.
         priority: Priority of the activity.
@@ -4161,6 +4162,7 @@ async def start_child_workflow(
             form of this is DEPRECATED.
         versioning_intent:  When using the Worker Versioning feature, specifies whether this Child
             Workflow should run on a worker with a compatible Build Id or not.
+            Deprecated: Use Worker Deployment versioning instead.
         static_summary: A single-line fixed summary for this child workflow execution that may appear
             in the UI/CLI. This can be in single-line Temporal markdown format.
         static_details: General fixed details for this child workflow execution that may appear in
@@ -4624,6 +4626,7 @@ def continue_as_new(
             DEPRECATED.
         versioning_intent: When using the Worker Versioning feature, specifies whether this Workflow
             should Continue-as-New onto a worker with a compatible Build Id or not.
+            Deprecated: Use Worker Deployment versioning instead.
 
     Returns:
         Never returns, always raises a :py:class:`ContinueAsNewError`.
@@ -5056,6 +5059,9 @@ class VersioningIntent(Enum):
     Where this type is accepted optionally, an unset value indicates that the SDK should choose the
     most sensible default behavior for the type of command, accounting for whether the command will
     be run on the same task queue as the current worker.
+
+    .. deprecated::
+        Use Worker Deployment versioning instead.
     """
 
     COMPATIBLE = 1


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
VersioningIntent should've been deprecated along with the rest of the old versioning APIs when deployment based versioning was introduced

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
