### PR TITLE
Evolve sandbox documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,7 +960,7 @@ If you are getting an error like:
 
 Then either:
 - [Most commonly] This is from a module that is safe to pass through (see "Passthrough Modules" section below).
-- You're using an invalid construct from the workflow, this is a known limitation of the sandbox, or
+- You're using an invalid construct from the workflow, this is a known limitation of the sandbox
 
 ##### How the Sandbox Works
 

--- a/README.md
+++ b/README.md
@@ -952,15 +952,6 @@ through all modules whose calls will be deterministic.** In particular, this adv
 activities to be referenced in workflows, and modules containing dataclasses and Pydantic models, which can be
 particularly expensive to import. See "Passthrough Modules" below on how to do this.
 
-If you are getting an error like:
-
-> temporalio.worker.workflow_sandbox._restrictions.RestrictedWorkflowAccessError: Cannot access
-> http.client.IncompleteRead.\_\_mro_entries\_\_ from inside a workflow. If this is code from a module not used in a
-> workflow or known to only be used deterministically from a workflow, mark the import as pass through.
-
-Then either:
-- [Most commonly] This is from a module that is safe to pass through (see "Passthrough Modules" section below).
-- You're using an invalid construct from the workflow (this is a known limitation of the sandbox).
 
 ##### How the Sandbox Works
 

--- a/README.md
+++ b/README.md
@@ -960,7 +960,7 @@ If you are getting an error like:
 
 Then either:
 - [Most commonly] This is from a module that is safe to pass through (see "Passthrough Modules" section below).
-- You're using an invalid construct from the workflow, this is a known limitation of the sandbox
+- You're using an invalid construct from the workflow (this is a known limitation of the sandbox).
 
 ##### How the Sandbox Works
 


### PR DESCRIPTION
Improve sandbox documentation, in particular relating to dataclasses and Pydantic models as a result of discussion in https://temporalio.slack.com/archives/CTT84RS0P/p1749927322488079.