### PR TITLE
Pin windows python version to 3.13.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
             pythonOverride: "3.13.2"
           - os: macos-arm
             runsOn: macos-latest
+          # On 3.13.5, python3.lib is missing for the linker
+          - os: windows-latest
+            python: "3.13"
+            pythonOverride: "3.13.4"
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Pin python version to 3.13.4 for windows-latest

## Why?
3.13.5 introduced a linker error

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
CI passes

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
