### PR TITLE
Fix ValidatorIterator serialization

### DIFF
--- a/temporalio/contrib/openai_agents/invoke_model_activity.py
+++ b/temporalio/contrib/openai_agents/invoke_model_activity.py
@@ -24,6 +24,7 @@ from agents import (
     WebSearchTool,
 )
 from agents.models.multi_provider import MultiProvider
+from pydantic_core import to_jsonable_python
 from typing_extensions import Required, TypedDict
 
 from temporalio import activity, workflow
@@ -139,7 +140,7 @@ class ModelActivity:
 
         # workaround for https://github.com/pydantic/pydantic/issues/9541
         # ValidatorIterator returned
-        input_json = json.dumps(input["input"], default=str)
+        input_json = json.dumps(to_jsonable_python(input["input"]))
         input_input = json.loads(input_json)
 
         def make_tool(tool: ToolInput) -> Tool:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
`to_jsonable_python` is now used instead of `default=str` to serialize pydantic models.

## Why?
<!-- Tell your future self why have you made these changes -->
Without this change `ValidatorIterator` is serialized as `"ValidatorIterator(...)"`

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
