### PR TITLE
Making raise on cancellation the default

### DIFF
--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -1622,14 +1622,11 @@ class _WorkflowInstanceImpl(
                     if handle._result_fut.done():
                         # TODO in next release, check sdk flag when not replaying instead of global override, remove the override, and set flag use
                         if (
-                            (
-                                not self._is_replaying
-                                and _raise_on_cancelling_completed_activity_override
-                            )
+                            not self._is_replaying
                             or _WorkflowLogicFlag.RAISE_ON_CANCELLING_COMPLETED_ACTIVITY
                             in self._current_internal_flags
                         ):
-                            # self._current_completion.successful.used_internal_flags.append(WorkflowLogicFlag.RAISE_ON_CANCELLING_COMPLETED_ACTIVITY)
+                            self._current_completion.successful.used_internal_flags.append(_WorkflowLogicFlag.RAISE_ON_CANCELLING_COMPLETED_ACTIVITY)
                             raise
                     # Send a cancel request to the activity
                     handle._apply_cancel_command(self._add_command())
@@ -3139,6 +3136,3 @@ class _WorkflowLogicFlag(IntEnum):
 
     RAISE_ON_CANCELLING_COMPLETED_ACTIVITY = 1
 
-
-# Used by tests to validate behavior prior to SDK flag becoming default
-_raise_on_cancelling_completed_activity_override = False

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -8005,8 +8005,6 @@ async def test_quick_activity_swallows_cancellation(client: Client):
         activities=[short_activity_async],
         activity_executor=concurrent.futures.ThreadPoolExecutor(max_workers=1),
     ) as worker:
-        temporalio.worker._workflow_instance._raise_on_cancelling_completed_activity_override = True
-
         for i in range(10):
             wf_duration = random.uniform(5.0, 15.0)
             wf_handle = await client.start_workflow(
@@ -8027,8 +8025,6 @@ async def test_quick_activity_swallows_cancellation(client: Client):
 
             assert isinstance(cause, CancelledError)
             assert cause.message == "Workflow cancelled"
-
-        temporalio.worker._workflow_instance._raise_on_cancelling_completed_activity_override = False
 
 
 async def test_workflow_logging_trace_identifier(client: Client):


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Set `RAISE_ON_CANCELLING_COMPLETED_ACTIVITY` when not replaying, and reraise by default.

## Why?
Prevents the swallowing of some activity cancellations

## Checklist
<!--- add/delete as needed --->

1. Closes #620 

2. How was this tested:
Modified tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
