### PR TITLE
Nexus error chain workaround

### DIFF
--- a/temporalio/worker/_nexus.py
+++ b/temporalio/worker/_nexus.py
@@ -444,7 +444,6 @@ def _exception_to_handler_error(err: BaseException) -> nexusrpc.HandlerError:
         err = ApplicationError(
             message=str(handler_err),
             non_retryable=not handler_err.retryable,
-            type=f"{handler_err.__class__.__module__}.{handler_err.__class__.__qualname__}",
         )
         err.__traceback__ = handler_err.__traceback__
         err.__cause__ = handler_err.__cause__

--- a/temporalio/worker/_nexus.py
+++ b/temporalio/worker/_nexus.py
@@ -337,38 +337,24 @@ class _NexusWorker:
 
         See https://github.com/nexus-rpc/api/blob/main/SPEC.md#failure
         """
-        message = str(error)
         if cause := error.__cause__:
             try:
                 failure = temporalio.api.failure.v1.Failure()
                 await self._data_converter.encode_failure(cause, failure)
-                # nexusrpc.HandlerError and nexusrpc.OperationError have their
-                # own error messages and stack traces, independent of any cause
-                # exception they may have, and it would be reasonable to expect
-                # these to be propagated to the caller.
-                #
-                # In the case of OperationError (UnsuccessfulOperationError
-                # proto), the server takes the message from the top-level
-                # UnsuccessfulOperationError and replace the message of the
-                # first entry in the details chain with it. Presumably the
-                # server is anticipating that we've hoisted the message to that
-                # position and is undoing the hoist. Therefore in that case, we
-                # put the message from the first entry of the details chain at
-                # the top level and accept that the message of the
-                # OperationError itself will be lost.
-                #
-                # Note that other SDKs (e.g. Java) remove the message from the
-                # first item in the details chain, since constructors are
-                # controlled such that the nexus exception itself does not have
-                # its own message.
-                #
+                # Following other SDKs, we move the message from the first item
+                # in the details chain to the top level nexus.v1.Failure
+                # message. In Go and Java this particularly makes sense since
+                # their constructors are controlled such that the nexus
+                # exception itself does not have its own message. However, in
+                # Python, nexusrpc.HandlerError and nexusrpc.OperationError have
+                # their own error messages and stack traces, independent of any
+                # cause exception they may have, and this must be propagated to
+                # the caller. See _exception_to_handler_error for how we address
+                # this by injecting an additional error into the cause chain
+                # before the current function is called.
                 failure_dict = google.protobuf.json_format.MessageToDict(failure)
-                if isinstance(error, nexusrpc.OperationError):
-                    message = failure_dict.pop("message", str(error))
-                else:
-                    message = str(error)
                 return temporalio.api.nexus.v1.Failure(
-                    message=message,
+                    message=failure_dict.pop("message", str(error)),
                     metadata={"type": _TEMPORAL_FAILURE_PROTO_TYPE},
                     details=json.dumps(
                         failure_dict,

--- a/tests/nexus/test_workflow_caller_error_chains.py
+++ b/tests/nexus/test_workflow_caller_error_chains.py
@@ -175,7 +175,6 @@ class RaiseNexusHandlerErrorNotFound(ErrorConversionTestCase):
             ApplicationError,
             {
                 "message": "handler-error-message",
-                "type": "nexusrpc._common.HandlerError",
                 "non_retryable": True,
             },
         ),

--- a/tests/nexus/test_workflow_caller_error_chains.py
+++ b/tests/nexus/test_workflow_caller_error_chains.py
@@ -174,9 +174,15 @@ class RaiseNexusHandlerErrorNotFound(ErrorConversionTestCase):
         (
             ApplicationError,
             {
-                # TODO(nexus-preview): empirically, this is "handler-error-message",
-                # but it should be "runtime-error-message"
-                # "message": "runtime-error-message",
+                "message": "handler-error-message",
+                "type": "nexusrpc._common.HandlerError",
+                "non_retryable": True,
+            },
+        ),
+        (
+            ApplicationError,
+            {
+                "message": "runtime-error-message",
                 "type": "RuntimeError",
                 "non_retryable": False,
             },
@@ -234,7 +240,7 @@ class RaiseNexusHandlerErrorNotFoundFromHandlerErrorUnavailable(
             (
                 nexusrpc.HandlerError,
                 {
-                    "message": "handler-error-message",
+                    "message": "handler-error-message-2",
                     "type": nexusrpc.HandlerErrorType.UNAVAILABLE,
                     "retryable": True,
                 },


### PR DESCRIPTION
Inject an additional error into the cause chain to work around the fact that `HandlerError` is an independent exception with its own error message and stack trace (unlike Go and Java).