### PR TITLE
Set supported pyright diagnostics explicitly in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,16 @@ project-name = "Temporal Python"
 sidebar-expand-depth = 2
 
 [tool.pyright]
+reportUnknownVariableType = "none"
+reportUnknownParameterType = "none"
+reportUnusedCallResult = "none"
+reportImplicitStringConcatenation = "none"
+reportPrivateUsage = "none"
+reportExplicitAny = "none"
+reportMissingTypeArgument = "none"
+reportAny = "none"
+enableTypeIgnoreComments = true
+
 include = ["temporalio", "tests"]
 exclude = [
   "temporalio/api",


### PR DESCRIPTION
A change of this sort (modulo the exact set of exclusions we make) is essentially forced on us by Cursor's switch to https://github.com/DetachHead/basedpyright, which AFAIK defaults to  reporting every type checking error category. The set added here are ones that I've found to be essential given the current state and conventions in our codebase.

However, I think that this is a good direction, independently of Cursor: by explicitly specifying the subset of Pyright diagnostics that we support, we should be able to get to the position where the type-checking requirements made by our CI exactly match those made by our IDE.