### PR TITLE
Nexus: use links from StartWorkflowExecutionResponse if present

### DIFF
--- a/temporalio/client.py
+++ b/temporalio/client.py
@@ -1542,6 +1542,12 @@ class WorkflowHandle(Generic[SelfType, ReturnType]):
         result_run_id: Optional[str] = None,
         first_execution_run_id: Optional[str] = None,
         result_type: Optional[Type] = None,
+        start_workflow_response: Optional[
+            Union[
+                temporalio.api.workflowservice.v1.StartWorkflowExecutionResponse,
+                temporalio.api.workflowservice.v1.SignalWithStartWorkflowExecutionResponse,
+            ]
+        ] = None,
     ) -> None:
         """Create workflow handle."""
         self._client = client
@@ -1550,6 +1556,7 @@ class WorkflowHandle(Generic[SelfType, ReturnType]):
         self._result_run_id = result_run_id
         self._first_execution_run_id = first_execution_run_id
         self._result_type = result_type
+        self._start_workflow_response = start_workflow_response
         self.__temporal_eagerly_started = False
 
     @property
@@ -5832,6 +5839,7 @@ class _ClientImpl(OutboundInterceptor):
             result_run_id=resp.run_id,
             first_execution_run_id=first_execution_run_id,
             result_type=input.ret_type,
+            start_workflow_response=resp,
         )
         setattr(handle, "__temporal_eagerly_started", eagerly_started)
         return handle

--- a/temporalio/nexus/_link_conversion.py
+++ b/temporalio/nexus/_link_conversion.py
@@ -23,7 +23,7 @@ LINK_EVENT_ID_PARAM_NAME = "eventID"
 LINK_EVENT_TYPE_PARAM_NAME = "eventType"
 
 
-def workflow_handle_to_workflow_execution_started_event_link(
+def workflow_execution_started_event_link_from_workflow_handle(
     handle: temporalio.client.WorkflowHandle[Any, Any],
 ) -> temporalio.api.common.v1.Link.WorkflowEvent:
     """Create a WorkflowEvent link corresponding to a started workflow"""


### PR DESCRIPTION
On starting a nexus-backed workflow, a Nexus handler implementation must return to the nexus caller a link to the started workflow.

Newer server versions return the link to the started workflow in the `StartWorkflow` response. Nexus implementations, on starting a nexus-backed workflow, should use the link in the server's response if present, falling back to constructing the link themselves.

https://github.com/temporalio/sdk-go/pull/1934 is an analogous PR.