### PR TITLE
Fix circular import: do not import temporalio.client in temporalio.nexus

### DIFF
--- a/temporalio/client.py
+++ b/temporalio/client.py
@@ -56,6 +56,7 @@ import temporalio.api.workflowservice.v1
 import temporalio.common
 import temporalio.converter
 import temporalio.exceptions
+import temporalio.nexus
 import temporalio.runtime
 import temporalio.service
 import temporalio.workflow
@@ -7323,23 +7324,8 @@ class CloudOperationsClient:
         self.service_client.update_api_key(value)
 
 
-@dataclass(frozen=True)
-class NexusCallback:
-    """Nexus callback to attach to events such as workflow completion.
-
-    .. warning::
-        This API is experimental and unstable.
-    """
-
-    url: str
-    """Callback URL."""
-
-    headers: Mapping[str, str]
-    """Header to attach to callback request."""
-
-
 # Intended to become a union of callback types
-Callback = NexusCallback
+Callback = temporalio.nexus.NexusCallback
 
 
 async def _encode_user_metadata(

--- a/temporalio/nexus/__init__.py
+++ b/temporalio/nexus/__init__.py
@@ -9,6 +9,7 @@ See https://github.com/temporalio/sdk-python/tree/main#nexus
 from ._decorators import workflow_run_operation as workflow_run_operation
 from ._operation_context import Info as Info
 from ._operation_context import LoggerAdapter as LoggerAdapter
+from ._operation_context import NexusCallback as NexusCallback
 from ._operation_context import (
     WorkflowRunOperationContext as WorkflowRunOperationContext,
 )

--- a/temporalio/nexus/_decorators.py
+++ b/temporalio/nexus/_decorators.py
@@ -16,16 +16,10 @@ from nexusrpc.handler import (
     StartOperationContext,
 )
 
-from temporalio.nexus._operation_context import (
-    WorkflowRunOperationContext,
-)
-from temporalio.nexus._operation_handlers import (
-    WorkflowRunOperationHandler,
-)
-from temporalio.nexus._token import (
-    WorkflowHandle,
-)
-from temporalio.nexus._util import (
+from ._operation_context import WorkflowRunOperationContext
+from ._operation_handlers import WorkflowRunOperationHandler
+from ._token import WorkflowHandle
+from ._util import (
     get_callable_name,
     get_workflow_run_start_method_input_and_output_type_annotations,
     set_operation_factory,

--- a/temporalio/nexus/_link_conversion.py
+++ b/temporalio/nexus/_link_conversion.py
@@ -4,6 +4,7 @@ import logging
 import re
 import urllib.parse
 from typing import (
+    TYPE_CHECKING,
     Any,
     Optional,
 )
@@ -12,7 +13,9 @@ import nexusrpc
 
 import temporalio.api.common.v1
 import temporalio.api.enums.v1
-import temporalio.client
+
+if TYPE_CHECKING:
+    import temporalio.client
 
 logger = logging.getLogger(__name__)
 

--- a/temporalio/nexus/_operation_handlers.py
+++ b/temporalio/nexus/_operation_handlers.py
@@ -22,7 +22,6 @@ from nexusrpc.handler import (
     StartOperationResultAsync,
 )
 
-from temporalio import client
 from temporalio.nexus._operation_context import (
     _temporal_cancel_operation_context,
 )
@@ -67,15 +66,14 @@ class WorkflowRunOperationHandler(OperationHandler[InputT, OutputT]):
         """Start the operation, by starting a workflow and completing asynchronously."""
         handle = await self._start(ctx, input)
         if not isinstance(handle, WorkflowHandle):
-            if isinstance(handle, client.WorkflowHandle):
-                raise RuntimeError(
-                    f"Expected {handle} to be a nexus.WorkflowHandle, but got a client.WorkflowHandle. "
-                    f"You must use WorkflowRunOperationContext.start_workflow "
-                    "to start a workflow that will deliver the result of the Nexus operation, "
-                    "not client.Client.start_workflow."
-                )
             raise RuntimeError(
                 f"Expected {handle} to be a nexus.WorkflowHandle, but got {type(handle)}. "
+                f"When using @workflow_run_operation you must use "
+                "WorkflowRunOperationContext.start_workflow() "
+                "to start a workflow that will deliver the result of the Nexus operation, "
+                "and you must return the nexus.WorkflowHandle that it returns. "
+                "It is not possible to use client.Client.start_workflow() and client.WorkflowHandle "
+                "for this purpose."
             )
         return StartOperationResultAsync(handle.to_token())
 

--- a/temporalio/nexus/_token.py
+++ b/temporalio/nexus/_token.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 import base64
 import json
 from dataclasses import dataclass
-from typing import Any, Generic, Literal, Optional, Type
+from typing import TYPE_CHECKING, Any, Generic, Literal, Optional
 
 from nexusrpc import OutputT
 
-from temporalio import client
-
 OperationTokenType = Literal[1]
 OPERATION_TOKEN_TYPE_WORKFLOW: OperationTokenType = 1
+
+if TYPE_CHECKING:
+    import temporalio.client
 
 
 @dataclass(frozen=True)
@@ -32,8 +33,10 @@ class WorkflowHandle(Generic[OutputT]):
     version: Optional[int] = None
 
     def _to_client_workflow_handle(
-        self, client: client.Client, result_type: Optional[Type[OutputT]] = None
-    ) -> client.WorkflowHandle[Any, OutputT]:
+        self,
+        client: temporalio.client.Client,
+        result_type: Optional[type[OutputT]] = None,
+    ) -> temporalio.client.WorkflowHandle[Any, OutputT]:
         """Create a :py:class:`temporalio.client.WorkflowHandle` from the token."""
         if client.namespace != self.namespace:
             raise ValueError(
@@ -46,7 +49,7 @@ class WorkflowHandle(Generic[OutputT]):
     # handle type.
     @classmethod
     def _unsafe_from_client_workflow_handle(
-        cls, workflow_handle: client.WorkflowHandle[Any, OutputT]
+        cls, workflow_handle: temporalio.client.WorkflowHandle[Any, OutputT]
     ) -> WorkflowHandle[OutputT]:
         """Create a :py:class:`WorkflowHandle` from a :py:class:`temporalio.client.WorkflowHandle`.
 


### PR DESCRIPTION
On main, a circular import error is revealed by doing e.g.

```
uv run tests/nexus/test_type_checking.py


Traceback (most recent call last):
  File "/Users/dan/src/temporalio/sdk-python/tests/nexus/test_type_checking.py", line 3, in <module>
    import temporalio.nexus
  File "/Users/dan/src/temporalio/sdk-python/temporalio/nexus/__init__.py", line 9, in <module>
    from ._decorators import workflow_run_operation as workflow_run_operation
  File "/Users/dan/src/temporalio/sdk-python/temporalio/nexus/_decorators.py", line 19, in <module>
    from temporalio.nexus._operation_context import (
  File "/Users/dan/src/temporalio/sdk-python/temporalio/nexus/_operation_context.py", line 22, in <module>
    import temporalio.client
  File "/Users/dan/src/temporalio/sdk-python/temporalio/client.py", line 60, in <module>
    import temporalio.workflow
  File "/Users/dan/src/temporalio/sdk-python/temporalio/workflow.py", line 62, in <module>
    from temporalio.nexus._util import ServiceHandlerT
  File "/Users/dan/src/temporalio/sdk-python/temporalio/nexus/_util.py", line 21, in <module>
    from temporalio.nexus._operation_context import WorkflowRunOperationContext
ImportError: cannot import name 'WorkflowRunOperationContext' from partially initialized module 'temporalio.nexus._operation_context' (most likely due to a circular import) (/Users/dan/src/temporalio/sdk-python/temporalio/nexus/_operation_context.py)
```

While that's not a command a user would actually run, the situation it reflects is undesirable and this will bite us at some point: `temporalio.nexus` has a run-time import dependency on `temporalio.client`.

This PR removes the dependency.