### PR TITLE
Nexus cancellation types

### DIFF
--- a/temporalio/worker/_interceptor.py
+++ b/temporalio/worker/_interceptor.py
@@ -298,6 +298,7 @@ class StartNexusOperationInput(Generic[InputT, OutputT]):
     operation: Union[nexusrpc.Operation[InputT, OutputT], str, Callable[..., Any]]
     input: InputT
     schedule_to_close_timeout: Optional[timedelta]
+    cancellation_type: temporalio.workflow.NexusOperationCancellationType
     headers: Optional[Mapping[str, str]]
     output_type: Optional[Type[OutputT]] = None
 

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -54,13 +54,13 @@ import temporalio.api.sdk.v1
 import temporalio.bridge.proto.activity_result
 import temporalio.bridge.proto.child_workflow
 import temporalio.bridge.proto.common
+import temporalio.bridge.proto.nexus
 import temporalio.bridge.proto.workflow_activation
 import temporalio.bridge.proto.workflow_commands
 import temporalio.bridge.proto.workflow_completion
 import temporalio.common
 import temporalio.converter
 import temporalio.exceptions
-import temporalio.nexus
 import temporalio.workflow
 from temporalio.service import __version__
 
@@ -881,9 +881,17 @@ class _WorkflowInstanceImpl(  # type: ignore[reportImplicitAbstractClass]
     ) -> None:
         handle = self._pending_nexus_operations.pop(job.seq, None)
         if not handle:
-            raise RuntimeError(
-                f"Failed to find nexus operation handle for job sequence number {job.seq}"
-            )
+            # One way this can occur is:
+            # 1. Cancel request issued with cancellation_type=WaitRequested.
+            # 2. Server receives nexus cancel handler task completion and writes
+            #    NexusOperationCancelRequestCompleted / NexusOperationCancelRequestFailed. On
+            #    consuming this event, core sends an activation resolving the handle future as
+            #    completed / failed.
+            # 4. Subsequently, the nexus operation completes as completed/failed, causing the server
+            #    to write NexusOperationCompleted / NexusOperationFailed. On consuming this event,
+            #    core sends an activation which would attempt to resolve the handle future as
+            #    completed / failed, but it has already been resolved.
+            return
 
         # Handle the four oneof variants of NexusOperationResult
         result = job.result
@@ -1500,9 +1508,10 @@ class _WorkflowInstanceImpl(  # type: ignore[reportImplicitAbstractClass]
         service: str,
         operation: Union[nexusrpc.Operation[InputT, OutputT], str, Callable[..., Any]],
         input: Any,
-        output_type: Optional[Type[OutputT]] = None,
-        schedule_to_close_timeout: Optional[timedelta] = None,
-        headers: Optional[Mapping[str, str]] = None,
+        output_type: Optional[Type[OutputT]],
+        schedule_to_close_timeout: Optional[timedelta],
+        cancellation_type: temporalio.workflow.NexusOperationCancellationType,
+        headers: Optional[Mapping[str, str]],
     ) -> temporalio.workflow.NexusOperationHandle[OutputT]:
         # start_nexus_operation
         return await self._outbound.start_nexus_operation(
@@ -1513,6 +1522,7 @@ class _WorkflowInstanceImpl(  # type: ignore[reportImplicitAbstractClass]
                 input=input,
                 output_type=output_type,
                 schedule_to_close_timeout=schedule_to_close_timeout,
+                cancellation_type=cancellation_type,
                 headers=headers,
             )
         )
@@ -1824,20 +1834,19 @@ class _WorkflowInstanceImpl(  # type: ignore[reportImplicitAbstractClass]
     async def _outbound_start_nexus_operation(
         self, input: StartNexusOperationInput[Any, OutputT]
     ) -> _NexusOperationHandle[OutputT]:
-        # A Nexus operation handle contains two futures: self._start_fut is resolved as a
-        # result of the Nexus operation starting (activation job:
-        # resolve_nexus_operation_start), and self._result_fut is resolved as a result of
-        # the Nexus operation completing (activation job: resolve_nexus_operation). The
-        # handle itself corresponds to an asyncio.Task which waits on self.result_fut,
-        # handling CancelledError by emitting a RequestCancelNexusOperation command. We do
-        # not return the handle until we receive resolve_nexus_operation_start, like
-        # ChildWorkflowHandle and unlike ActivityHandle. Note that a Nexus operation may
-        # complete synchronously (in which case both jobs will be sent in the same
-        # activation, and start will be resolved without an operation token), or
-        # asynchronously (in which case start they may be sent in separate activations,
-        # and start will be resolved with an operation token). See comments in
-        # tests/worker/test_nexus.py for worked examples of the evolution of the resulting
-        # handle state machine in the sync and async Nexus response cases.
+        # A Nexus operation handle contains two futures: self._start_fut is resolved as a result of
+        # the Nexus operation starting (activation job: resolve_nexus_operation_start), and
+        # self._result_fut is resolved as a result of the Nexus operation completing (activation
+        # job: resolve_nexus_operation). The handle itself corresponds to an asyncio.Task which
+        # waits on self.result_fut, handling CancelledError by emitting a
+        # RequestCancelNexusOperation command. We do not return the handle until we receive
+        # resolve_nexus_operation_start, like ChildWorkflowHandle and unlike ActivityHandle. Note
+        # that a Nexus operation may complete synchronously (in which case both jobs will be sent in
+        # the same activation, and start will be resolved without an operation token), or
+        # asynchronously (in which case they may be sent in separate activations, and start will be
+        # resolved with an operation token). See comments in tests/worker/test_nexus.py for worked
+        # examples of the evolution of the resulting handle state machine in the sync and async
+        # Nexus response cases.
         handle: _NexusOperationHandle[OutputT]
 
         async def operation_handle_fn() -> OutputT:
@@ -2758,7 +2767,7 @@ class _ActivityHandle(temporalio.workflow.ActivityHandle[Any]):
         if self._input.retry_policy:
             self._input.retry_policy.apply_to_proto(v.retry_policy)
         v.cancellation_type = cast(
-            "temporalio.bridge.proto.workflow_commands.ActivityCancellationType.ValueType",
+            temporalio.bridge.proto.workflow_commands.ActivityCancellationType.ValueType,
             int(self._input.cancellation_type),
         )
 
@@ -2894,7 +2903,7 @@ class _ChildWorkflowHandle(temporalio.workflow.ChildWorkflowHandle[Any, Any]):
         if self._input.task_timeout:
             v.workflow_task_timeout.FromTimedelta(self._input.task_timeout)
         v.parent_close_policy = cast(
-            "temporalio.bridge.proto.child_workflow.ParentClosePolicy.ValueType",
+            temporalio.bridge.proto.child_workflow.ParentClosePolicy.ValueType,
             int(self._input.parent_close_policy),
         )
         v.workflow_id_reuse_policy = cast(
@@ -2916,7 +2925,7 @@ class _ChildWorkflowHandle(temporalio.workflow.ChildWorkflowHandle[Any, Any]):
                 self._input.search_attributes, v.search_attributes
             )
         v.cancellation_type = cast(
-            "temporalio.bridge.proto.child_workflow.ChildWorkflowCancellationType.ValueType",
+            temporalio.bridge.proto.child_workflow.ChildWorkflowCancellationType.ValueType,
             int(self._input.cancellation_type),
         )
         if self._input.versioning_intent:
@@ -3012,11 +3021,6 @@ class _NexusOperationHandle(temporalio.workflow.NexusOperationHandle[OutputT]):
 
     @property
     def operation_token(self) -> Optional[str]:
-        # TODO(nexus-preview): How should this behave?
-        # Java has a separate class that only exists if the operation token exists:
-        # https://github.com/temporalio/sdk-java/blob/master/temporal-sdk/src/main/java/io/temporal/internal/sync/NexusOperationExecutionImpl.java#L26
-        # And Go similar:
-        # https://github.com/temporalio/sdk-go/blob/master/internal/workflow.go#L2770-L2771
         try:
             return self._start_fut.result()
         except BaseException:
@@ -3065,6 +3069,11 @@ class _NexusOperationHandle(temporalio.workflow.NexusOperationHandle[OutputT]):
             v.schedule_to_close_timeout.FromTimedelta(
                 self._input.schedule_to_close_timeout
             )
+        v.cancellation_type = cast(
+            temporalio.bridge.proto.nexus.NexusOperationCancellationType.ValueType,
+            int(self._input.cancellation_type),
+        )
+
         if self._input.headers:
             for key, val in self._input.headers.items():
                 v.nexus_header[key] = val

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,8 @@ async def env(env_type: str) -> AsyncGenerator[WorkflowEnvironment, None]:
                 "system.enableDeploymentVersions=true",
                 "--dynamic-config-value",
                 "frontend.activityAPIsEnabled=true",
+                "--dynamic-config-value",
+                "component.nexusoperations.recordCancelRequestCompletionEvents=true",
                 "--http-port",
                 str(http_port),
             ],

--- a/tests/nexus/test_workflow_caller_cancellation_types.py
+++ b/tests/nexus/test_workflow_caller_cancellation_types.py
@@ -1,0 +1,498 @@
+import asyncio
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import nexusrpc
+import nexusrpc.handler._decorators
+import pytest
+
+import temporalio.nexus._operation_handlers
+from temporalio import exceptions, nexus, workflow
+from temporalio.api.enums.v1 import EventType
+from temporalio.api.history.v1 import HistoryEvent
+from temporalio.client import (
+    WithStartWorkflowOperation,
+    WorkflowExecutionStatus,
+    WorkflowFailureError,
+    WorkflowHandle,
+)
+from temporalio.common import WorkflowIDConflictPolicy
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+from tests.helpers.nexus import create_nexus_endpoint, make_nexus_endpoint_name
+
+
+@dataclass
+class TestContext:
+    __test__ = False
+    cancellation_type: workflow.NexusOperationCancellationType
+    caller_op_future_resolved: asyncio.Future[datetime] = field(
+        default_factory=asyncio.Future
+    )
+    cancel_handler_released: asyncio.Future[datetime] = field(
+        default_factory=asyncio.Future
+    )
+
+
+test_context: TestContext
+
+
+@workflow.defn(sandboxed=False)
+class HandlerWorkflow:
+    def __init__(self):
+        self.caller_op_future_resolved = asyncio.Event()
+
+    @workflow.run
+    async def run(self) -> None:
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            if test_context.cancellation_type in [
+                workflow.NexusOperationCancellationType.TRY_CANCEL,
+                workflow.NexusOperationCancellationType.WAIT_REQUESTED,
+            ]:
+                # We want to prove that the caller op future can be resolved before the operation
+                # (i.e. its backing workflow) is cancelled.
+                await self.caller_op_future_resolved.wait()
+            raise
+
+    @workflow.signal
+    def set_caller_op_future_resolved(self) -> None:
+        self.caller_op_future_resolved.set()
+
+
+@nexusrpc.service
+class Service:
+    workflow_op: nexusrpc.Operation[None, None]
+
+
+class WorkflowOpHandler(
+    temporalio.nexus._operation_handlers.WorkflowRunOperationHandler
+):
+    def __init__(self):
+        pass
+
+    async def start(
+        self, ctx: nexusrpc.handler.StartOperationContext, input: None
+    ) -> nexusrpc.handler.StartOperationResultAsync:
+        tctx = nexus.WorkflowRunOperationContext._from_start_operation_context(ctx)
+        handle = await tctx.start_workflow(
+            HandlerWorkflow.run,
+            id="handler-wf-" + str(uuid.uuid4()),
+        )
+        return nexusrpc.handler.StartOperationResultAsync(token=handle.to_token())
+
+    async def cancel(
+        self, ctx: nexusrpc.handler.CancelOperationContext, token: str
+    ) -> None:
+        if (
+            test_context.cancellation_type
+            == workflow.NexusOperationCancellationType.TRY_CANCEL
+        ):
+            # When this cancel handler returns, a nexus task completion will be sent to the handler
+            # server, and the handler server will respond to the nexus cancel request that was made
+            # by the caller server. At that point, the caller server will write
+            # NexusOperationCancelRequestCompleted. For TRY_CANCEL we want to prove that the nexus
+            # op handle future can be resolved as cancelled before any of that.
+            await test_context.caller_op_future_resolved
+        test_context.cancel_handler_released.set_result(datetime.now(timezone.utc))
+        await super().cancel(ctx, token)
+
+
+@nexusrpc.handler.service_handler(service=Service)
+class ServiceHandler:
+    @nexusrpc.handler._decorators.operation_handler
+    def workflow_op(self) -> nexusrpc.handler.OperationHandler[None, None]:
+        return WorkflowOpHandler()
+
+
+@dataclass
+class Input:
+    endpoint: str
+    cancellation_type: Optional[workflow.NexusOperationCancellationType]
+
+
+@dataclass
+class CancellationResult:
+    operation_token: str
+
+
+@workflow.defn(sandboxed=False)
+class CallerWorkflow:
+    @workflow.init
+    def __init__(self, input: Input):
+        self.nexus_client = workflow.create_nexus_client(
+            service=Service,
+            endpoint=input.endpoint,
+        )
+        self.released = False
+        self.operation_token: Optional[str] = None
+
+    @workflow.signal
+    def release(self):
+        self.released = True
+
+    @workflow.update
+    async def get_operation_token(self) -> str:
+        await workflow.wait_condition(lambda: self.operation_token is not None)
+        assert self.operation_token
+        return self.operation_token
+
+    @workflow.run
+    async def run(self, input: Input) -> CancellationResult:
+        op_handle = await (
+            self.nexus_client.start_operation(
+                Service.workflow_op,
+                input=None,
+                cancellation_type=input.cancellation_type,
+            )
+            if input.cancellation_type is not None
+            else self.nexus_client.start_operation(Service.workflow_op, input=None)
+        )
+        self.operation_token = op_handle.operation_token
+        assert self.operation_token
+        # Request cancellation of the asyncio task representing the nexus operation. When the handle
+        # task is awaited, the resulting asyncio.CancelledError is caught, and a
+        # RequestCancelNexusOperation command is emitted instead (see
+        # _WorkflowInstanceImpl._outbound_start_nexus_operation).
+        #
+        # On processing this command in the activation completion, the sdk-core nexus_operation
+        # state machine transitions behaves as follows for the different cancellation types:
+        #
+        # - Abandon and TryCancel: Immediately resolves with cancellation (i.e. via a second
+        #                          activation in the same WFT)
+        #
+        # For non-Abandon types, a RequestCancelNexusOperation command is sent to the server:
+        #
+        # - TryCancel: Immediately resolve the handle task as cancelled, but also cause the server
+        #              to write NexusOperationCancelRequested.
+        #
+        # - WaitCancellationRequested: waits for NexusOperationCancelRequestCompleted (i.e. nexus op
+        #              cancel handler has responded) before sending an activation job to Python
+        #              resolving the nexus operation as cancelled
+        # - WaitCancellationCompleted: waits for NexusOperationCanceled (e.g. backing workflow has
+        #              closed as cancelled) before sending an activation job to Python resolving the
+        #              nexus operation as cancelled
+        op_handle.cancel()
+        if (
+            test_context.cancellation_type
+            == workflow.NexusOperationCancellationType.WAIT_REQUESTED
+        ):
+            # For WAIT_REQUESTED, we need core to receive the NexusOperationCancelRequestCompleted
+            # event. That event should trigger a workflow task, but does not currently due to
+            # https://github.com/temporalio/temporal/issues/8175. Force a new WFT, allowing time for
+            # the event hopefully to arrive.
+            await workflow.sleep(0.1, summary="Force new WFT")
+        try:
+            await op_handle
+        except exceptions.NexusOperationError:
+            test_context.caller_op_future_resolved.set_result(
+                datetime.now(timezone.utc)
+            )
+            assert op_handle.operation_token
+            if input.cancellation_type in [
+                workflow.NexusOperationCancellationType.TRY_CANCEL,
+                workflow.NexusOperationCancellationType.WAIT_REQUESTED,
+            ]:
+                # We want to prove that the future can be unblocked before the handler workflow is
+                # cancelled. Send a signal, so that handler workflow can wait for it.
+                await workflow.get_external_workflow_handle_for(
+                    HandlerWorkflow.run,
+                    workflow_id=(
+                        nexus.WorkflowHandle[None]
+                        .from_token(self.operation_token)
+                        .workflow_id
+                    ),
+                ).signal(HandlerWorkflow.set_caller_op_future_resolved)
+
+            await workflow.wait_condition(lambda: self.released)
+            return CancellationResult(
+                operation_token=op_handle.operation_token,
+            )
+        else:
+            pytest.fail("Expected NexusOperationError")
+
+
+@pytest.mark.parametrize(
+    "cancellation_type_name",
+    [
+        workflow.NexusOperationCancellationType.ABANDON.name,
+        workflow.NexusOperationCancellationType.TRY_CANCEL.name,
+        workflow.NexusOperationCancellationType.WAIT_REQUESTED.name,
+        workflow.NexusOperationCancellationType.WAIT_COMPLETED.name,
+    ],
+)
+async def test_cancellation_type(
+    env: WorkflowEnvironment,
+    cancellation_type_name: str,
+):
+    if env.supports_time_skipping:
+        pytest.skip("Nexus tests don't work with time-skipping server")
+
+    cancellation_type = workflow.NexusOperationCancellationType[cancellation_type_name]
+    global test_context
+    test_context = TestContext(cancellation_type=cancellation_type)
+
+    client = env.client
+
+    async with Worker(
+        client,
+        task_queue=str(uuid.uuid4()),
+        workflows=[CallerWorkflow, HandlerWorkflow],
+        nexus_service_handlers=[ServiceHandler()],
+    ) as worker:
+        await create_nexus_endpoint(worker.task_queue, client)
+
+        # Start the caller workflow, wait for the nexus op to have started and retrieve the nexus op
+        # token
+        with_start_workflow = WithStartWorkflowOperation(
+            CallerWorkflow.run,
+            Input(
+                endpoint=make_nexus_endpoint_name(worker.task_queue),
+                cancellation_type=cancellation_type,
+            ),
+            id="caller-wf-" + str(uuid.uuid4()),
+            task_queue=worker.task_queue,
+            id_conflict_policy=WorkflowIDConflictPolicy.FAIL,
+        )
+
+        operation_token = await client.execute_update_with_start_workflow(
+            CallerWorkflow.get_operation_token,
+            start_workflow_operation=with_start_workflow,
+        )
+        handler_wf = (
+            nexus.WorkflowHandle[None]
+            .from_token(operation_token)
+            ._to_client_workflow_handle(client)
+        )
+        caller_wf = await with_start_workflow.workflow_handle()
+
+        if cancellation_type == workflow.NexusOperationCancellationType.ABANDON:
+            await check_behavior_for_abandon(caller_wf, handler_wf)
+        elif cancellation_type == workflow.NexusOperationCancellationType.TRY_CANCEL:
+            await check_behavior_for_try_cancel(caller_wf, handler_wf)
+        elif (
+            cancellation_type == workflow.NexusOperationCancellationType.WAIT_REQUESTED
+        ):
+            await check_behavior_for_wait_cancellation_requested(caller_wf, handler_wf)
+        elif (
+            cancellation_type == workflow.NexusOperationCancellationType.WAIT_COMPLETED
+        ):
+            await check_behavior_for_wait_cancellation_completed(caller_wf, handler_wf)
+        else:
+            pytest.fail(f"Invalid cancellation type: {cancellation_type}")
+
+
+async def check_behavior_for_abandon(
+    caller_wf: WorkflowHandle,
+    handler_wf: WorkflowHandle,
+) -> None:
+    """
+    Check that a cancellation request is not sent.
+    """
+    handler_status = (await handler_wf.describe()).status
+    assert handler_status == WorkflowExecutionStatus.RUNNING
+    await caller_wf.signal(CallerWorkflow.release)
+    await caller_wf.result()
+    await assert_event_subsequence(
+        [
+            (caller_wf, EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED),
+            (caller_wf, EventType.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED),
+        ]
+    )
+    assert not await has_event(
+        caller_wf,
+        EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED,
+    )
+
+
+async def check_behavior_for_try_cancel(
+    caller_wf: WorkflowHandle[Any, CancellationResult],
+    handler_wf: WorkflowHandle[Any, None],
+) -> None:
+    """
+    Check that a cancellation request is sent and the caller workflow nexus op future is unblocked
+    as cancelled before the cancel handler returns (i.e. before the
+    NexusOperationCancelRequestCompleted in the caller workflow history).
+    """
+    try:
+        await handler_wf.result()
+    except WorkflowFailureError as err:
+        assert isinstance(err.__cause__, exceptions.CancelledError)
+    else:
+        pytest.fail("Expected WorkflowFailureError")
+    await caller_wf.signal(CallerWorkflow.release)
+    await caller_wf.result()
+
+    handler_status = (await handler_wf.describe()).status
+    assert handler_status == WorkflowExecutionStatus.CANCELED
+    caller_op_future_resolved = test_context.caller_op_future_resolved.result()
+    await assert_event_subsequence(
+        [
+            (caller_wf, EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED),
+            (caller_wf, EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED),
+            (caller_wf, EventType.EVENT_TYPE_NEXUS_OPERATION_CANCELED),
+        ]
+    )
+    op_cancel_requested_event = await get_event_time(
+        caller_wf,
+        EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED,
+    )
+    op_cancel_request_completed_event = await get_event_time(
+        caller_wf,
+        EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED,
+    )
+    assert (
+        caller_op_future_resolved
+        < op_cancel_requested_event
+        < op_cancel_request_completed_event
+    )
+
+
+async def check_behavior_for_wait_cancellation_requested(
+    caller_wf: WorkflowHandle[Any, CancellationResult],
+    handler_wf: WorkflowHandle,
+) -> None:
+    """
+    Check that a cancellation request is sent and the caller workflow nexus operation future is
+    unblocked as cancelled after the cancel handler returns (i.e. after the
+    NexusOperationCancelRequestCompleted in the caller workflow history) but without waiting for
+    the operation to be canceled.
+    """
+    try:
+        await handler_wf.result()
+    except WorkflowFailureError as err:
+        assert isinstance(err.__cause__, exceptions.CancelledError)
+    else:
+        pytest.fail("Expected WorkflowFailureError")
+
+    await caller_wf.signal(CallerWorkflow.release)
+    await caller_wf.result()
+
+    handler_status = (await handler_wf.describe()).status
+    assert handler_status == WorkflowExecutionStatus.CANCELED
+    await assert_event_subsequence(
+        [
+            (caller_wf, EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED),
+            (caller_wf, EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED),
+            (caller_wf, EventType.EVENT_TYPE_NEXUS_OPERATION_CANCELED),
+        ]
+    )
+    caller_op_future_resolved = test_context.caller_op_future_resolved.result()
+    op_cancel_request_completed = await get_event_time(
+        caller_wf,
+        EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED,
+    )
+    op_canceled = await get_event_time(
+        handler_wf,
+        EventType.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED,
+    )
+    assert op_cancel_request_completed < caller_op_future_resolved < op_canceled
+
+
+async def check_behavior_for_wait_cancellation_completed(
+    caller_wf: WorkflowHandle[Any, CancellationResult],
+    handler_wf: WorkflowHandle,
+) -> None:
+    """
+    Check that a cancellation request is sent and the caller workflow nexus operation future is
+    unblocked after the operation is canceled.
+    """
+    try:
+        await handler_wf.result()
+    except WorkflowFailureError as err:
+        assert isinstance(err.__cause__, exceptions.CancelledError)
+    else:
+        pytest.fail("Expected WorkflowFailureError")
+
+    handler_status = (await handler_wf.describe()).status
+    assert handler_status == WorkflowExecutionStatus.CANCELED
+
+    await caller_wf.signal(CallerWorkflow.release)
+    await caller_wf.result()
+
+    await assert_event_subsequence(
+        [
+            (caller_wf, EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED),
+            (caller_wf, EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED),
+            (
+                handler_wf,
+                EventType.EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED,
+            ),
+            (handler_wf, EventType.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED),
+            (caller_wf, EventType.EVENT_TYPE_NEXUS_OPERATION_CANCELED),
+            (caller_wf, EventType.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED),
+        ]
+    )
+    caller_op_future_resolved = test_context.caller_op_future_resolved.result()
+    handler_wf_canceled_event_time = await get_event_time(
+        handler_wf,
+        EventType.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED,
+    )
+    assert caller_op_future_resolved > handler_wf_canceled_event_time
+
+
+async def has_event(wf_handle: WorkflowHandle, event_type: EventType.ValueType):
+    async for e in wf_handle.fetch_history_events():
+        if e.event_type == event_type:
+            return True
+    return False
+
+
+async def get_event_time(
+    wf_handle: WorkflowHandle,
+    event_type: EventType.ValueType,
+) -> datetime:
+    async for event in wf_handle.fetch_history_events():
+        if event.event_type == event_type:
+            return event.event_time.ToDatetime().replace(tzinfo=timezone.utc)
+    event_type_name = EventType.Name(event_type).removeprefix("EVENT_TYPE_")
+    assert False, f"Event {event_type_name} not found in {wf_handle.id}"
+
+
+async def assert_event_subsequence(
+    expected_events: list[tuple[WorkflowHandle, EventType.ValueType]],
+) -> None:
+    """
+    Given a sequence of (WorkflowHandle, EventType) pairs, assert that the sorted sequence of events
+    from both workflows contains that subsequence.
+    """
+
+    def _event_time(
+        item: tuple[WorkflowHandle, HistoryEvent],
+    ) -> datetime:
+        return item[1].event_time.ToDatetime()
+
+    all_events = []
+    handles = {h for h, _ in expected_events}
+    for h in handles:
+        async for e in h.fetch_history_events():
+            all_events.append((h, e))
+    _all_events = iter(sorted(all_events, key=_event_time))
+    _expected_events = iter(expected_events)
+
+    previous_expected_handle, previous_expected_event_type_name = None, None
+    for expected_handle, expected_event_type in _expected_events:
+        expected_event_type_name = EventType.Name(expected_event_type).removeprefix(
+            "EVENT_TYPE_"
+        )
+        has_expected = next(
+            (
+                (h, e)
+                for h, e in _all_events
+                if h == expected_handle and e.event_type == expected_event_type
+            ),
+            None,
+        )
+        if not has_expected:
+            if previous_expected_handle is not None:
+                prefix = f"After {previous_expected_event_type_name} in {previous_expected_handle.id}, "
+            else:
+                prefix = ""
+            pytest.fail(
+                f"{prefix}expected {expected_event_type_name} in {expected_handle.id}"
+            )
+        previous_expected_event_type_name = expected_event_type_name
+        previous_expected_handle = expected_handle

--- a/tests/nexus/test_workflow_caller_cancellation_types_when_cancel_handler_fails.py
+++ b/tests/nexus/test_workflow_caller_cancellation_types_when_cancel_handler_fails.py
@@ -1,0 +1,355 @@
+import asyncio
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import nexusrpc
+import nexusrpc.handler._decorators
+import pytest
+
+import temporalio.nexus._operation_handlers
+from temporalio import exceptions, nexus, workflow
+from temporalio.api.enums.v1 import EventType
+from temporalio.client import (
+    WithStartWorkflowOperation,
+    WorkflowExecutionStatus,
+    WorkflowHandle,
+)
+from temporalio.common import WorkflowIDConflictPolicy
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+from tests.helpers.nexus import create_nexus_endpoint, make_nexus_endpoint_name
+from tests.nexus.test_workflow_caller_cancellation_types import (
+    assert_event_subsequence,
+    get_event_time,
+    has_event,
+)
+
+
+@dataclass
+class TestContext:
+    __test__ = False
+    cancellation_type: workflow.NexusOperationCancellationType
+    caller_op_future_resolved: asyncio.Future[datetime] = field(
+        default_factory=asyncio.Future
+    )
+    cancel_handler_released: asyncio.Future[datetime] = field(
+        default_factory=asyncio.Future
+    )
+
+
+test_context: TestContext
+
+
+@workflow.defn(sandboxed=False)
+class HandlerWorkflow:
+    def __init__(self):
+        self.cancel_handler_released = asyncio.Event()
+
+    @workflow.run
+    async def run(self) -> None:
+        # We want the cancel handler to be invoked, so this workflow must not close before
+        # then.
+        await self.cancel_handler_released.wait()
+        # TODO: there is technically a race now between (1) caller server writing
+        # NEXUS_OPERATION_CANCEL_REQUEST_FAILED in reponse to failed cancel handler in nexus task
+        # and (2) NEXUS_OPERATION_COMPLETED due to this workflow completing.
+
+    @workflow.signal
+    def set_cancel_handler_released(self) -> None:
+        self.cancel_handler_released.set()
+
+
+@nexusrpc.service
+class Service:
+    workflow_op: nexusrpc.Operation[None, None]
+
+
+class WorkflowOpHandler(
+    temporalio.nexus._operation_handlers.WorkflowRunOperationHandler
+):
+    def __init__(self):
+        pass
+
+    async def start(
+        self, ctx: nexusrpc.handler.StartOperationContext, input: None
+    ) -> nexusrpc.handler.StartOperationResultAsync:
+        tctx = nexus.WorkflowRunOperationContext._from_start_operation_context(ctx)
+        handle = await tctx.start_workflow(
+            HandlerWorkflow.run,
+            id="handler-wf-" + str(uuid.uuid4()),
+        )
+        return nexusrpc.handler.StartOperationResultAsync(token=handle.to_token())
+
+    async def cancel(
+        self, ctx: nexusrpc.handler.CancelOperationContext, token: str
+    ) -> None:
+        client = nexus.client()
+        handler_wf: WorkflowHandle[HandlerWorkflow, None] = (
+            client.get_workflow_handle_for(
+                HandlerWorkflow.run,
+                workflow_id=nexus.WorkflowHandle[None].from_token(token).workflow_id,
+            )
+        )
+        await handler_wf.signal(HandlerWorkflow.set_cancel_handler_released)
+        test_context.cancel_handler_released.set_result(datetime.now(timezone.utc))
+        raise nexusrpc.HandlerError(
+            "Deliberate non-retryable error in cancel handler",
+            type=nexusrpc.HandlerErrorType.BAD_REQUEST,
+        )
+
+
+@nexusrpc.handler.service_handler(service=Service)
+class ServiceHandler:
+    @nexusrpc.handler._decorators.operation_handler
+    def workflow_op(self) -> nexusrpc.handler.OperationHandler[None, None]:
+        return WorkflowOpHandler()
+
+
+@dataclass
+class Input:
+    endpoint: str
+    cancellation_type: Optional[workflow.NexusOperationCancellationType]
+
+
+@dataclass
+class CancellationResult:
+    operation_token: str
+    error_type: Optional[str] = None
+    error_cause_type: Optional[str] = None
+
+
+@workflow.defn(sandboxed=False)
+class CallerWorkflow:
+    @workflow.init
+    def __init__(self, input: Input):
+        self.nexus_client = workflow.create_nexus_client(
+            service=Service,
+            endpoint=input.endpoint,
+        )
+        self.released = False
+        self.operation_token: Optional[str] = None
+
+    @workflow.signal
+    def release(self):
+        self.released = True
+
+    @workflow.update
+    async def get_operation_token(self) -> str:
+        await workflow.wait_condition(lambda: self.operation_token is not None)
+        assert self.operation_token
+        return self.operation_token
+
+    @workflow.run
+    async def run(self, input: Input) -> CancellationResult:
+        op_handle = await (
+            self.nexus_client.start_operation(
+                Service.workflow_op,
+                input=None,
+                cancellation_type=input.cancellation_type,
+            )
+            if input.cancellation_type is not None
+            else self.nexus_client.start_operation(Service.workflow_op, input=None)
+        )
+        self.operation_token = op_handle.operation_token
+        assert self.operation_token
+        op_handle.cancel()
+        if (
+            test_context.cancellation_type
+            == workflow.NexusOperationCancellationType.WAIT_REQUESTED
+        ):
+            await workflow.sleep(0.1, summary="Force new WFT")
+        error_type, error_cause_type = None, None
+        try:
+            await op_handle
+        except exceptions.NexusOperationError as err:
+            error_type = err.__class__.__name__
+            error_cause_type = err.__cause__.__class__.__name__
+
+        test_context.caller_op_future_resolved.set_result(datetime.now(timezone.utc))
+        assert op_handle.operation_token
+        await workflow.wait_condition(lambda: self.released)
+        return CancellationResult(
+            operation_token=op_handle.operation_token,
+            error_type=error_type,
+            error_cause_type=error_cause_type,
+        )
+
+
+@pytest.mark.parametrize(
+    "cancellation_type_name",
+    [
+        workflow.NexusOperationCancellationType.ABANDON.name,
+        workflow.NexusOperationCancellationType.TRY_CANCEL.name,
+        workflow.NexusOperationCancellationType.WAIT_REQUESTED.name,
+        workflow.NexusOperationCancellationType.WAIT_COMPLETED.name,
+    ],
+)
+async def test_cancellation_type(
+    env: WorkflowEnvironment,
+    cancellation_type_name: str,
+):
+    if env.supports_time_skipping:
+        pytest.skip("Nexus tests don't work with time-skipping server")
+
+    cancellation_type = workflow.NexusOperationCancellationType[cancellation_type_name]
+    global test_context
+    test_context = TestContext(cancellation_type=cancellation_type)
+
+    client = env.client
+
+    async with Worker(
+        client,
+        task_queue=str(uuid.uuid4()),
+        workflows=[CallerWorkflow, HandlerWorkflow],
+        nexus_service_handlers=[ServiceHandler()],
+    ) as worker:
+        await create_nexus_endpoint(worker.task_queue, client)
+
+        # Start the caller workflow, wait for the nexus op to have started and retrieve the nexus op
+        # token
+        with_start_workflow = WithStartWorkflowOperation(
+            CallerWorkflow.run,
+            Input(
+                endpoint=make_nexus_endpoint_name(worker.task_queue),
+                cancellation_type=cancellation_type,
+            ),
+            id="caller-wf-" + str(uuid.uuid4()),
+            task_queue=worker.task_queue,
+            id_conflict_policy=WorkflowIDConflictPolicy.FAIL,
+        )
+
+        operation_token = await client.execute_update_with_start_workflow(
+            CallerWorkflow.get_operation_token,
+            start_workflow_operation=with_start_workflow,
+        )
+        handler_wf = (
+            nexus.WorkflowHandle[None]
+            .from_token(operation_token)
+            ._to_client_workflow_handle(client)
+        )
+        caller_wf = await with_start_workflow.workflow_handle()
+
+        if cancellation_type == workflow.NexusOperationCancellationType.ABANDON:
+            await check_behavior_for_abandon(caller_wf, handler_wf)
+        elif cancellation_type == workflow.NexusOperationCancellationType.TRY_CANCEL:
+            await check_behavior_for_try_cancel(caller_wf, handler_wf)
+        elif (
+            cancellation_type == workflow.NexusOperationCancellationType.WAIT_REQUESTED
+        ):
+            await check_behavior_for_wait_cancellation_requested(caller_wf, handler_wf)
+        elif (
+            cancellation_type == workflow.NexusOperationCancellationType.WAIT_COMPLETED
+        ):
+            await check_behavior_for_wait_cancellation_completed(caller_wf, handler_wf)
+        else:
+            pytest.fail(f"Invalid cancellation type: {cancellation_type}")
+
+
+async def check_behavior_for_abandon(
+    caller_wf: WorkflowHandle,
+    handler_wf: WorkflowHandle,
+) -> None:
+    """
+    Check that a cancellation request is not sent.
+    """
+    handler_status = (await handler_wf.describe()).status
+    assert handler_status == WorkflowExecutionStatus.RUNNING
+    await caller_wf.signal(CallerWorkflow.release)
+    result = await caller_wf.result()
+    assert result.error_type == "NexusOperationError"
+    assert result.error_cause_type == "CancelledError"
+
+    await assert_event_subsequence(
+        [
+            (caller_wf, EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED),
+            (caller_wf, EventType.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED),
+        ]
+    )
+    assert not await has_event(
+        caller_wf,
+        EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED,
+    )
+
+
+async def check_behavior_for_try_cancel(
+    caller_wf: WorkflowHandle[Any, CancellationResult],
+    handler_wf: WorkflowHandle[Any, None],
+) -> None:
+    await handler_wf.result()
+    await caller_wf.signal(CallerWorkflow.release)
+    result = await caller_wf.result()
+    assert result.error_type == "NexusOperationError"
+    assert result.error_cause_type == "CancelledError"
+
+    caller_op_future_resolved = test_context.caller_op_future_resolved.result()
+    await assert_event_subsequence(
+        [
+            (caller_wf, EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED),
+            (caller_wf, EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED),
+            (caller_wf, EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED),
+        ]
+    )
+    op_cancel_requested_event = await get_event_time(
+        caller_wf,
+        EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED,
+    )
+    op_cancel_request_failed_event = await get_event_time(
+        caller_wf,
+        EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED,
+    )
+    assert (
+        caller_op_future_resolved
+        < op_cancel_requested_event
+        < op_cancel_request_failed_event
+    )
+
+
+async def check_behavior_for_wait_cancellation_requested(
+    caller_wf: WorkflowHandle[Any, CancellationResult],
+    handler_wf: WorkflowHandle,
+) -> None:
+    await handler_wf.result()
+    await caller_wf.signal(CallerWorkflow.release)
+    result = await caller_wf.result()
+    assert result.error_type == "NexusOperationError"
+    assert result.error_cause_type == "HandlerError"
+    await assert_event_subsequence(
+        [
+            (caller_wf, EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED),
+            (caller_wf, EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED),
+            (caller_wf, EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED),
+            (caller_wf, EventType.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED),
+        ]
+    )
+    caller_op_future_resolved = test_context.caller_op_future_resolved.result()
+    op_cancel_request_failed = await get_event_time(
+        caller_wf,
+        EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED,
+    )
+    assert op_cancel_request_failed < caller_op_future_resolved
+
+
+async def check_behavior_for_wait_cancellation_completed(
+    caller_wf: WorkflowHandle[Any, CancellationResult],
+    handler_wf: WorkflowHandle,
+) -> None:
+    await handler_wf.result()
+    await caller_wf.signal(CallerWorkflow.release)
+    result = await caller_wf.result()
+    assert not result.error_type
+    await assert_event_subsequence(
+        [
+            (caller_wf, EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUESTED),
+            (caller_wf, EventType.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED),
+            (handler_wf, EventType.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED),
+            (caller_wf, EventType.EVENT_TYPE_NEXUS_OPERATION_COMPLETED),
+        ]
+    )
+    caller_op_future_resolved = test_context.caller_op_future_resolved.result()
+    handler_wf_completed = await get_event_time(
+        handler_wf,
+        EventType.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED,
+    )
+    assert handler_wf_completed < caller_op_future_resolved


### PR DESCRIPTION
Implements cancellation types for Python Nexus. This PR is mainly tests. These provide coverage for the state machine changes in https://github.com/temporalio/sdk-core/pull/977. See https://github.com/temporalio/sdk-core/issues/911#issuecomment-3151904819


The gist for anyone who needs a refresher is:

- `Abandon` - caller workflow never even send a request cancel command. The state machine is such that the operation handle future is resolved with a cancellation exception in a second activation in the same WFT

- `TryCancel` - same as `Abandon` regarding the immediate resolution of the future, but do emit the cancel nexus op request command (maybe it could also have been called RequestAsync or something)

For the next two, one has to keep two concepts clearly distinct: the Nexus cancel handler invocation, and cancellation of the nexus op itself. The typical case is that the handler issues a `RequestCancelWorkflowExecution` to the workflow that's backing the nexus operation and then when that workflow is eventually cancelled, that triggers cancellation of the nexus op itself (the worfklow  reaching a terminal state triggers some nexus stuff server-side)

- `WaitRequested` - caller workflow issues the cancel request command, and waits for an event saying that the cancel handler invocation is complete (that event is the new event for which Rust state machine changes were made)

- `WaitCompleted` - caller workflow issues the cancel request command and waits for the operation to be cancelled (isn't affected by the new event)

And then finally, it's not one new event; there's two because the cancel handler might succeed or fail. Under `WaitRequested` the fail event also resolves the nexus operation handle future in the caller workflow, but as a normal nexus error, not as cancelled.