### PR TITLE
Add argument validation for the types of provided tools

### DIFF
--- a/temporalio/contrib/openai_agents/_invoke_model_activity.py
+++ b/temporalio/contrib/openai_agents/_invoke_model_activity.py
@@ -160,7 +160,7 @@ class ModelActivity:
                 raise UserError(f"Unknown tool type: {tool.name}")
 
         tools = [make_tool(x) for x in input.get("tools", [])]
-        handoffs = [
+        handoffs: list[Handoff[Any, Any]] = [
             Handoff(
                 tool_name=x.tool_name,
                 tool_description=x.tool_description,

--- a/temporalio/contrib/openai_agents/_openai_runner.py
+++ b/temporalio/contrib/openai_agents/_openai_runner.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from dataclasses import replace
 from typing import Union
 
@@ -7,7 +8,6 @@ from agents import (
     RunResult,
     RunResultStreaming,
     TContext,
-    Tool,
     TResponseInputItem,
 )
 from agents.run import DEFAULT_AGENT_RUNNER, DEFAULT_MAX_TURNS, AgentRunner
@@ -44,7 +44,7 @@ class TemporalOpenAIRunner(AgentRunner):
             )
 
         for t in starting_agent.tools:
-            if not isinstance(t, Tool):
+            if isinstance(t, Callable):
                 raise ValueError(
                     "Provided tool is not a tool type. If using an activity, make sure to wrap it with openai_agents.workflow.activity_as_tool."
                 )

--- a/temporalio/contrib/openai_agents/_openai_runner.py
+++ b/temporalio/contrib/openai_agents/_openai_runner.py
@@ -46,7 +46,7 @@ class TemporalOpenAIRunner(AgentRunner):
 
         tool_types = typing.get_args(Tool)
         for t in starting_agent.tools:
-            if isinstance(t, tool_types):
+            if not isinstance(t, tool_types):
                 raise ValueError(
                     "Provided tool is not a tool type. If using an activity, make sure to wrap it with openai_agents.workflow.activity_as_tool."
                 )

--- a/temporalio/contrib/openai_agents/_openai_runner.py
+++ b/temporalio/contrib/openai_agents/_openai_runner.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+import typing
 from dataclasses import replace
 from typing import Union
 
@@ -8,6 +8,7 @@ from agents import (
     RunResult,
     RunResultStreaming,
     TContext,
+    Tool,
     TResponseInputItem,
 )
 from agents.run import DEFAULT_AGENT_RUNNER, DEFAULT_MAX_TURNS, AgentRunner
@@ -43,8 +44,9 @@ class TemporalOpenAIRunner(AgentRunner):
                 **kwargs,
             )
 
+        tool_types = typing.get_args(Tool)
         for t in starting_agent.tools:
-            if isinstance(t, Callable):
+            if isinstance(t, tool_types):
                 raise ValueError(
                     "Provided tool is not a tool type. If using an activity, make sure to wrap it with openai_agents.workflow.activity_as_tool."
                 )


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
If a tool is provided to an `Agent` that is not a tool type, raise an early exception. 

## Why?
This can happen easily if a user passes an activity without wrapping in `activity_as_tool`

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
