### PR TITLE
Env config - make profile optional

### DIFF
--- a/temporalio/envconfig.py
+++ b/temporalio/envconfig.py
@@ -253,7 +253,7 @@ class ClientConfigProfile:
 
     @staticmethod
     def load(
-        profile: str = "default",
+        profile: Optional[str] = None,
         *,
         config_source: Optional[DataSource] = None,
         disable_file: bool = False,
@@ -377,7 +377,7 @@ class ClientConfig:
 
     @staticmethod
     def load_client_connect_config(
-        profile: str = "default",
+        profile: Optional[str] = None,
         *,
         config_file: Optional[str] = None,
         disable_file: bool = False,


### PR DESCRIPTION
## What was changed
The `profile` parameter is now optional, instead of defaulting to a value of `default`.

## Why?
A defined `profile` value is an explicit request for a specific profile in a provided configuration. Consequently, providing a default value made it impossible for a user to provide **zero** configuration (they would have to define a `default` profile in their TOML).

However, we want to allow users to provide **zero** configuration and have it default to `localhost:7233` address and `default` namespace.

This change makes that possible in combination with https://github.com/temporalio/sdk-core/pull/968

2. How was this tested:
Existing integration tests

3. Any docs updates needed?
This change achieves parity with the docs
