### PR TITLE
Nexus: eliminate unused arguments

### DIFF
--- a/temporalio/nexus/_decorators.py
+++ b/temporalio/nexus/_decorators.py
@@ -120,7 +120,7 @@ def workflow_run_operation(
                 )
 
             _start.__doc__ = start.__doc__
-            return WorkflowRunOperationHandler(_start, input_type, output_type)
+            return WorkflowRunOperationHandler(_start)
 
         method_name = get_callable_name(start)
         nexusrpc.set_operation_definition(

--- a/temporalio/nexus/_operation_handlers.py
+++ b/temporalio/nexus/_operation_handlers.py
@@ -4,8 +4,6 @@ from typing import (
     Any,
     Awaitable,
     Callable,
-    Optional,
-    Type,
 )
 
 from nexusrpc import (
@@ -50,8 +48,6 @@ class WorkflowRunOperationHandler(OperationHandler[InputT, OutputT]):
             [StartOperationContext, InputT],
             Awaitable[WorkflowHandle[OutputT]],
         ],
-        input_type: Optional[Type[InputT]],
-        output_type: Optional[Type[OutputT]],
     ) -> None:
         """Initialize the workflow run operation handler."""
         if not is_async_callable(start):
@@ -64,8 +60,6 @@ class WorkflowRunOperationHandler(OperationHandler[InputT, OutputT]):
         if start.__doc__:
             if start_func := getattr(self.start, "__func__", None):
                 start_func.__doc__ = start.__doc__
-        self._input_type = input_type
-        self._output_type = output_type
 
     async def start(
         self, ctx: StartOperationContext, input: InputT


### PR DESCRIPTION
Remove unused parameters from `WorkflowRunOperationHandler`. It's not yet publicly exposed so there's no backwards-incompatibility impact.