### PR TITLE
Add first_execution_run_id to workflow info

### DIFF
--- a/temporalio/worker/_workflow.py
+++ b/temporalio/worker/_workflow.py
@@ -522,6 +522,7 @@ class _WorkflowWorker:
             execution_timeout=init.workflow_execution_timeout.ToTimedelta()
             if init.HasField("workflow_execution_timeout")
             else None,
+            first_execution_run_id=init.first_execution_run_id,
             headers=dict(init.headers),
             namespace=self._namespace,
             parent=parent,

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -493,6 +493,7 @@ class Info:
     continued_run_id: Optional[str]
     cron_schedule: Optional[str]
     execution_timeout: Optional[timedelta]
+    first_execution_run_id: str
     headers: Mapping[str, temporalio.api.common.v1.Payload]
     namespace: str
     parent: Optional[ParentInfo]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Title

## Why?
This can be useful to users to access.

## Checklist
<!--- add/delete as needed --->

1. Closes #1025 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
