### PR TITLE
Move model stub creation from RunConfig to Agent

### DIFF
--- a/temporalio/contrib/openai_agents/_model_parameters.py
+++ b/temporalio/contrib/openai_agents/_model_parameters.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Optional, Union, Callable, Any
+from typing import Any, Callable, Optional, Union
 
 from agents import Agent, TResponseInputItem
 
@@ -43,7 +43,14 @@ class ModelActivityParameters:
     versioning_intent: Optional[VersioningIntent] = None
     """Versioning intent for the activity."""
 
-    summary_override: Optional[Union[str, Callable[[Agent[Any], Optional[str], Union[str, list[TResponseInputItem]]], str]]] = None
+    summary_override: Optional[
+        Union[
+            str,
+            Callable[
+                [Agent[Any], Optional[str], Union[str, list[TResponseInputItem]]], str
+            ],
+        ]
+    ] = None
     """Summary for the activity execution."""
 
     priority: Priority = Priority.default

--- a/temporalio/contrib/openai_agents/_model_parameters.py
+++ b/temporalio/contrib/openai_agents/_model_parameters.py
@@ -47,7 +47,12 @@ class ModelActivityParameters:
         Union[
             str,
             Callable[
-                [Agent[Any], Optional[str], Union[str, list[TResponseInputItem]]], str
+                [
+                    Optional[Agent[Any]],
+                    Optional[str],
+                    Union[str, list[TResponseInputItem]],
+                ],
+                str,
             ],
         ]
     ] = None

--- a/temporalio/contrib/openai_agents/_model_parameters.py
+++ b/temporalio/contrib/openai_agents/_model_parameters.py
@@ -2,7 +2,9 @@
 
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Optional
+from typing import Optional, Union, Callable, Any
+
+from agents import Agent, TResponseInputItem
 
 from temporalio.common import Priority, RetryPolicy
 from temporalio.workflow import ActivityCancellationType, VersioningIntent
@@ -41,7 +43,7 @@ class ModelActivityParameters:
     versioning_intent: Optional[VersioningIntent] = None
     """Versioning intent for the activity."""
 
-    summary_override: Optional[str] = None
+    summary_override: Optional[Union[str, Callable[[Agent[Any], Optional[str], Union[str, list[TResponseInputItem]]], str]]] = None
     """Summary for the activity execution."""
 
     priority: Priority = Priority.default

--- a/temporalio/contrib/openai_agents/_temporal_model_stub.py
+++ b/temporalio/contrib/openai_agents/_temporal_model_stub.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 from typing import Any, AsyncIterator, Union, cast
 
 from agents import (
+    Agent,
     AgentOutputSchema,
     AgentOutputSchemaBase,
     CodeInterpreterTool,
@@ -25,7 +26,7 @@ from agents import (
     ModelTracing,
     Tool,
     TResponseInputItem,
-    WebSearchTool, Agent,
+    WebSearchTool,
 )
 from agents.items import TResponseStreamEvent
 from openai.types.responses.response_prompt_param import ResponsePromptParam
@@ -70,6 +71,7 @@ class _TemporalModelStub(Model):
         prompt: Optional[ResponsePromptParam],
     ) -> ModelResponse:
         print("Model stub invocation:", self.model_name)
+
         def make_tool_info(tool: Tool) -> ToolInput:
             if isinstance(
                 tool,
@@ -138,8 +140,15 @@ class _TemporalModelStub(Model):
         )
 
         if self.model_params.summary_override:
-            summary = self.model_params.summary_override if isinstance(self.model_params.summary_override, str) else (
-                self.model_params.summary_override(self.agent, system_instructions, input))
+            summary = (
+                self.model_params.summary_override
+                if isinstance(self.model_params.summary_override, str)
+                else (
+                    self.model_params.summary_override(
+                        self.agent, system_instructions, input
+                    )
+                )
+            )
         else:
             summary = self.agent.name
 

--- a/temporalio/contrib/openai_agents/_temporal_model_stub.py
+++ b/temporalio/contrib/openai_agents/_temporal_model_stub.py
@@ -69,6 +69,7 @@ class _TemporalModelStub(Model):
         previous_response_id: Optional[str],
         prompt: Optional[ResponsePromptParam],
     ) -> ModelResponse:
+        print("Model stub invocation:", self.model_name)
         def make_tool_info(tool: Tool) -> ToolInput:
             if isinstance(
                 tool,

--- a/temporalio/contrib/openai_agents/_temporal_model_stub.py
+++ b/temporalio/contrib/openai_agents/_temporal_model_stub.py
@@ -51,7 +51,7 @@ class _TemporalModelStub(Model):
         model_name: Optional[str],
         *,
         model_params: ModelActivityParameters,
-        agent: Agent[Any],
+        agent: Optional[Agent[Any]],
     ) -> None:
         self.model_name = model_name
         self.model_params = model_params
@@ -70,8 +70,6 @@ class _TemporalModelStub(Model):
         previous_response_id: Optional[str],
         prompt: Optional[ResponsePromptParam],
     ) -> ModelResponse:
-        print("Model stub invocation:", self.model_name)
-
         def make_tool_info(tool: Tool) -> ToolInput:
             if isinstance(
                 tool,
@@ -149,8 +147,10 @@ class _TemporalModelStub(Model):
                     )
                 )
             )
-        else:
+        elif self.agent:
             summary = self.agent.name
+        else:
+            summary = None
 
         return await workflow.execute_activity_method(
             ModelActivity.invoke_model_activity,

--- a/tests/contrib/openai_agents/test_openai.py
+++ b/tests/contrib/openai_agents/test_openai.py
@@ -916,7 +916,6 @@ class CustomerServiceModel(StaticTestModel):
     ]
 
 
-
 @workflow.defn
 class CustomerServiceWorkflow:
     def __init__(self, input_items: list[TResponseInputItem] = []):
@@ -995,9 +994,7 @@ async def test_customer_service_workflow(client: Client, use_local_model: bool):
             model_params=ModelActivityParameters(
                 start_to_close_timeout=timedelta(seconds=30)
             ),
-            model_provider= provider
-            if use_local_model
-            else None,
+            model_provider=provider if use_local_model else None,
         )
     ]
     client = Client(**new_config)
@@ -2047,7 +2044,7 @@ async def test_hosted_mcp_tool(client: Client, use_local_model):
 
 
 class AssertDifferentModelProvider(ModelProvider):
-    model_names = set()
+    model_names: set[Optional[str]] = set()
 
     def __init__(self, model: Model):
         self._model = model
@@ -2065,6 +2062,7 @@ class MultipleModelsModel(StaticTestModel):
         ),
     ]
 
+
 @workflow.defn
 class MultipleModelWorkflow:
     @workflow.run
@@ -2078,7 +2076,7 @@ class MultipleModelWorkflow:
             name="Lazy Assistant",
             model="gpt-4o-mini",
             instructions="You delegate all your work to another agent.",
-            handoffs=[underling]
+            handoffs=[underling],
         )
         result = await Runner.run(
             starting_agent=starting_agent,
@@ -2095,7 +2093,7 @@ async def test_multiple_models(client: Client):
             model_params=ModelActivityParameters(
                 start_to_close_timeout=timedelta(seconds=120)
             ),
-            model_provider=provider
+            model_provider=provider,
         )
     ]
     client = Client(**new_config)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Instead of overriding the model in `RunConfig` with that provided by the user in `RunConfig` or `Agent`, make the corresponding override wherever they provided it.

Also changed the framework for summaries. It defaults to the agent name, or none if the model is provided at the `RunConfig` level, but can be overridden by either a constant or a function given the agent and input.

## Why?
If a user provided specific models in handoff agents, those choices would not be respected since the model was overridden globally based on the starting agent.

## Checklist
<!--- add/delete as needed --->

1. Closes #1024 1024

2. How was this tested:
New tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
