### PR TITLE
remove address check

### DIFF
--- a/temporalio/envconfig.py
+++ b/temporalio/envconfig.py
@@ -230,15 +230,10 @@ class ClientConfigProfile:
 
     def to_client_connect_config(self) -> ClientConnectConfig:
         """Create a `ClientConnectConfig` from this profile."""
-        if not self.address:
-            raise ValueError(
-                "Configuration profile must contain an 'address' to be used for "
-                "client connection"
-            )
-
         # Only include non-None values
         config: Dict[str, Any] = {}
-        config["target_host"] = self.address
+        if self.address:
+            config["target_host"] = self.address
         if self.namespace is not None:
             config["namespace"] = self.namespace
         if self.api_key is not None:

--- a/tests/test_envconfig.py
+++ b/tests/test_envconfig.py
@@ -505,13 +505,6 @@ custom-header = "custom-value"
     assert new_client.namespace == "env-only-namespace"
 
 
-def test_to_client_connect_config_missing_address_fails():
-    """Test that to_client_connect_config raises a ValueError if address is missing."""
-    profile = ClientConfigProfile()
-    with pytest.raises(ValueError, match="must contain an 'address'"):
-        profile.to_client_connect_config()
-
-
 def test_disables_raise_error():
     """Test that providing both disable_file and disable_env raises an error."""
     with pytest.raises(RuntimeError, match="Cannot disable both"):


### PR DESCRIPTION
## What was changed
Remove check for `address` in config. Allows for users to call `to_client_connect_config` and override this value themselves. The `Client.connect` call already does this validation for us.

Makes it easy in the general case where users just want to do:

```
config = ClientConfig.load_client_connect_config()
config.setdefault("target_host", "localhost:7233")
Client.connect(**config)
```

2. How was this tested:
No tests

3. Any docs updates needed?
No
