### PR TITLE
Implement `get_task_factory`

### DIFF
--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -2429,6 +2429,9 @@ class _WorkflowInstanceImpl(  # type: ignore[reportImplicitAbstractClass]
     def get_exception_handler(self) -> Optional[_ExceptionHandler]:
         return self._exception_handler
 
+    def get_task_factory(self) -> None:
+        return None
+
     def set_exception_handler(self, handler: Optional[_ExceptionHandler]) -> None:
         self._exception_handler = handler
 


### PR DESCRIPTION
This PR implements [`get_task_factory`](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.get_task_factory) on the workflow event loop.

This is good practice in general, and is needed when using `anyio` from within workflow code: https://github.com/agronholm/anyio/blob/b8e91a5cfe35c3b28f91ea8251674a871a7f4e26/src/anyio/_backends/_asyncio.py#L861

One situation when one needs to use `anyio` from within workflow code is when using the Python MCP SDK's `mcp.ClientSession` to make MCP calls from a Temporal workflow via a custom transport. See e.g. https://github.com/bergundy/nexus-mcp-python/pull/1