### PR TITLE
:boom: Remove 'activity' from the model activity name

### DIFF
--- a/temporalio/contrib/openai_agents/_invoke_model_activity.py
+++ b/temporalio/contrib/openai_agents/_invoke_model_activity.py
@@ -159,6 +159,11 @@ class ModelActivity:
         )
 
     @activity.defn
+    async def invoke_model(self, input: ActivityModelInput) -> ModelResponse:
+        """Activity that invokes a model with the given input."""
+        return await self.invoke_model_activity(input)
+
+    @activity.defn
     @_auto_heartbeater
     async def invoke_model_activity(self, input: ActivityModelInput) -> ModelResponse:
         """Activity that invokes a model with the given input."""

--- a/temporalio/contrib/openai_agents/_invoke_model_activity.py
+++ b/temporalio/contrib/openai_agents/_invoke_model_activity.py
@@ -159,13 +159,8 @@ class ModelActivity:
         )
 
     @activity.defn
-    async def invoke_model(self, input: ActivityModelInput) -> ModelResponse:
-        """Activity that invokes a model with the given input."""
-        return await self.invoke_model_activity(input)
-
-    @activity.defn
     @_auto_heartbeater
-    async def invoke_model_activity(self, input: ActivityModelInput) -> ModelResponse:
+    async def invoke_model(self, input: ActivityModelInput) -> ModelResponse:
         """Activity that invokes a model with the given input."""
         model = self._model_provider.get_model(input.get("model_name"))
 

--- a/temporalio/contrib/openai_agents/_temporal_model_stub.py
+++ b/temporalio/contrib/openai_agents/_temporal_model_stub.py
@@ -153,7 +153,7 @@ class _TemporalModelStub(Model):
             summary = None
 
         return await workflow.execute_activity_method(
-            ModelActivity.invoke_model_activity,
+            ModelActivity.invoke_model,
             activity_input,
             summary=summary,
             task_queue=self.model_params.task_queue,

--- a/temporalio/contrib/openai_agents/_temporal_openai_agents.py
+++ b/temporalio/contrib/openai_agents/_temporal_openai_agents.py
@@ -281,10 +281,8 @@ class OpenAIAgentsPlugin(temporalio.client.Plugin, temporalio.worker.Plugin):
         config["interceptors"] = list(config.get("interceptors") or []) + [
             OpenAIAgentsTracingInterceptor()
         ]
-        model_activity = ModelActivity(self._model_provider)
         config["activities"] = list(config.get("activities") or []) + [
-            model_activity.invoke_model_activity,
-            model_activity.invoke_model,
+            ModelActivity(self._model_provider).invoke_model,
         ]
         return self.next_worker_plugin.configure_worker(config)
 

--- a/temporalio/contrib/openai_agents/_temporal_openai_agents.py
+++ b/temporalio/contrib/openai_agents/_temporal_openai_agents.py
@@ -281,8 +281,10 @@ class OpenAIAgentsPlugin(temporalio.client.Plugin, temporalio.worker.Plugin):
         config["interceptors"] = list(config.get("interceptors") or []) + [
             OpenAIAgentsTracingInterceptor()
         ]
+        model_activity = ModelActivity(self._model_provider)
         config["activities"] = list(config.get("activities") or []) + [
-            ModelActivity(self._model_provider).invoke_model_activity
+            model_activity.invoke_model_activity,
+            model_activity.invoke_model,
         ]
         return self.next_worker_plugin.configure_worker(config)
 

--- a/tests/contrib/openai_agents/histories/agents-as-tools-workflow-history.json
+++ b/tests/contrib/openai_agents/histories/agents-as-tools-workflow-history.json
@@ -96,7 +96,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "1",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "1e8fa3c8-41b4-4ea7-907b-63088b63e36f",
@@ -233,7 +233,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "2",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "1e8fa3c8-41b4-4ea7-907b-63088b63e36f",
@@ -370,7 +370,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "3",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "1e8fa3c8-41b4-4ea7-907b-63088b63e36f",
@@ -499,7 +499,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "4",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "1e8fa3c8-41b4-4ea7-907b-63088b63e36f",

--- a/tests/contrib/openai_agents/histories/customer-service-workflow-history.json
+++ b/tests/contrib/openai_agents/histories/customer-service-workflow-history.json
@@ -162,7 +162,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "1",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "be82986c-9ddc-441b-9833-c3fce7c79df1",
@@ -400,7 +400,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "2",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "be82986c-9ddc-441b-9833-c3fce7c79df1",
@@ -537,7 +537,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "3",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "be82986c-9ddc-441b-9833-c3fce7c79df1",
@@ -767,7 +767,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "4",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "be82986c-9ddc-441b-9833-c3fce7c79df1",
@@ -1005,7 +1005,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "5",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "be82986c-9ddc-441b-9833-c3fce7c79df1",
@@ -1142,7 +1142,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "6",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "be82986c-9ddc-441b-9833-c3fce7c79df1",

--- a/tests/contrib/openai_agents/histories/hello-workflow-history.json
+++ b/tests/contrib/openai_agents/histories/hello-workflow-history.json
@@ -96,7 +96,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "1",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "5dd7a6ba-834c-4206-bcbc-a02599f1b54c",

--- a/tests/contrib/openai_agents/histories/input-guardrail-workflow-history.json
+++ b/tests/contrib/openai_agents/histories/input-guardrail-workflow-history.json
@@ -96,7 +96,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "1",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "e488932b-c66d-48b6-97cb-7b8feaa1c41c",
@@ -151,7 +151,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "2",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "e488932b-c66d-48b6-97cb-7b8feaa1c41c",
@@ -370,7 +370,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "3",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "e488932b-c66d-48b6-97cb-7b8feaa1c41c",
@@ -425,7 +425,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "4",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "e488932b-c66d-48b6-97cb-7b8feaa1c41c",

--- a/tests/contrib/openai_agents/histories/output-guardrail-workflow-history.json
+++ b/tests/contrib/openai_agents/histories/output-guardrail-workflow-history.json
@@ -86,7 +86,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "1",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "2227feb4-0f1d-4092-9653-308e9366edb0",

--- a/tests/contrib/openai_agents/histories/research-workflow-history.json
+++ b/tests/contrib/openai_agents/histories/research-workflow-history.json
@@ -96,7 +96,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "1",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "fc97ba3c-6c32-4f4c-a986-8d7f4f5c7f80",
@@ -233,7 +233,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "2",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "fc97ba3c-6c32-4f4c-a986-8d7f4f5c7f80",
@@ -288,7 +288,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "3",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "fc97ba3c-6c32-4f4c-a986-8d7f4f5c7f80",
@@ -343,7 +343,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "4",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "fc97ba3c-6c32-4f4c-a986-8d7f4f5c7f80",
@@ -398,7 +398,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "5",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "fc97ba3c-6c32-4f4c-a986-8d7f4f5c7f80",
@@ -453,7 +453,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "6",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "fc97ba3c-6c32-4f4c-a986-8d7f4f5c7f80",
@@ -508,7 +508,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "7",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "fc97ba3c-6c32-4f4c-a986-8d7f4f5c7f80",
@@ -563,7 +563,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "8",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "fc97ba3c-6c32-4f4c-a986-8d7f4f5c7f80",
@@ -618,7 +618,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "9",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "fc97ba3c-6c32-4f4c-a986-8d7f4f5c7f80",
@@ -673,7 +673,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "10",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "fc97ba3c-6c32-4f4c-a986-8d7f4f5c7f80",
@@ -728,7 +728,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "11",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "fc97ba3c-6c32-4f4c-a986-8d7f4f5c7f80",
@@ -1603,7 +1603,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "12",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "fc97ba3c-6c32-4f4c-a986-8d7f4f5c7f80",

--- a/tests/contrib/openai_agents/histories/tools-workflow-history.json
+++ b/tests/contrib/openai_agents/histories/tools-workflow-history.json
@@ -96,7 +96,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "1",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "98bba13c-e75a-446d-a2f8-077680fb23af",
@@ -362,7 +362,7 @@
       "activityTaskScheduledEventAttributes": {
         "activityId": "3",
         "activityType": {
-          "name": "invoke_model_activity"
+          "name": "invoke_model"
         },
         "taskQueue": {
           "name": "98bba13c-e75a-446d-a2f8-077680fb23af",


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Changed `invoke_model_activity` to `invoke_model`. This breaking change will cause workflows started on a previous version which use models to fail.

## Why?
`activity` clutters the UI with no additional information.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
