### PR TITLE
Don't fail on newtype string dict keys

### DIFF
--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -1590,9 +1590,9 @@ def value_to_type(
                         elif key_type is type(None):
                             key = {"null": None}[key]
 
-                    # Can't call isinstance of key_type is a newtype
-                    supertype = getattr(key_type, "__supertype__", None)
-                    if supertype or not isinstance(key, key_type):
+                    # Can't call isinstance if key_type is a newtype
+                    is_newtype = getattr(key_type, "__supertype__", None)
+                    if is_newtype or not isinstance(key, key_type):
                         key = value_to_type(key_type, key, custom_converters)
                 except Exception as err:
                     raise TypeError(

--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -1590,7 +1590,9 @@ def value_to_type(
                         elif key_type is type(None):
                             key = {"null": None}[key]
 
-                    if not isinstance(key, key_type):
+                    # Can't call isinstance of key_type is a newtype
+                    supertype = getattr(key_type, "__supertype__", None)
+                    if supertype or not isinstance(key, key_type):
                         key = value_to_type(key_type, key, custom_converters)
                 except Exception as err:
                     raise TypeError(

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -53,6 +53,7 @@ from temporalio.converter import (
     _JSONTypeConverterUnhandled,
     decode_search_attributes,
     encode_search_attribute_values,
+    value_to_type,
 )
 from temporalio.exceptions import ApplicationError, FailureError
 
@@ -89,6 +90,14 @@ class MyDataClass:
 @dataclass
 class DatetimeClass:
     datetime: datetime
+
+
+MyNewTypeStr = NewType("MyNewTypeStr", str)
+
+
+@dataclass
+class NewTypeMessage:
+    data: dict[MyNewTypeStr, str]
 
 
 async def test_converter_default():
@@ -213,6 +222,22 @@ async def test_converter_default():
         "json/plain",
         '{"datetime":"2020-01-01T01:01:01"}',
         type_hint=DatetimeClass,
+    )
+
+    # Newtype String
+    await assert_payload(
+        MyNewTypeStr("somestr"),
+        "json/plain",
+        '"somestr"',
+        type_hint=MyNewTypeStr,
+    )
+
+    # Newtype String key
+    await assert_payload(
+        NewTypeMessage({MyNewTypeStr("key"): "value"}),
+        "json/plain",
+        '{"data":{"key":"value"}}',
+        type_hint=NewTypeMessage,
     )
 
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Check for newtype before calling `isinstance`.

## Why?
`isinstance` fails when the `key_type` is not a type.

## Checklist
<!--- add/delete as needed --->

1. Closes part of #1032

2. How was this tested:
New tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
