### PR TITLE
💥  Nexus support in worker tuner

### DIFF
--- a/temporalio/bridge/src/worker.rs
+++ b/temporalio/bridge/src/worker.rs
@@ -147,6 +147,7 @@ pub struct TunerHolder {
     workflow_slot_supplier: SlotSupplier,
     activity_slot_supplier: SlotSupplier,
     local_activity_slot_supplier: SlotSupplier,
+    nexus_slot_supplier: SlotSupplier,
 }
 
 #[derive(FromPyObject)]
@@ -745,10 +746,17 @@ fn convert_tuner_holder(
         } else {
             None
         };
+    let maybe_nexus_resource_opts =
+        if let SlotSupplier::ResourceBased(ref ss) = holder.nexus_slot_supplier {
+            Some(&ss.tuner_config)
+        } else {
+            None
+        };
     let all_resource_opts = [
         maybe_wf_resource_opts,
         maybe_act_resource_opts,
         maybe_local_act_resource_opts,
+        maybe_nexus_resource_opts,
     ];
     let mut set_resource_opts = all_resource_opts.iter().flatten();
     let first = set_resource_opts.next();
@@ -784,6 +792,10 @@ fn convert_tuner_holder(
         )?)
         .local_activity_slot_options(convert_slot_supplier(
             holder.local_activity_slot_supplier,
+            task_locals.clone(),
+        )?)
+        .nexus_slot_options(convert_slot_supplier(
+            holder.nexus_slot_supplier,
             task_locals,
         )?);
     Ok(options

--- a/temporalio/bridge/worker.py
+++ b/temporalio/bridge/worker.py
@@ -168,6 +168,7 @@ class TunerHolder:
     workflow_slot_supplier: SlotSupplier
     activity_slot_supplier: SlotSupplier
     local_activity_slot_supplier: SlotSupplier
+    nexus_slot_supplier: SlotSupplier
 
 
 class Worker:

--- a/temporalio/worker/__init__.py
+++ b/temporalio/worker/__init__.py
@@ -33,6 +33,7 @@ from ._tuning import (
     CustomSlotSupplier,
     FixedSizeSlotSupplier,
     LocalActivitySlotInfo,
+    NexusSlotInfo,
     ResourceBasedSlotConfig,
     ResourceBasedSlotSupplier,
     ResourceBasedTunerConfig,
@@ -117,4 +118,5 @@ __all__ = [
     "SlotReleaseContext",
     "SlotReserveContext",
     "WorkflowSlotInfo",
+    "NexusSlotInfo",
 ]

--- a/temporalio/worker/_replayer.py
+++ b/temporalio/worker/_replayer.py
@@ -264,6 +264,9 @@ class Replayer:
                         local_activity_slot_supplier=temporalio.bridge.worker.FixedSizeSlotSupplier(
                             1
                         ),
+                        nexus_slot_supplier=temporalio.bridge.worker.FixedSizeSlotSupplier(
+                            1
+                        ),
                     ),
                     nonsticky_to_sticky_poll_ratio=1,
                     no_remote_activities=True,

--- a/tests/worker/test_worker.py
+++ b/tests/worker/test_worker.py
@@ -7,8 +7,10 @@ from datetime import timedelta
 from typing import Any, Awaitable, Callable, Optional, Sequence
 from urllib.request import urlopen
 
+import nexusrpc
+
 import temporalio.api.enums.v1
-import temporalio.client
+import temporalio.nexus
 import temporalio.worker._worker
 from temporalio import activity, workflow
 from temporalio.api.workflowservice.v1 import (
@@ -33,6 +35,7 @@ from temporalio.worker import (
     CustomSlotSupplier,
     FixedSizeSlotSupplier,
     LocalActivitySlotInfo,
+    NexusSlotInfo,
     PollerBehaviorAutoscaling,
     ResourceBasedSlotConfig,
     ResourceBasedSlotSupplier,
@@ -42,7 +45,6 @@ from temporalio.worker import (
     SlotReleaseContext,
     SlotReserveContext,
     Worker,
-    WorkerConfig,
     WorkerDeploymentConfig,
     WorkerDeploymentVersion,
     WorkerTuner,
@@ -55,6 +57,7 @@ from tests.helpers import (
     new_worker,
     worker_versioning_enabled,
 )
+from tests.helpers.nexus import create_nexus_endpoint, make_nexus_endpoint_name
 
 # Passing through because Python 3.9 has an import bug at
 # https://github.com/python/cpython/issues/91351
@@ -78,6 +81,21 @@ async def never_run_activity() -> None:
 class NeverRunWorkflow:
     @workflow.run
     async def run(self) -> None:
+        raise NotImplementedError
+
+
+@nexusrpc.handler.service_handler
+class NeverRunService:
+    @nexusrpc.handler.sync_operation
+    async def never_run_operation(
+        self, _ctx: nexusrpc.handler.StartOperationContext, _input: None
+    ) -> None:
+        raise NotImplementedError
+
+    @temporalio.nexus.workflow_run_operation
+    async def never_run_workflow_run_operation(
+        self, _ctx: temporalio.nexus.WorkflowRunOperationContext, _input: None
+    ) -> temporalio.nexus.WorkflowHandle[None]:
         raise NotImplementedError
 
 
@@ -317,6 +335,7 @@ async def test_can_run_composite_tuner_worker(client: Client, env: WorkflowEnvir
             ),
             resource_based_options,
         ),
+        nexus_supplier=FixedSizeSlotSupplier(10),
     )
     async with new_worker(
         client,
@@ -354,7 +373,7 @@ async def test_cant_specify_max_concurrent_and_tuner(
     assert "when also specifying tuner" in str(err.value)
 
 
-async def test_warns_when_workers_too_lot(client: Client, env: WorkflowEnvironment):
+async def test_warns_when_workers_too_low(client: Client, env: WorkflowEnvironment):
     tuner = WorkerTuner.create_resource_based(
         target_memory_usage=0.5,
         target_cpu_usage=0.5,
@@ -372,9 +391,63 @@ async def test_warns_when_workers_too_lot(client: Client, env: WorkflowEnvironme
                 activity_executor=executor,
             ):
                 pass
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        with pytest.warns(
+            UserWarning,
+            match="Worker max_concurrent_nexus_tasks is 500 but nexus_task_executor's max_workers is only",
+        ):
+            async with new_worker(
+                client,
+                WaitOnSignalWorkflow,
+                nexus_service_handlers=[NeverRunService()],
+                tuner=tuner,
+                nexus_task_executor=executor,
+            ):
+                pass
+
+
+@nexusrpc.handler.service_handler
+class SayHelloService:
+    @nexusrpc.handler.sync_operation
+    async def say_hello(
+        self, _ctx: nexusrpc.handler.StartOperationContext, name: str
+    ) -> str:
+        return f"Hello, {name}!"
+
+
+@workflow.defn
+class CustomSlotSupplierWorkflow:
+    def __init__(self) -> None:
+        self._last_signal = "<none>"
+
+    @workflow.run
+    async def run(self) -> None:
+        await workflow.wait_condition(lambda: self._last_signal == "finish")
+        await workflow.execute_activity(
+            say_hello,
+            "hi",
+            versioning_intent=VersioningIntent.DEFAULT,
+            start_to_close_timeout=timedelta(seconds=5),
+        )
+        nexus_client = workflow.create_nexus_client(
+            endpoint=make_nexus_endpoint_name(workflow.info().task_queue),
+            service=SayHelloService,
+        )
+        await nexus_client.execute_operation(
+            SayHelloService.say_hello,
+            "hi",
+        )
+
+    @workflow.signal
+    def my_signal(self, value: str) -> None:
+        self._last_signal = value
+        workflow.logger.info(f"Signal: {value}")
 
 
 async def test_custom_slot_supplier(client: Client, env: WorkflowEnvironment):
+    if env.supports_time_skipping:
+        pytest.skip("Nexus tests don't work under Java test server")
+
     class MyPermit(SlotPermit):
         def __init__(self, pnum: int):
             super().__init__()
@@ -413,6 +486,8 @@ async def test_custom_slot_supplier(client: Client, env: WorkflowEnvironment):
                 self.seen_used_slot_kinds.add("a")
             elif isinstance(ctx.slot_info, LocalActivitySlotInfo):
                 self.seen_used_slot_kinds.add("la")
+            elif isinstance(ctx.slot_info, NexusSlotInfo):
+                self.seen_used_slot_kinds.add("nx")
             self.used += 1
 
         def release_slot(self, ctx: SlotReleaseContext) -> None:
@@ -439,21 +514,26 @@ async def test_custom_slot_supplier(client: Client, env: WorkflowEnvironment):
     ss = MySlotSupplier()
 
     tuner = WorkerTuner.create_composite(
-        workflow_supplier=ss, activity_supplier=ss, local_activity_supplier=ss
+        workflow_supplier=ss,
+        activity_supplier=ss,
+        local_activity_supplier=ss,
+        nexus_supplier=ss,
     )
     async with new_worker(
         client,
-        WaitOnSignalWorkflow,
+        CustomSlotSupplierWorkflow,
         activities=[say_hello],
+        nexus_service_handlers=[SayHelloService()],
         tuner=tuner,
         identity="myworker",
     ) as w:
+        await create_nexus_endpoint(w.task_queue, client)
         wf1 = await client.start_workflow(
-            WaitOnSignalWorkflow.run,
+            CustomSlotSupplierWorkflow.run,
             id=f"custom-slot-supplier-{uuid.uuid4()}",
             task_queue=w.task_queue,
         )
-        await wf1.signal(WaitOnSignalWorkflow.my_signal, "finish")
+        await wf1.signal(CustomSlotSupplierWorkflow.my_signal, "finish")
         await wf1.result()
 
     # We can't use reserve number directly because there is a technically possible race
@@ -461,11 +541,10 @@ async def test_custom_slot_supplier(client: Client, env: WorkflowEnvironment):
     # This isn't solvable without redoing a chunk of pyo3-asyncio. So we only check
     # that the permits passed to release line up.
     assert ss.highest_seen_reserve_on_release == ss.releases
-    # Two workflow tasks, one activity
-    assert ss.used == 3
+    assert ss.used == 5
     assert ss.seen_sticky_kinds == {True, False}
-    assert ss.seen_slot_kinds == {"workflow", "activity", "local-activity"}
-    assert ss.seen_used_slot_kinds == {"wf", "a"}
+    assert ss.seen_slot_kinds == {"workflow", "activity", "local-activity", "nexus"}
+    assert ss.seen_used_slot_kinds == {"wf", "a", "nx"}
     assert ss.seen_release_info_empty
     assert ss.seen_release_info_nonempty
 
@@ -501,7 +580,10 @@ async def test_throwing_slot_supplier(client: Client, env: WorkflowEnvironment):
     ss = ThrowingSlotSupplier()
 
     tuner = WorkerTuner.create_composite(
-        workflow_supplier=ss, activity_supplier=ss, local_activity_supplier=ss
+        workflow_supplier=ss,
+        activity_supplier=ss,
+        local_activity_supplier=ss,
+        nexus_supplier=ss,
     )
     async with new_worker(
         client,
@@ -537,7 +619,10 @@ async def test_blocking_slot_supplier(client: Client, env: WorkflowEnvironment):
     ss = BlockingSlotSupplier()
 
     tuner = WorkerTuner.create_composite(
-        workflow_supplier=ss, activity_supplier=ss, local_activity_supplier=ss
+        workflow_supplier=ss,
+        activity_supplier=ss,
+        local_activity_supplier=ss,
+        nexus_supplier=ss,
     )
     async with new_worker(
         client,
@@ -1134,6 +1219,7 @@ def create_worker(
         task_queue=f"task-queue-{uuid.uuid4()}",
         activities=[never_run_activity],
         workflows=[NeverRunWorkflow],
+        nexus_service_handlers=[NeverRunService()],
         on_fatal_error=on_fatal_error,
     )
 


### PR DESCRIPTION
- Add support for nexus in WorkerTuner and support `max_concurrent_nexus_tasks` worker config option
- Add tests for nexus worker concurrency parameters

💥 This is a breaking change: `create_composite()` has gained a required `nexus_supplier` parameter.