### PR TITLE
Fix Flaky Test: test_custom_slot_supplier

### DIFF
--- a/tests/worker/test_worker.py
+++ b/tests/worker/test_worker.py
@@ -540,7 +540,7 @@ async def test_custom_slot_supplier(client: Client, env: WorkflowEnvironment):
     # where the python reserve function appears to complete, but Rust doesn't see that.
     # This isn't solvable without redoing a chunk of pyo3-asyncio. So we only check
     # that the permits passed to release line up.
-    assert ss.highest_seen_reserve_on_release <= ss.releases
+    assert ss.highest_seen_reserve_on_release >= ss.releases
     assert ss.used == 5
     assert ss.seen_sticky_kinds == {True, False}
     assert ss.seen_slot_kinds == {"workflow", "activity", "local-activity", "nexus"}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Remove assert on number of releases versus highest reserve. 

## Why?
Core does not guarantee that a "reserved" slot which hasn't been accepted by core will be released on worker shutdown. When one is left unused, this can cause failures.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
