### PR TITLE
Move visitor, bridge client generation, and formatting to poe tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,6 @@ jobs:
           uv sync --all-extras
           poe build-develop
           poe gen-protos
-          poe format
           [[ -z $(git status --porcelain temporalio) ]] || (git diff temporalio; echo "Protos changed"; exit 1)
           poe test -s
         timeout-minutes: 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,21 @@ build-develop-with-release = { cmd = "uv run maturin develop --release --uv" }
 format = [
   { cmd = "uv run ruff check --select I --fix" },
   { cmd = "uv run ruff format" },
+  { cmd = "cargo fmt", cwd = "temporalio/bridge" },
 ]
 gen-docs = "uv run scripts/gen_docs.py"
-gen-protos = "uv run scripts/gen_protos.py"
-gen-protos-docker = "uv run scripts/gen_protos_docker.py"
+gen-protos = [
+  { cmd = "uv run scripts/gen_protos.py" },
+  { cmd = "uv run scripts/gen_payload_visitor.py" },
+  { cmd = "uv run scripts/gen_bridge_client.py" },
+  { ref = "format" },
+]
+gen-protos-docker = [
+  { cmd = "uv run scripts/gen_protos_docker.py" },
+  { cmd = "uv run scripts/gen_payload_visitor.py" },
+  { cmd = "uv run scripts/gen_bridge_client.py" },
+  { ref = "format" },
+]
 lint = [
   { cmd = "uv run ruff check --select I" },
   { cmd = "uv run ruff format --check" },

--- a/scripts/_proto/Dockerfile
+++ b/scripts/_proto/Dockerfile
@@ -10,6 +10,6 @@ COPY ./ ./
 RUN mkdir -p ./temporalio/api
 RUN uv add "protobuf<4"
 RUN uv sync --all-extras
-RUN poe gen-protos
+RUN uv run scripts/gen_protos.py
 
 CMD ["sh", "-c", "cp -r ./temporalio/api/* /api_new && cp -r ./temporalio/bridge/proto/* /bridge_new"]

--- a/scripts/gen_payload_visitor.py
+++ b/scripts/gen_payload_visitor.py
@@ -203,7 +203,7 @@ class PayloadVisitor:
         # Process regular fields first
         for field in regular_fields:
             # Repeated fields (including maps which are represented as repeated messages)
-            if field.is_repeated:
+            if field.label == FieldDescriptor.LABEL_REPEATED:
                 if (
                     field.message_type is not None
                     and field.message_type.GetOptions().map_entry

--- a/scripts/gen_protos_docker.py
+++ b/scripts/gen_protos_docker.py
@@ -30,21 +30,3 @@ subprocess.run(
     ],
     check=True,
 )
-
-subprocess.run(
-    ["uv", "run", os.path.join(os.getcwd(), "scripts", "gen_payload_visitor.py")],
-    check=True,
-)
-
-subprocess.run(
-    ["uv", "run", os.path.join(os.getcwd(), "scripts", "gen_bridge_client.py")],
-    check=True,
-)
-
-subprocess.run(["uv", "run", "poe", "format"], check=True)
-
-subprocess.run(
-    ["cargo", "fmt"],
-    check=True,
-    cwd=os.path.join(os.getcwd(), "temporalio", "bridge"),
-)


### PR DESCRIPTION
## What was changed

Title

## Why?

This moves the calls to generate source out of the gen-protos-docker script and instead rely on poe tasks to align CI with local development.

## Checklist

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
