### PR TITLE
Replace tctl references with Temporal CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1676,8 +1676,8 @@ worker = Worker(
 ### Workflow Replay
 
 Given a workflow's history, it can be replayed locally to check for things like non-determinism errors. For example,
-assuming `history_str` is populated with a JSON string history either exported from the web UI or from `tctl`, the
-following function will replay it:
+assuming `history_str` is populated with a JSON string history either exported from the web UI or from the 
+`Temporal CLI`, the following function will replay it:
 
 ```python
 from temporalio.client import WorkflowHistory

--- a/temporalio/client.py
+++ b/temporalio/client.py
@@ -3355,7 +3355,7 @@ class WorkflowHistory:
     ) -> WorkflowHistory:
         """Construct a WorkflowHistory from an ID and a json dump of history.
 
-        This is built to work both with Temporal UI/tctl JSON as well as
+        This is built to work both with Temporal UI/CLI JSON as well as
         :py:meth:`to_json` even though they are slightly different.
 
         Args:

--- a/temporalio/worker/_replayer.py
+++ b/temporalio/worker/_replayer.py
@@ -112,7 +112,7 @@ class Replayer:
         Args:
             history: The history to replay. Can be fetched directly, or use
                 :py:meth:`temporalio.client.WorkflowHistory.from_json` to parse
-                a history downloaded via ``tctl`` or the web UI.
+                a history downloaded via ``Temporal CLI`` or the web UI.
             raise_on_replay_failure: If ``True`` (the default), this will raise
                 a :py:attr:`WorkflowReplayResult.replay_failure` if it is
                 present.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Replaced all references of tctl with Temporal CLI

## Why?
<!-- Tell your future self why have you made these changes -->
tctl is deprecated

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces remaining "tctl" mentions with "Temporal CLI" in README and docstrings related to workflow history/replay.
> 
> - **Docs**:
>   - Update `README.md` Workflow Replay section to reference `Temporal CLI` instead of `tctl`.
>   - In `temporalio/client.py`, adjust `WorkflowHistory.from_json` docstring to say UI/CLI JSON.
>   - In `temporalio/worker/_replayer.py`, update `Replayer.replay_workflow` docstring to reference `Temporal CLI`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70c3fea53ca3b48170517087c6b999d4a12442fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->