### PR TITLE
Add nightly throughput stress

### DIFF
--- a/.github/workflows/nightly-throughput-stress.yml
+++ b/.github/workflows/nightly-throughput-stress.yml
@@ -171,14 +171,3 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SDK_ALERTS_WEBHOOK }}
-
-      - name: Report test results
-        if: always()
-        run: |
-          if [ "${{ job.status }}" = "success" ]; then
-            echo "✅ Throughput stress test completed successfully"
-          else
-            echo "❌ Throughput stress test failed"
-            echo "📦 Check the uploaded artifacts for detailed logs and state"
-            exit 1
-          fi


### PR DESCRIPTION
## What was changed
Added a nightly workflow to run Omes throughput stress scenario.

Runs throughput stress with a minimum throughput expectation.

Uploads worker logs artifacts and sends a Slack notification on failure.


## Why?
Provides basic smoke/stress testing, with a base benchmark throughput expectation.
