### PR TITLE
fix: typed search contains should work for falsy values

### DIFF
--- a/temporalio/common.py
+++ b/temporalio/common.py
@@ -496,7 +496,7 @@ class TypedSearchAttributes(Collection[SearchAttributePair]):
 
         This uses key equality so the key must be the same name and type.
         """
-        return any(v for k, v in self if k == key)
+        return any(k == key for k, v in self)
 
     @overload
     def get(

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -99,6 +99,25 @@ def test_typed_search_attribute_duplicates():
         )
 
 
+def test_typed_search_attributes_contains_with_falsy_value():
+    int_key = SearchAttributeKey.for_int("my-int")
+    attrs = TypedSearchAttributes([SearchAttributePair(int_key, 0)])
+    assert int_key in attrs
+
+
+def test_typed_search_attributes_contains_with_truthy_value():
+    int_key = SearchAttributeKey.for_int("my-int")
+    attrs = TypedSearchAttributes([SearchAttributePair(int_key, 42)])
+    assert int_key in attrs
+
+
+def test_typed_search_attributes_contains_missing_key():
+    int_key = SearchAttributeKey.for_int("my-int")
+    missing_key = SearchAttributeKey.for_keyword("missing")
+    attrs = TypedSearchAttributes([SearchAttributePair(int_key, 42)])
+    assert missing_key not in attrs
+
+
 def test_cant_construct_bad_priority():
     with pytest.raises(TypeError):
         Priority(priority_key=1.1)  # type: ignore


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Fixes a bug where falsy values would not be recognized in the typed search contains

## Why?
<!-- Tell your future self why have you made these changes -->
Falsy values in search attributes should still show up as part of the typed search contains

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here --> N/A

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
I wrote unit tests that were previously failing

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No doc updates needed
