### PR TITLE
Ensure NoneType when inspecting origin type args contain None

### DIFF
--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -1692,6 +1692,11 @@ def value_to_type(
     origin = getattr(hint, "__origin__", hint)
     type_args: tuple = getattr(hint, "__args__", ())
 
+    # using Dict[None,...] produces the type args (NoneType,...)
+    # using dict[None,...] produces the type args (None,...)
+    # Ensure we're always using NoneType over None
+    type_args = tuple(type(t) if t is None else t for t in type_args)
+
     # Literal
     if origin is Literal or origin is typing_extensions.Literal:
         if value not in type_args:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -441,11 +441,8 @@ def test_json_type_hints():
     ok(dict[float, str], {1.0: "1"})
     ok(dict[bool, str], {True: "1"})
 
-    # On a 3.10+ dict type, None isn't returned from a key. This is potentially a bug
-    ok(dict[None, str], {"null": "1"})
-
-    # Dict has a different value for None keys
     ok(Dict[None, str], {None: "1"})
+    ok(dict[None, str], {None: "1"})
 
     # Alias
     ok(MyDataClassAlias, MyDataClass("foo", 5, SerializableEnum.FOO))


### PR DESCRIPTION
## What was changed
* Ensure we're using NoneType instead of None when inspecting type args in converter

## Why?

When inspecting the origin type args in the converter `Dict[None,...]` produces the type args `(NoneType,...)` while `dict[None,...]` produces the type args `(None,...)`. This change normalizes `None` to `NoneType`. 

## Checklist

1. Closes #1237 

2. How was this tested:

Existing convert tests were adjusted to capture the expectation that `dict[None,...]` returns `{None:...}`.
