### PR TITLE
Remove stdlib_module_names test that is no longer relevant

### DIFF
--- a/tests/worker/workflow_sandbox/test_restrictions.py
+++ b/tests/worker/workflow_sandbox/test_restrictions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pathlib
-import sys
 from dataclasses import dataclass
 from typing import ClassVar
 


### PR DESCRIPTION
## What was changed

Remove stdlib_module_names test that is no longer relevant

## Why?

This test was applicable when we had to maintain a clone of `stdlib_module_names` for use on older versions of Python but is not longer necessary.

