### PR TITLE
fix(README): replace relative imports with absolute imports in quicks…

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ from temporalio import workflow
 
 # Import our activity, passing it through the sandbox
 with workflow.unsafe.imports_passed_through():
-    from .activities import say_hello
+    from activities import say_hello
 
 @workflow.defn
 class SayHello:
@@ -184,8 +184,8 @@ from temporalio.client import Client
 from temporalio.worker import Worker
 
 # Import the activity and workflow from our other files
-from .activities import say_hello
-from .workflows import SayHello
+from activities import say_hello
+from workflows import SayHello
 
 async def main():
     # Create client connected to server at the given address
@@ -220,7 +220,7 @@ import asyncio
 from temporalio.client import Client
 
 # Import the workflow from the previous code
-from .workflows import SayHello
+from workflows import SayHello
 
 async def main():
     # Create client connected to server at the given address


### PR DESCRIPTION
The quickstart examples used relative imports (e.g., `from .activities`) which fail when scripts are run directly with the error "attempted relative import with no known parent package".

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Changed relative imports to absolute imports README

## Why?
Relative imports fail when Python scripts are executed directly (e.g., `python run_worker.py`) because Python doesn't recognize the script as part of a package. Using absolute imports allows the scripts to be run directly without import errors.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
   - Ran `python run_worker.py` and verified it no longer throws `ImportError: attempted relative import with no known parent package`
   - Verified imports work correctly when running the script directly

4. Any docs updates needed?
   No docs updates needed.