### PR TITLE
test(dev-server): support UI port

### DIFF
--- a/temporalio/bridge/src/testing.rs
+++ b/temporalio/bridge/src/testing.rs
@@ -25,6 +25,7 @@ pub struct DevServerConfig {
     port: Option<u16>,
     database_filename: Option<String>,
     ui: bool,
+    ui_port: Option<u16>,
     log_format: String,
     log_level: String,
     extra_args: Vec<String>,
@@ -133,6 +134,7 @@ impl From<DevServerConfig> for ephemeral_server::TemporalDevServerConfig {
             .maybe_port(conf.port)
             .maybe_db_filename(conf.database_filename)
             .ui(conf.ui)
+            .maybe_ui_port(conf.ui_port)
             .log((conf.log_format, conf.log_level))
             .extra_args(conf.extra_args)
             .build()

--- a/temporalio/bridge/testing.py
+++ b/temporalio/bridge/testing.py
@@ -27,6 +27,7 @@ class DevServerConfig:
     port: int | None
     database_filename: str | None
     ui: bool
+    ui_port: int | None
     log_format: str
     log_level: str
     extra_args: Sequence[str]

--- a/temporalio/testing/_workflow.py
+++ b/temporalio/testing/_workflow.py
@@ -91,6 +91,7 @@ class WorkflowEnvironment:
         dev_server_download_version: str = "default",
         dev_server_extra_args: Sequence[str] = [],
         dev_server_download_ttl: timedelta | None = None,
+        ui_port: int | None = None,
     ) -> WorkflowEnvironment:
         """Start a full Temporal server locally, downloading if necessary.
 
@@ -149,6 +150,7 @@ class WorkflowEnvironment:
             dev_server_extra_args: Extra arguments for the CLI binary.
             dev_server_download_ttl: TTL for the downloaded CLI binary. If unset, it will be
                 cached indefinitely.
+            ui_port: UI port to use if UI is enabled.
 
         Returns:
             The started CLI dev server workflow environment.
@@ -173,6 +175,7 @@ class WorkflowEnvironment:
                 new_args.append(f"{attr.name}={attr._metadata_type}")
             new_args += dev_server_extra_args
             dev_server_extra_args = new_args
+
         # Start CLI dev server
         runtime = runtime or temporalio.runtime.Runtime.default()
         download_ttl_ms = None
@@ -191,12 +194,14 @@ class WorkflowEnvironment:
                 port=port,
                 database_filename=dev_server_database_filename,
                 ui=ui,
+                ui_port=ui_port,
                 log_format=dev_server_log_format,
                 log_level=dev_server_log_level,
                 extra_args=dev_server_extra_args,
                 download_ttl_ms=download_ttl_ms,
             ),
         )
+
         # If we can't connect to the server, we should shut it down
         try:
             return _EphemeralServerWorkflowEnvironment(

--- a/tests/testing/test_workflow.py
+++ b/tests/testing/test_workflow.py
@@ -317,6 +317,16 @@ async def test_search_attributes_on_dev_server(
         assert attrs == desc.typed_search_attributes
 
 
+async def test_ui_port():
+    """Test that ui_port parameter works correctly."""
+    async with await WorkflowEnvironment.start_local(
+        ui=True,
+        ui_port=18080,
+    ) as env:
+        # Just verify it starts without error
+        assert env.client is not None
+
+
 def assert_timestamp_from_now(
     ts: datetime | float, expected_from_now: float, max_delta: float = 30
 ) -> None:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added `ui_port` parameter to `WorkflowEnvironment.start_local()` method to allow users to customize the UI port when starting a local Temporal dev server environment.

## Why?
This feature allows users to specify a custom UI port when starting the dev server

## Checklist
<!--- add/delete as needed --->

1. Closes #748

2. How was this tested:
   - Test verifies that the server starts successfully with the configured UI port

4. Any docs updates needed?
   - Parameter is already documented in the docstring of `start_local()` method
   - No additional README or external docs changes required as this is an internal testing feature