### PR TITLE
Add is_replaying_history_events to allow logging in queries and validators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ temporalio/bridge/temporal_sdk_bridge*
 /.zed
 *.DS_Store
 tags
+/.claude
+tmpclaude-*

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -741,6 +741,9 @@ class _Runtime(ABC):
     def workflow_is_replaying(self) -> bool: ...
 
     @abstractmethod
+    def workflow_is_replaying_history_events(self) -> bool: ...
+
+    @abstractmethod
     def workflow_memo(self) -> Mapping[str, Any]: ...
 
     @abstractmethod
@@ -1444,10 +1447,23 @@ class unsafe:
     def is_replaying() -> bool:
         """Whether the workflow is currently replaying.
 
+        This includes queries and update validators that occur during replay.
+
         Returns:
             True if the workflow is currently replaying
         """
         return _Runtime.current().workflow_is_replaying()
+
+    @staticmethod
+    def is_replaying_history_events() -> bool:
+        """Whether the workflow is replaying history events.
+
+        This excludes queries and update validators, which are live operations.
+
+        Returns:
+            True if replaying history events, False otherwise.
+        """
+        return _Runtime.current().workflow_is_replaying_history_events()
 
     @staticmethod
     def is_sandbox_unrestricted() -> bool:
@@ -1602,7 +1618,7 @@ class LoggerAdapter(logging.LoggerAdapter):
 
     def isEnabledFor(self, level: int) -> bool:
         """Override to ignore replay logs."""
-        if not self.log_during_replay and unsafe.is_replaying():
+        if not self.log_during_replay and unsafe.is_replaying_history_events():
             return False
         return super().isEnabledFor(level)
 

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -1986,6 +1986,7 @@ class LoggingWorkflow:
 
     @workflow.query
     def last_signal(self) -> str:
+        workflow.logger.info("Query called")
         return self._last_signal
 
 
@@ -2021,6 +2022,7 @@ async def test_workflow_logging(client: Client):
         assert capturer.find_log("Signal: signal 2")
         assert capturer.find_log("Update: update 1")
         assert capturer.find_log("Update: update 2")
+        assert capturer.find_log("Query called")
         assert not capturer.find_log("Signal: signal 3")
         # Also make sure it has some workflow info and correct funcName
         record = capturer.find_log("Signal: signal 1")


### PR DESCRIPTION
## What was changed

Added `workflow.unsafe.is_replaying_history_events()` to distinguish replaying historical events from handling live read operations (queries/update validators). Updated replay-safe logger to allow logs during queries and validators.