### PR TITLE
Add support for more timeouts to Nexus operations

### DIFF
--- a/temporalio/worker/_interceptor.py
+++ b/temporalio/worker/_interceptor.py
@@ -303,6 +303,8 @@ class StartNexusOperationInput(Generic[InputT, OutputT]):
     operation: nexusrpc.Operation[InputT, OutputT] | str | Callable[..., Any]
     input: InputT
     schedule_to_close_timeout: timedelta | None
+    schedule_to_start_timeout: timedelta | None
+    start_to_close_timeout: timedelta | None
     cancellation_type: temporalio.workflow.NexusOperationCancellationType
     headers: Mapping[str, str] | None
     summary: str | None

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -3349,9 +3349,7 @@ class _NexusOperationHandle(temporalio.workflow.NexusOperationHandle[OutputT]):
                 self._input.schedule_to_start_timeout
             )
         if self._input.start_to_close_timeout is not None:
-            v.start_to_close_timeout.FromTimedelta(
-                self._input.start_to_close_timeout
-            )
+            v.start_to_close_timeout.FromTimedelta(self._input.start_to_close_timeout)
         v.cancellation_type = cast(
             temporalio.bridge.proto.nexus.NexusOperationCancellationType.ValueType,
             int(self._input.cancellation_type),

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -1596,6 +1596,8 @@ class _WorkflowInstanceImpl(  # type: ignore[reportImplicitAbstractClass]
         input: Any,
         output_type: type[OutputT] | None,
         schedule_to_close_timeout: timedelta | None,
+        schedule_to_start_timeout: timedelta | None,
+        start_to_close_timeout: timedelta | None,
         cancellation_type: temporalio.workflow.NexusOperationCancellationType,
         headers: Mapping[str, str] | None,
         summary: str | None,
@@ -1609,6 +1611,8 @@ class _WorkflowInstanceImpl(  # type: ignore[reportImplicitAbstractClass]
                 input=input,
                 output_type=output_type,
                 schedule_to_close_timeout=schedule_to_close_timeout,
+                schedule_to_start_timeout=schedule_to_start_timeout,
+                start_to_close_timeout=start_to_close_timeout,
                 cancellation_type=cancellation_type,
                 headers=headers,
                 summary=summary,
@@ -3339,6 +3343,14 @@ class _NexusOperationHandle(temporalio.workflow.NexusOperationHandle[OutputT]):
         if self._input.schedule_to_close_timeout is not None:
             v.schedule_to_close_timeout.FromTimedelta(
                 self._input.schedule_to_close_timeout
+            )
+        if self._input.schedule_to_start_timeout is not None:
+            v.schedule_to_start_timeout.FromTimedelta(
+                self._input.schedule_to_start_timeout
+            )
+        if self._input.start_to_close_timeout is not None:
+            v.start_to_close_timeout.FromTimedelta(
+                self._input.start_to_close_timeout
             )
         v.cancellation_type = cast(
             temporalio.bridge.proto.nexus.NexusOperationCancellationType.ValueType,

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -5418,6 +5418,8 @@ class NexusClient(ABC, Generic[ServiceT]):
         *,
         output_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
         cancellation_type: NexusOperationCancellationType = NexusOperationCancellationType.WAIT_COMPLETED,
         headers: Mapping[str, str] | None = None,
         summary: str | None = None,
@@ -5433,6 +5435,8 @@ class NexusClient(ABC, Generic[ServiceT]):
         *,
         output_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
         cancellation_type: NexusOperationCancellationType = NexusOperationCancellationType.WAIT_COMPLETED,
         headers: Mapping[str, str] | None = None,
         summary: str | None = None,
@@ -5451,6 +5455,8 @@ class NexusClient(ABC, Generic[ServiceT]):
         *,
         output_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
         cancellation_type: NexusOperationCancellationType = NexusOperationCancellationType.WAIT_COMPLETED,
         headers: Mapping[str, str] | None = None,
         summary: str | None = None,
@@ -5469,6 +5475,8 @@ class NexusClient(ABC, Generic[ServiceT]):
         *,
         output_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
         cancellation_type: NexusOperationCancellationType = NexusOperationCancellationType.WAIT_COMPLETED,
         headers: Mapping[str, str] | None = None,
         summary: str | None = None,
@@ -5487,6 +5495,8 @@ class NexusClient(ABC, Generic[ServiceT]):
         *,
         output_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
         cancellation_type: NexusOperationCancellationType = NexusOperationCancellationType.WAIT_COMPLETED,
         headers: Mapping[str, str] | None = None,
         summary: str | None = None,
@@ -5504,6 +5514,8 @@ class NexusClient(ABC, Generic[ServiceT]):
         *,
         output_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
         cancellation_type: NexusOperationCancellationType = NexusOperationCancellationType.WAIT_COMPLETED,
         headers: Mapping[str, str] | None = None,
         summary: str | None = None,
@@ -5517,6 +5529,8 @@ class NexusClient(ABC, Generic[ServiceT]):
         *,
         output_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
         cancellation_type: NexusOperationCancellationType = NexusOperationCancellationType.WAIT_COMPLETED,
         headers: Mapping[str, str] | None = None,
         summary: str | None = None,
@@ -5528,6 +5542,8 @@ class NexusClient(ABC, Generic[ServiceT]):
             input: The Nexus operation input.
             output_type: The Nexus operation output type.
             schedule_to_close_timeout: Timeout for the entire operation attempt.
+            schedule_to_start_timeout: Timeout for the operation to be started.
+            start_to_close_timeout: Timeout for async operations to complete after starting.
             headers: Headers to send with the Nexus HTTP request.
 
         Returns:
@@ -5548,6 +5564,8 @@ class NexusClient(ABC, Generic[ServiceT]):
         *,
         output_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
         cancellation_type: NexusOperationCancellationType = NexusOperationCancellationType.WAIT_COMPLETED,
         headers: Mapping[str, str] | None = None,
         summary: str | None = None,
@@ -5563,6 +5581,8 @@ class NexusClient(ABC, Generic[ServiceT]):
         *,
         output_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
         cancellation_type: NexusOperationCancellationType = NexusOperationCancellationType.WAIT_COMPLETED,
         headers: Mapping[str, str] | None = None,
         summary: str | None = None,
@@ -5581,6 +5601,8 @@ class NexusClient(ABC, Generic[ServiceT]):
         *,
         output_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
         cancellation_type: NexusOperationCancellationType = NexusOperationCancellationType.WAIT_COMPLETED,
         headers: Mapping[str, str] | None = None,
         summary: str | None = None,
@@ -5599,6 +5621,8 @@ class NexusClient(ABC, Generic[ServiceT]):
         *,
         output_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
         cancellation_type: NexusOperationCancellationType = NexusOperationCancellationType.WAIT_COMPLETED,
         headers: Mapping[str, str] | None = None,
         summary: str | None = None,
@@ -5617,6 +5641,8 @@ class NexusClient(ABC, Generic[ServiceT]):
         *,
         output_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
         cancellation_type: NexusOperationCancellationType = NexusOperationCancellationType.WAIT_COMPLETED,
         headers: Mapping[str, str] | None = None,
         summary: str | None = None,
@@ -5635,6 +5661,8 @@ class NexusClient(ABC, Generic[ServiceT]):
         *,
         output_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
         cancellation_type: NexusOperationCancellationType = NexusOperationCancellationType.WAIT_COMPLETED,
         headers: Mapping[str, str] | None = None,
         summary: str | None = None,
@@ -5648,6 +5676,8 @@ class NexusClient(ABC, Generic[ServiceT]):
         *,
         output_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
         cancellation_type: NexusOperationCancellationType = NexusOperationCancellationType.WAIT_COMPLETED,
         headers: Mapping[str, str] | None = None,
         summary: str | None = None,
@@ -5659,6 +5689,8 @@ class NexusClient(ABC, Generic[ServiceT]):
             input: The Nexus operation input.
             output_type: The Nexus operation output type.
             schedule_to_close_timeout: Timeout for the entire operation attempt.
+            schedule_to_start_timeout: Timeout for the operation to be started.
+            start_to_close_timeout: Timeout for async operations to complete after starting.
             headers: Headers to send with the Nexus HTTP request.
 
         Returns:
@@ -5701,6 +5733,8 @@ class _NexusClient(NexusClient[ServiceT]):
         *,
         output_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
         cancellation_type: NexusOperationCancellationType = NexusOperationCancellationType.WAIT_COMPLETED,
         headers: Mapping[str, str] | None = None,
         summary: str | None = None,
@@ -5713,6 +5747,8 @@ class _NexusClient(NexusClient[ServiceT]):
                 input=input,
                 output_type=output_type,
                 schedule_to_close_timeout=schedule_to_close_timeout,
+                schedule_to_start_timeout=schedule_to_start_timeout,
+                start_to_close_timeout=start_to_close_timeout,
                 cancellation_type=cancellation_type,
                 headers=headers,
                 summary=summary,
@@ -5726,6 +5762,8 @@ class _NexusClient(NexusClient[ServiceT]):
         *,
         output_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
         cancellation_type: NexusOperationCancellationType = NexusOperationCancellationType.WAIT_COMPLETED,
         headers: Mapping[str, str] | None = None,
         summary: str | None = None,
@@ -5735,6 +5773,8 @@ class _NexusClient(NexusClient[ServiceT]):
             input,
             output_type=output_type,
             schedule_to_close_timeout=schedule_to_close_timeout,
+            schedule_to_start_timeout=schedule_to_start_timeout,
+            start_to_close_timeout=start_to_close_timeout,
             cancellation_type=cancellation_type,
             headers=headers,
             summary=summary,

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -856,6 +856,8 @@ class _Runtime(ABC):
         input: Any,
         output_type: type[OutputT] | None,
         schedule_to_close_timeout: timedelta | None,
+        schedule_to_start_timeout: timedelta | None,
+        start_to_close_timeout: timedelta | None,
         cancellation_type: temporalio.workflow.NexusOperationCancellationType,
         headers: Mapping[str, str] | None,
         summary: str | None,

--- a/tests/nexus/test_workflow_caller_errors.py
+++ b/tests/nexus/test_workflow_caller_errors.py
@@ -30,6 +30,7 @@ from temporalio.exceptions import (
     ApplicationError,
     NexusOperationError,
     TimeoutError,
+    TimeoutType,
 )
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
@@ -321,6 +322,155 @@ async def test_error_raised_by_timeout_of_nexus_start_operation(
                     "Expected exception due to timeout of nexus start operation"
                 )
             assert capturer.find_log("unexpected cancellation reason") is None
+
+
+# Schedule to start timeout test
+@service_handler
+class ScheduleToStartTimeoutTestService:
+    @sync_operation
+    async def expect_schedule_to_start_timeout(
+        self, ctx: StartOperationContext, _input: None
+    ) -> None:
+        try:
+            await asyncio.wait_for(ctx.task_cancellation.wait_until_cancelled(), 1)
+        except asyncio.TimeoutError:
+            raise ApplicationError("expected cancel", non_retryable=True)
+
+
+@workflow.defn
+class ScheduleToStartTimeoutTestCallerWorkflow:
+    @workflow.init
+    def __init__(self):
+        self.nexus_client = workflow.create_nexus_client(
+            service=ScheduleToStartTimeoutTestService,
+            endpoint=make_nexus_endpoint_name(workflow.info().task_queue),
+        )
+
+    @workflow.run
+    async def run(self) -> None:
+        await self.nexus_client.execute_operation(
+            ScheduleToStartTimeoutTestService.expect_schedule_to_start_timeout,
+            None,
+            output_type=None,
+            schedule_to_start_timeout=timedelta(seconds=0.1),
+        )
+
+
+async def test_error_raised_by_schedule_to_start_timeout_of_nexus_operation(
+    client: Client, env: WorkflowEnvironment
+):
+    if env.supports_time_skipping:
+        pytest.skip("Nexus tests don't work with time-skipping server")
+
+    task_queue = str(uuid.uuid4())
+    async with Worker(
+        client,
+        nexus_service_handlers=[ScheduleToStartTimeoutTestService()],
+        workflows=[ScheduleToStartTimeoutTestCallerWorkflow],
+        task_queue=task_queue,
+        nexus_task_executor=concurrent.futures.ThreadPoolExecutor(),
+    ):
+        await create_nexus_endpoint(task_queue, client)
+        try:
+            await client.execute_workflow(
+                ScheduleToStartTimeoutTestCallerWorkflow.run,
+                id=str(uuid.uuid4()),
+                task_queue=task_queue,
+            )
+        except Exception as err:
+            assert isinstance(err, WorkflowFailureError)
+            assert isinstance(err.__cause__, NexusOperationError)
+            assert isinstance(err.__cause__.__cause__, TimeoutError)
+            timeout_err = err.__cause__.__cause__
+            assert timeout_err.type == TimeoutType.SCHEDULE_TO_START
+        else:
+            pytest.fail(
+                "Expected exception due to schedule to start timeout of nexus operation"
+            )
+
+
+# Start to close timeout test
+
+
+class OperationThatExpectsStartToCloseTimeoutAsync(OperationHandler[None, None]):
+    async def start(
+        self, ctx: StartOperationContext, input: None
+    ) -> StartOperationResultAsync:
+        return StartOperationResultAsync("fake-token")
+
+    async def cancel(self, ctx: CancelOperationContext, token: str) -> None:
+        pass
+
+
+class OperationThatExpectsStartToCloseTimeoutSync(OperationHandler[None, None]):
+    async def start(
+        self, ctx: StartOperationContext, input: None
+    ) -> StartOperationResultAsync:
+        return StartOperationResultAsync("fake-token")
+
+    async def cancel(self, ctx: CancelOperationContext, token: str) -> None:
+        pass
+
+
+@service_handler
+class StartToCloseTimeoutTestService:
+    @operation_handler
+    def expect_start_to_close_timeout(self) -> OperationHandler[None, None]:
+        return OperationThatExpectsStartToCloseTimeoutAsync()
+
+
+@workflow.defn
+class StartToCloseTimeoutTestCallerWorkflow:
+    @workflow.init
+    def __init__(
+        self,
+    ):
+        self.nexus_client = workflow.create_nexus_client(
+            service=StartToCloseTimeoutTestService,
+            endpoint=make_nexus_endpoint_name(workflow.info().task_queue),
+        )
+
+    @workflow.run
+    async def run(self) -> None:
+        op_handle = await self.nexus_client.start_operation(
+            StartToCloseTimeoutTestService.expect_start_to_close_timeout,
+            None,
+            start_to_close_timeout=timedelta(seconds=0.1),
+        )
+        await op_handle
+
+
+async def test_error_raised_by_start_to_close_timeout_of_nexus_operation(
+    client: Client, env: WorkflowEnvironment
+):
+    if env.supports_time_skipping:
+        pytest.skip("Nexus tests don't work with time-skipping server")
+
+    task_queue = str(uuid.uuid4())
+    async with Worker(
+        client,
+        nexus_service_handlers=[StartToCloseTimeoutTestService()],
+        workflows=[StartToCloseTimeoutTestCallerWorkflow],
+        task_queue=task_queue,
+        nexus_task_executor=concurrent.futures.ThreadPoolExecutor(),
+    ):
+        await create_nexus_endpoint(task_queue, client)
+        try:
+            await client.execute_workflow(
+                StartToCloseTimeoutTestCallerWorkflow.run,
+                id=str(uuid.uuid4()),
+                task_queue=task_queue,
+            )
+        except Exception as err:
+            assert isinstance(err, WorkflowFailureError)
+            assert isinstance(err.__cause__, NexusOperationError)
+            timeout_err = err.__cause__.__cause__
+            assert isinstance(timeout_err, TimeoutError)
+            assert timeout_err.type == TimeoutType.START_TO_CLOSE
+        else:
+            pytest.fail(
+                "Expected exception due to start to close timeout of nexus operation"
+            )
 
 
 # Cancellation timeout test

--- a/tests/nexus/test_workflow_caller_errors.py
+++ b/tests/nexus/test_workflow_caller_errors.py
@@ -370,7 +370,9 @@ async def test_error_raised_by_schedule_to_start_timeout_of_nexus_operation(
         task_queue=task_queue,
         nexus_task_executor=concurrent.futures.ThreadPoolExecutor(),
     ):
-        await create_nexus_endpoint(task_queue, client)
+        await env.create_nexus_endpoint(
+            make_nexus_endpoint_name(task_queue), task_queue
+        )
         try:
             await client.execute_workflow(
                 ScheduleToStartTimeoutTestCallerWorkflow.run,
@@ -444,7 +446,9 @@ async def test_error_raised_by_start_to_close_timeout_of_nexus_operation(
         task_queue=task_queue,
         nexus_task_executor=concurrent.futures.ThreadPoolExecutor(),
     ):
-        await create_nexus_endpoint(task_queue, client)
+        await env.create_nexus_endpoint(
+            make_nexus_endpoint_name(task_queue), task_queue
+        )
         try:
             await client.execute_workflow(
                 StartToCloseTimeoutTestCallerWorkflow.run,

--- a/tests/nexus/test_workflow_caller_errors.py
+++ b/tests/nexus/test_workflow_caller_errors.py
@@ -402,16 +402,6 @@ class OperationThatExpectsStartToCloseTimeoutAsync(OperationHandler[None, None])
         pass
 
 
-class OperationThatExpectsStartToCloseTimeoutSync(OperationHandler[None, None]):
-    async def start(
-        self, ctx: StartOperationContext, input: None
-    ) -> StartOperationResultAsync:
-        return StartOperationResultAsync("fake-token")
-
-    async def cancel(self, ctx: CancelOperationContext, token: str) -> None:
-        pass
-
-
 @service_handler
 class StartToCloseTimeoutTestService:
     @operation_handler


### PR DESCRIPTION
Add schedule-to-start and start-to-close for Nexus operations

NOTE, before this can be merged the API still needs to be tagged, core changes need to be merged and tests need to be added

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands a public API surface and changes how Nexus operations are scheduled by adding new timeout fields, which could affect operation execution semantics if mis-mapped. Covered by new error-path tests, but relies on server/core support for the new proto fields.
> 
> **Overview**
> Adds support for two additional Nexus operation timeouts by threading `schedule_to_start_timeout` and `start_to_close_timeout` through the workflow Nexus client API, worker runtime interceptors, and the scheduled `schedule_nexus_operation` command.
> 
> Updates the public `NexusClient.start_operation`/`execute_operation` signatures and `_Runtime.workflow_start_nexus_operation` to accept these new parameters, and adds new integration tests asserting `TimeoutError` surfaces with `TimeoutType.SCHEDULE_TO_START` and `TimeoutType.START_TO_CLOSE` when those limits are exceeded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a78070708e4a6f6dbba4b3326b0c4b5b1ea08ebd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->