### PR TITLE
Add support for parsing LitellmModel for OpenAI

### DIFF
--- a/temporalio/contrib/openai_agents/_openai_runner.py
+++ b/temporalio/contrib/openai_agents/_openai_runner.py
@@ -13,6 +13,7 @@ from agents import (
     TContext,
     TResponseInputItem,
 )
+from agents.extensions.models.litellm_model import LitellmModel
 from agents.run import DEFAULT_AGENT_RUNNER, DEFAULT_MAX_TURNS, AgentRunner
 
 from temporalio import workflow
@@ -200,9 +201,13 @@ class TemporalOpenAIRunner(AgentRunner):
 
 
 def _model_name(agent: Agent[Any]) -> str | None:
-    name = agent.model
-    if name is not None and not isinstance(name, str):
-        raise ValueError(
-            "Temporal workflows require a model name to be a string in the agent."
-        )
-    return name
+    model = agent.model
+    if model is None or isinstance(model, str):
+        return model
+
+    if isinstance(model, LitellmModel):
+        return model.model
+
+    raise ValueError(
+        "Temporal workflows require a model name to be a string or a LitellmModel in the agent."
+    )


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Updated `_model_name` function in `_openai_runner.py` to support `LitellmModel` by extracting the model name from its model attribute instead of only accepting string model names.   

## Why?
<!-- Tell your future self why have you made these changes -->

Currently the temporal OpenAI Agents SDK integration only allows you to run agents with OpenAI models. If you tried using their `LitellmModel` [compatibility feature](https://openai.github.io/openai-agents-python/models/litellm/) you would get the error:
```
ValueError: Temporal workflows require a model name to be a string in the agent.
```

This change will allow you to use any model with the Agents SDK on Temporal.

## Checklist
<!--- add/delete as needed --->

1. Issue:
https://github.com/temporalio/sdk-python/issues/1302

2. How was this tested:
`poe test`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
dont think so?
