### PR TITLE
[fix] Make `workflow_id: str` for workflow serialization context

### DIFF
--- a/temporalio/converter.py
+++ b/temporalio/converter.py
@@ -91,7 +91,7 @@ class WorkflowSerializationContext(SerializationContext):
     namespace: str
     """The namespace the workflow is running in."""
 
-    workflow_id: str | None
+    workflow_id: str
     """The ID of the workflow.
     
     Note that this is the ID of the workflow of which the payload being operated on is an input or


### PR DESCRIPTION
## What was changed
DWISOTT

## Why?
Unintended to be possibly `None` (this case does not exist)

1. Closes #1339

2. How was this tested:
Existing tests

3. Any docs updates needed?
No
