### PR TITLE
AI-59: Mark LangSmith plugin as experimental

### DIFF
--- a/temporalio/contrib/langsmith/README.md
+++ b/temporalio/contrib/langsmith/README.md
@@ -1,5 +1,7 @@
 # LangSmith Plugin for Temporal Python SDK
 
+> ⚠️ **This package is currently at an experimental release stage.** ⚠️
+
 This Temporal [Plugin](https://docs.temporal.io/develop/plugins-guide) allows your [LangSmith](https://smith.langchain.com/) traces to work within Temporal Workflows. It propagates trace context across Worker boundaries so that `@traceable` calls, LLM invocations, and Temporal operations show up in a single connected trace, and ensures that replaying does not generate duplicate traces.
 
 ## Quick Start

--- a/temporalio/contrib/langsmith/__init__.py
+++ b/temporalio/contrib/langsmith/__init__.py
@@ -1,5 +1,9 @@
 """LangSmith integration for Temporal SDK.
 
+.. warning::
+    This package is experimental and may change in future versions.
+    Use with caution in production environments.
+
 This package provides LangSmith tracing integration for Temporal workflows,
 activities, and other operations. It includes automatic run creation and
 context propagation for distributed tracing in LangSmith.

--- a/temporalio/contrib/langsmith/_interceptor.py
+++ b/temporalio/contrib/langsmith/_interceptor.py
@@ -533,6 +533,10 @@ class LangSmithInterceptor(
 ):
     """Interceptor that supports client and worker LangSmith run creation
     and context propagation.
+
+    .. warning::
+        This class is experimental and may change in future versions.
+        Use with caution in production environments.
     """
 
     def __init__(

--- a/temporalio/contrib/langsmith/_plugin.py
+++ b/temporalio/contrib/langsmith/_plugin.py
@@ -18,6 +18,10 @@ from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
 class LangSmithPlugin(SimplePlugin):
     """LangSmith tracing plugin for Temporal SDK.
 
+    .. warning::
+        This class is experimental and may change in future versions.
+        Use with caution in production environments.
+
     Provides automatic LangSmith run creation for workflows, activities,
     and other Temporal operations with context propagation.
     """


### PR DESCRIPTION
## Summary

- Add experimental warnings to the LangSmith plugin, consistent with the pattern used by OpenTelemetry, Google ADK, and AWS S3 contrib plugins
- Adds RST `.. warning::` blocks to `LangSmithPlugin` and `LangSmithInterceptor` class docstrings and the module docstring
- Adds an experimental banner to the README

## Test plan

- [x] All 7 linters pass (`ruff check`, `ruff format`, `pyright`, `mypy`, `basedpyright`, `pydocstyle`, `pydoctor`)
- [x] Docs-only change — no behavioral changes
- [x] Code auditor: clean pass
- [x] Comment auditor: clean pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)