### PR TITLE
S3 Driver: Require hash algorithm and value in claim payloads

### DIFF
--- a/temporalio/contrib/aws/s3driver/_driver.py
+++ b/temporalio/contrib/aws/s3driver/_driver.py
@@ -188,23 +188,28 @@ class S3StorageDriver(StorageDriver):
                     f"S3StorageDriver retrieve failed [bucket={bucket}, key={key}]"
                 ) from e
 
-            expected_hash = claim.claim_data.get("hash_value")
             hash_algorithm = claim.claim_data.get("hash_algorithm")
-            if expected_hash and hash_algorithm:
-                if hash_algorithm != "sha256":
-                    raise ValueError(
-                        f"S3StorageDriver unsupported hash algorithm "
-                        f"[bucket={bucket}, key={key}]: "
-                        f"expected sha256, got {hash_algorithm}"
-                    )
-                actual_hash = hashlib.sha256(payload_bytes).hexdigest().lower()
-                if actual_hash != expected_hash:
-                    raise ValueError(
-                        f"S3StorageDriver integrity check failed "
-                        f"[bucket={bucket}, key={key}]: "
-                        f"expected {hash_algorithm}:{expected_hash}, "
-                        f"got {hash_algorithm}:{actual_hash}"
-                    )
+            expected_hash = claim.claim_data.get("hash_value")
+            if not hash_algorithm or not expected_hash:
+                raise ValueError(
+                    f"S3StorageDriver claim is missing required content hash information "
+                    f"[bucket={bucket}, key={key}]: "
+                    f"claim_data must contain 'hash_algorithm' and 'hash_value'"
+                )
+            if hash_algorithm != "sha256":
+                raise ValueError(
+                    f"S3StorageDriver unsupported hash algorithm "
+                    f"[bucket={bucket}, key={key}]: "
+                    f"expected sha256, got {hash_algorithm}"
+                )
+            actual_hash = hashlib.sha256(payload_bytes).hexdigest().lower()
+            if actual_hash != expected_hash:
+                raise ValueError(
+                    f"S3StorageDriver integrity check failed "
+                    f"[bucket={bucket}, key={key}]: "
+                    f"expected {hash_algorithm}:{expected_hash}, "
+                    f"got {hash_algorithm}:{actual_hash}"
+                )
 
             payload = Payload()
             payload.ParseFromString(payload_bytes)

--- a/tests/contrib/aws/s3driver/test_s3driver.py
+++ b/tests/contrib/aws/s3driver/test_s3driver.py
@@ -489,7 +489,7 @@ class TestS3StorageDriverStoreRetrieve:
     async def test_retrieve_without_hash_in_claim(
         self, driver_client: S3StorageDriverClient
     ) -> None:
-        """Claims without hash fields still retrieve successfully (backward compat)."""
+        """Claims missing content hash fields raise ValueError on retrieve."""
         driver = S3StorageDriver(client=driver_client, bucket=BUCKET)
         payload = make_payload("no-hash-claim")
         [claim] = await driver.store(make_store_context(), [payload])
@@ -500,10 +500,11 @@ class TestS3StorageDriverStoreRetrieve:
                 "key": claim.claim_data["key"],
             },
         )
-        [retrieved] = await driver.retrieve(
-            StorageDriverRetrieveContext(), [legacy_claim]
-        )
-        assert retrieved == payload
+        with pytest.raises(
+            ValueError,
+            match=r"S3StorageDriver claim is missing required content hash information",
+        ):
+            await driver.retrieve(StorageDriverRetrieveContext(), [legacy_claim])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Update S3 driver to require hash algorithm and value on the claim payloads.

## Why?

The driver provides the hash algorithm and value on payloads it produces. It should validate that this information is on the claim payloads to validate the integrity of the external data. This change brings functionality in alignment with other language implementation of the S3 driver.

## Checklist
<!--- add/delete as needed --->

2. How was this tested: Existing tests with slight update to `test_retrieve_without_hash_in_claim` test.

3. Any docs updates needed? No
