### PR TITLE
AI-60: Add summary_fn parameter to TemporalModel for dynamic activity summaries

### DIFF
--- a/temporalio/contrib/google_adk_agents/__init__.py
+++ b/temporalio/contrib/google_adk_agents/__init__.py
@@ -7,12 +7,13 @@ from temporalio.contrib.google_adk_agents._mcp import (
     TemporalMcpToolSet,
     TemporalMcpToolSetProvider,
 )
-from temporalio.contrib.google_adk_agents._model import TemporalModel
+from temporalio.contrib.google_adk_agents._model import AdkActivityConfig, TemporalModel
 from temporalio.contrib.google_adk_agents._plugin import (
     GoogleAdkPlugin,
 )
 
 __all__ = [
+    "AdkActivityConfig",
     "GoogleAdkPlugin",
     "TemporalMcpToolSet",
     "TemporalMcpToolSetProvider",

--- a/temporalio/contrib/google_adk_agents/__init__.py
+++ b/temporalio/contrib/google_adk_agents/__init__.py
@@ -7,13 +7,12 @@ from temporalio.contrib.google_adk_agents._mcp import (
     TemporalMcpToolSet,
     TemporalMcpToolSetProvider,
 )
-from temporalio.contrib.google_adk_agents._model import AdkActivityConfig, TemporalModel
+from temporalio.contrib.google_adk_agents._model import TemporalModel
 from temporalio.contrib.google_adk_agents._plugin import (
     GoogleAdkPlugin,
 )
 
 __all__ = [
-    "AdkActivityConfig",
     "GoogleAdkPlugin",
     "TemporalMcpToolSet",
     "TemporalMcpToolSetProvider",

--- a/temporalio/contrib/google_adk_agents/_model.py
+++ b/temporalio/contrib/google_adk_agents/_model.py
@@ -11,7 +11,13 @@ from temporalio.workflow import ActivityConfig
 
 
 class AdkActivityConfig(ActivityConfig, total=False):
-    """Activity config with ADK-specific options."""
+    """Activity config with ADK-specific options.
+
+    Attributes:
+        summary_fn: Optional callable that receives the LlmRequest and returns
+            a summary string (or None). Must be deterministic as it is called
+            during workflow execution.
+    """
 
     summary_fn: Callable[[LlmRequest], str | None] | None
 

--- a/temporalio/contrib/google_adk_agents/_model.py
+++ b/temporalio/contrib/google_adk_agents/_model.py
@@ -58,7 +58,7 @@ class TemporalModel(BaseLlm):
                 the workflow task.
 
         Raises:
-            ValueError: If both 'summary' and 'summary_fn' are set.
+            ValueError: If both ``ActivityConfig["summary"]`` and ``summary_fn`` are set.
         """
         super().__init__(model=model_name)
         self._model_name = model_name
@@ -68,7 +68,9 @@ class TemporalModel(BaseLlm):
         )
         if activity_config is not None:
             if summary_fn is not None and activity_config.get("summary") is not None:
-                raise ValueError("Cannot specify both 'summary' and 'summary_fn'")
+                raise ValueError(
+                    "Cannot specify both ActivityConfig 'summary' and 'summary_fn'"
+                )
             self._activity_config.update(activity_config)
 
     async def generate_content_async(

--- a/temporalio/contrib/google_adk_agents/_model.py
+++ b/temporalio/contrib/google_adk_agents/_model.py
@@ -10,18 +10,6 @@ from temporalio import activity, workflow
 from temporalio.workflow import ActivityConfig
 
 
-class AdkActivityConfig(ActivityConfig, total=False):
-    """Activity config with ADK-specific options.
-
-    Attributes:
-        summary_fn: Optional callable that receives the LlmRequest and returns
-            a summary string (or None). Must be deterministic as it is called
-            during workflow execution.
-    """
-
-    summary_fn: Callable[[LlmRequest], str | None] | None
-
-
 @activity.defn
 async def invoke_model(llm_request: LlmRequest) -> list[LlmResponse]:
     """Activity that invokes an LLM model.
@@ -54,27 +42,34 @@ class TemporalModel(BaseLlm):
     def __init__(
         self,
         model_name: str,
-        activity_config: AdkActivityConfig | ActivityConfig | None = None,
+        activity_config: ActivityConfig | None = None,
+        *,
+        summary_fn: Callable[[LlmRequest], str | None] | None = None,
     ) -> None:
         """Initialize the TemporalModel.
 
         Args:
             model_name: The name of the model to use.
             activity_config: Configuration options for the activity execution.
+            summary_fn: Optional callable that receives the LlmRequest and
+                returns a summary string (or None) for the activity. Must be
+                deterministic as it is called during workflow execution. If
+                the callable raises, the exception will propagate and fail
+                the workflow task.
 
         Raises:
             ValueError: If both 'summary' and 'summary_fn' are set.
         """
         super().__init__(model=model_name)
         self._model_name = model_name
-        raw = dict(activity_config) if activity_config else {}
-        self._summary_fn: Callable[[LlmRequest], str | None] | None = raw.pop(
-            "summary_fn", None
-        )  # type: ignore[assignment]
-        raw.setdefault("start_to_close_timeout", timedelta(seconds=60))
-        if raw.get("summary") is not None and self._summary_fn is not None:
-            raise ValueError("Cannot specify both 'summary' and 'summary_fn'")
-        self._activity_config = ActivityConfig(**raw)  # type: ignore[typeddict-item]
+        self._summary_fn = summary_fn
+        self._activity_config = ActivityConfig(
+            start_to_close_timeout=timedelta(seconds=60)
+        )
+        if activity_config is not None:
+            if summary_fn is not None and activity_config.get("summary") is not None:
+                raise ValueError("Cannot specify both 'summary' and 'summary_fn'")
+            self._activity_config.update(activity_config)
 
     async def generate_content_async(
         self, llm_request: LlmRequest, stream: bool = False

--- a/temporalio/contrib/google_adk_agents/_model.py
+++ b/temporalio/contrib/google_adk_agents/_model.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from datetime import timedelta
 
 from google.adk.models import BaseLlm, LLMRegistry
@@ -8,6 +8,12 @@ from google.adk.models.llm_response import LlmResponse
 import temporalio.workflow
 from temporalio import activity, workflow
 from temporalio.workflow import ActivityConfig
+
+
+class AdkActivityConfig(ActivityConfig, total=False):
+    """Activity config with ADK-specific options."""
+
+    summary_fn: Callable[[LlmRequest], str | None] | None
 
 
 @activity.defn
@@ -40,21 +46,29 @@ class TemporalModel(BaseLlm):
     """A Temporal-based LLM model that executes model invocations as activities."""
 
     def __init__(
-        self, model_name: str, activity_config: ActivityConfig | None = None
+        self,
+        model_name: str,
+        activity_config: AdkActivityConfig | ActivityConfig | None = None,
     ) -> None:
         """Initialize the TemporalModel.
 
         Args:
             model_name: The name of the model to use.
             activity_config: Configuration options for the activity execution.
+
+        Raises:
+            ValueError: If both 'summary' and 'summary_fn' are set.
         """
         super().__init__(model=model_name)
         self._model_name = model_name
-        self._activity_config = ActivityConfig(
-            start_to_close_timeout=timedelta(seconds=60)
-        )
-        if activity_config:
-            self._activity_config.update(activity_config)
+        raw = dict(activity_config) if activity_config else {}
+        self._summary_fn: Callable[[LlmRequest], str | None] | None = raw.pop(
+            "summary_fn", None
+        )  # type: ignore[assignment]
+        raw.setdefault("start_to_close_timeout", timedelta(seconds=60))
+        if raw.get("summary") is not None and self._summary_fn is not None:
+            raise ValueError("Cannot specify both 'summary' and 'summary_fn'")
+        self._activity_config = ActivityConfig(**raw)  # type: ignore[typeddict-item]
 
     async def generate_content_async(
         self, llm_request: LlmRequest, stream: bool = False
@@ -76,10 +90,20 @@ class TemporalModel(BaseLlm):
                 yield response
             return
 
+        config = self._activity_config.copy()
+        if self._summary_fn is not None:
+            summary = self._summary_fn(llm_request)
+            if summary is not None:
+                config["summary"] = summary
+        elif "summary" not in config:
+            if llm_request.config and llm_request.config.labels:
+                agent_name = llm_request.config.labels.get("adk_agent_name")
+                if agent_name:
+                    config["summary"] = agent_name
         responses = await workflow.execute_activity(
             invoke_model,
             args=[llm_request],
-            **self._activity_config,
+            **config,
         )
         for response in responses:
             yield response

--- a/tests/contrib/google_adk_agents/test_google_adk_agents.py
+++ b/tests/contrib/google_adk_agents/test_google_adk_agents.py
@@ -597,13 +597,11 @@ class SummaryFnModel(TestModel):
 class SummaryFnWorkflow:
     @workflow.run
     async def run(self, model_name: str) -> str | None:
-        from temporalio.contrib.google_adk_agents import AdkActivityConfig
-
         agent = Agent(
             name="summary_fn_agent",
             model=TemporalModel(
                 model_name,
-                AdkActivityConfig(summary_fn=lambda req: f"Invoking {req.model}"),
+                summary_fn=lambda req: f"Invoking {req.model}",
             ),
         )
         runner = InMemoryRunner(agent=agent, app_name="summary_fn_app")
@@ -627,7 +625,7 @@ class SummaryFnWorkflow:
 
 @pytest.mark.asyncio
 async def test_summary_fn_produces_dynamic_summary(client: Client):
-    """summary_fn in AdkActivityConfig sets summary on invoke_model activity."""
+    """summary_fn on TemporalModel sets summary on invoke_model activity."""
     new_config = client.config()
     new_config["plugins"] = [GoogleAdkPlugin()]
     client = Client(**new_config)
@@ -664,13 +662,11 @@ async def test_summary_fn_produces_dynamic_summary(client: Client):
 class SummaryFnNoneWorkflow:
     @workflow.run
     async def run(self, model_name: str) -> str | None:
-        from temporalio.contrib.google_adk_agents import AdkActivityConfig
-
         agent = Agent(
             name="none_summary_agent",
             model=TemporalModel(
                 model_name,
-                AdkActivityConfig(summary_fn=lambda req: None),
+                summary_fn=lambda req: None,
             ),
         )
         runner = InMemoryRunner(agent=agent, app_name="none_summary_app")
@@ -722,37 +718,138 @@ async def test_summary_fn_returning_none(client: Client):
                     assert not e.user_metadata.summary.data
 
 
-def test_adk_agent_name_label_fallback():
+@workflow.defn
+class SummaryFnEmptyStringWorkflow:
+    @workflow.run
+    async def run(self, model_name: str) -> str | None:
+        agent = Agent(
+            name="empty_summary_agent",
+            model=TemporalModel(
+                model_name,
+                summary_fn=lambda req: "",
+            ),
+        )
+        runner = InMemoryRunner(agent=agent, app_name="empty_summary_app")
+        session = await runner.session_service.create_session(
+            app_name="empty_summary_app", user_id="test"
+        )
+        last_event = None
+        async with Aclosing(
+            runner.run_async(
+                user_id="test",
+                session_id=session.id,
+                new_message=types.Content(role="user", parts=[types.Part(text="hi")]),
+            )
+        ) as agen:
+            async for event in agen:
+                last_event = event
+        if last_event and last_event.content and last_event.content.parts:
+            return last_event.content.parts[0].text
+        return None
+
+
+@pytest.mark.asyncio
+async def test_summary_fn_empty_string(client: Client):
+    """summary_fn returning empty string is a valid summary."""
+    new_config = client.config()
+    new_config["plugins"] = [GoogleAdkPlugin()]
+    client = Client(**new_config)
+    LLMRegistry.register(SummaryFnModel)
+
+    async with Worker(
+        client,
+        task_queue="adk-summary-fn-empty-test",
+        workflows=[SummaryFnEmptyStringWorkflow],
+        max_cached_workflows=0,
+    ):
+        handle = await client.start_workflow(
+            SummaryFnEmptyStringWorkflow.run,
+            "summary_fn_model",
+            id=f"summary-fn-empty-{uuid.uuid4()}",
+            task_queue="adk-summary-fn-empty-test",
+            execution_timeout=timedelta(seconds=60),
+        )
+        await handle.result()
+
+        found = False
+        async for e in handle.fetch_history_events():
+            if e.HasField("activity_task_scheduled_event_attributes"):
+                attrs = e.activity_task_scheduled_event_attributes
+                if attrs.activity_type.name == "invoke_model":
+                    assert e.user_metadata.summary.data == b""
+                    found = True
+        assert found, "No invoke_model activity found in history"
+
+
+@workflow.defn
+class LabelFallbackWorkflow:
+    @workflow.run
+    async def run(self, model_name: str) -> str | None:
+        agent = Agent(
+            name="label_fallback_agent",
+            model=TemporalModel(model_name),
+        )
+        runner = InMemoryRunner(agent=agent, app_name="label_fallback_app")
+        session = await runner.session_service.create_session(
+            app_name="label_fallback_app", user_id="test"
+        )
+        last_event = None
+        async with Aclosing(
+            runner.run_async(
+                user_id="test",
+                session_id=session.id,
+                new_message=types.Content(role="user", parts=[types.Part(text="hi")]),
+            )
+        ) as agen:
+            async for event in agen:
+                last_event = event
+        if last_event and last_event.content and last_event.content.parts:
+            return last_event.content.parts[0].text
+        return None
+
+
+@pytest.mark.asyncio
+async def test_adk_agent_name_label_fallback(client: Client):
     """When no summary or summary_fn, adk_agent_name label is used as summary."""
-    model = TemporalModel("m")
-    request = LlmRequest(
-        model="m",
-        config=types.GenerateContentConfig(labels={"adk_agent_name": "my_agent"}),
-    )
-    # Simulate what generate_content_async does
-    config = model._activity_config.copy()
-    if model._summary_fn is not None:
-        summary = model._summary_fn(request)
-        if summary is not None:
-            config["summary"] = summary
-    elif "summary" not in config:
-        if request.config and request.config.labels:
-            agent_name = request.config.labels.get("adk_agent_name")
-            if agent_name:
-                config["summary"] = agent_name
-    assert config.get("summary") == "my_agent"
+    new_config = client.config()
+    new_config["plugins"] = [GoogleAdkPlugin()]
+    client = Client(**new_config)
+    LLMRegistry.register(SummaryFnModel)
+
+    async with Worker(
+        client,
+        task_queue="adk-label-fallback-test",
+        workflows=[LabelFallbackWorkflow],
+        max_cached_workflows=0,
+    ):
+        handle = await client.start_workflow(
+            LabelFallbackWorkflow.run,
+            "summary_fn_model",
+            id=f"label-fallback-{uuid.uuid4()}",
+            task_queue="adk-label-fallback-test",
+            execution_timeout=timedelta(seconds=60),
+        )
+        await handle.result()
+
+        found = False
+        async for e in handle.fetch_history_events():
+            if e.HasField("activity_task_scheduled_event_attributes"):
+                attrs = e.activity_task_scheduled_event_attributes
+                if attrs.activity_type.name == "invoke_model":
+                    assert e.user_metadata.summary.data == b'"label_fallback_agent"'
+                    found = True
+        assert found, "No invoke_model activity found in history"
 
 
 def test_summary_and_summary_fn_raises():
     """Cannot specify both summary and summary_fn."""
-    from temporalio.contrib.google_adk_agents import AdkActivityConfig
-
     with pytest.raises(
         ValueError, match="Cannot specify both 'summary' and 'summary_fn'"
     ):
         TemporalModel(
             "m",
-            AdkActivityConfig(summary="static", summary_fn=lambda req: "dynamic"),
+            activity_config=ActivityConfig(summary="static"),
+            summary_fn=lambda req: "dynamic",
         )
 
 

--- a/tests/contrib/google_adk_agents/test_google_adk_agents.py
+++ b/tests/contrib/google_adk_agents/test_google_adk_agents.py
@@ -660,6 +660,89 @@ async def test_summary_fn_produces_dynamic_summary(client: Client):
         assert found, "No invoke_model activity found in history"
 
 
+@workflow.defn
+class SummaryFnNoneWorkflow:
+    @workflow.run
+    async def run(self, model_name: str) -> str | None:
+        from temporalio.contrib.google_adk_agents import AdkActivityConfig
+
+        agent = Agent(
+            name="none_summary_agent",
+            model=TemporalModel(
+                model_name,
+                AdkActivityConfig(summary_fn=lambda req: None),
+            ),
+        )
+        runner = InMemoryRunner(agent=agent, app_name="none_summary_app")
+        session = await runner.session_service.create_session(
+            app_name="none_summary_app", user_id="test"
+        )
+        last_event = None
+        async with Aclosing(
+            runner.run_async(
+                user_id="test",
+                session_id=session.id,
+                new_message=types.Content(role="user", parts=[types.Part(text="hi")]),
+            )
+        ) as agen:
+            async for event in agen:
+                last_event = event
+        if last_event and last_event.content and last_event.content.parts:
+            return last_event.content.parts[0].text
+        return None
+
+
+@pytest.mark.asyncio
+async def test_summary_fn_returning_none(client: Client):
+    """summary_fn returning None means no summary on the activity."""
+    new_config = client.config()
+    new_config["plugins"] = [GoogleAdkPlugin()]
+    client = Client(**new_config)
+    LLMRegistry.register(SummaryFnModel)
+
+    async with Worker(
+        client,
+        task_queue="adk-summary-fn-none-test",
+        workflows=[SummaryFnNoneWorkflow],
+        max_cached_workflows=0,
+    ):
+        handle = await client.start_workflow(
+            SummaryFnNoneWorkflow.run,
+            "summary_fn_model",
+            id=f"summary-fn-none-{uuid.uuid4()}",
+            task_queue="adk-summary-fn-none-test",
+            execution_timeout=timedelta(seconds=60),
+        )
+        await handle.result()
+
+        async for e in handle.fetch_history_events():
+            if e.HasField("activity_task_scheduled_event_attributes"):
+                attrs = e.activity_task_scheduled_event_attributes
+                if attrs.activity_type.name == "invoke_model":
+                    assert not e.user_metadata.summary.data
+
+
+def test_adk_agent_name_label_fallback():
+    """When no summary or summary_fn, adk_agent_name label is used as summary."""
+    model = TemporalModel("m")
+    request = LlmRequest(
+        model="m",
+        config=types.GenerateContentConfig(labels={"adk_agent_name": "my_agent"}),
+    )
+    # Simulate what generate_content_async does
+    config = model._activity_config.copy()
+    if model._summary_fn is not None:
+        summary = model._summary_fn(request)
+        if summary is not None:
+            config["summary"] = summary
+    elif "summary" not in config:
+        if request.config and request.config.labels:
+            agent_name = request.config.labels.get("adk_agent_name")
+            if agent_name:
+                config["summary"] = agent_name
+    assert config.get("summary") == "my_agent"
+
+
 def test_summary_and_summary_fn_raises():
     """Cannot specify both summary and summary_fn."""
     from temporalio.contrib.google_adk_agents import AdkActivityConfig

--- a/tests/contrib/google_adk_agents/test_google_adk_agents.py
+++ b/tests/contrib/google_adk_agents/test_google_adk_agents.py
@@ -844,7 +844,8 @@ async def test_adk_agent_name_label_fallback(client: Client):
 def test_summary_and_summary_fn_raises():
     """Cannot specify both summary and summary_fn."""
     with pytest.raises(
-        ValueError, match="Cannot specify both 'summary' and 'summary_fn'"
+        ValueError,
+        match="Cannot specify both ActivityConfig 'summary' and 'summary_fn'",
     ):
         TemporalModel(
             "m",

--- a/tests/contrib/google_adk_agents/test_google_adk_agents.py
+++ b/tests/contrib/google_adk_agents/test_google_adk_agents.py
@@ -580,6 +580,99 @@ async def test_unsetting_timeout():
     assert model._activity_config.get("start_to_close_timeout", None) is None
 
 
+class SummaryFnModel(TestModel):
+    """Returns a single text response for summary_fn testing."""
+
+    def responses(self) -> list[LlmResponse]:
+        return [
+            LlmResponse(content=Content(role="model", parts=[Part(text="response")])),
+        ]
+
+    @classmethod
+    def supported_models(cls) -> list[str]:
+        return ["summary_fn_model"]
+
+
+@workflow.defn
+class SummaryFnWorkflow:
+    @workflow.run
+    async def run(self, model_name: str) -> str | None:
+        from temporalio.contrib.google_adk_agents import AdkActivityConfig
+
+        agent = Agent(
+            name="summary_fn_agent",
+            model=TemporalModel(
+                model_name,
+                AdkActivityConfig(summary_fn=lambda req: f"Invoking {req.model}"),
+            ),
+        )
+        runner = InMemoryRunner(agent=agent, app_name="summary_fn_app")
+        session = await runner.session_service.create_session(
+            app_name="summary_fn_app", user_id="test"
+        )
+        last_event = None
+        async with Aclosing(
+            runner.run_async(
+                user_id="test",
+                session_id=session.id,
+                new_message=types.Content(role="user", parts=[types.Part(text="hi")]),
+            )
+        ) as agen:
+            async for event in agen:
+                last_event = event
+        if last_event and last_event.content and last_event.content.parts:
+            return last_event.content.parts[0].text
+        return None
+
+
+@pytest.mark.asyncio
+async def test_summary_fn_produces_dynamic_summary(client: Client):
+    """summary_fn in AdkActivityConfig sets summary on invoke_model activity."""
+    new_config = client.config()
+    new_config["plugins"] = [GoogleAdkPlugin()]
+    client = Client(**new_config)
+    LLMRegistry.register(SummaryFnModel)
+
+    async with Worker(
+        client,
+        task_queue="adk-summary-fn-test",
+        workflows=[SummaryFnWorkflow],
+        max_cached_workflows=0,
+    ):
+        handle = await client.start_workflow(
+            SummaryFnWorkflow.run,
+            "summary_fn_model",
+            id=f"summary-fn-{uuid.uuid4()}",
+            task_queue="adk-summary-fn-test",
+            execution_timeout=timedelta(seconds=60),
+        )
+        await handle.result()
+
+        found = False
+        async for e in handle.fetch_history_events():
+            if e.HasField("activity_task_scheduled_event_attributes"):
+                attrs = e.activity_task_scheduled_event_attributes
+                if attrs.activity_type.name == "invoke_model":
+                    assert (
+                        e.user_metadata.summary.data == b'"Invoking summary_fn_model"'
+                    )
+                    found = True
+        assert found, "No invoke_model activity found in history"
+
+
+def test_summary_and_summary_fn_raises():
+    """Cannot specify both summary and summary_fn."""
+    from temporalio.contrib.google_adk_agents import AdkActivityConfig
+
+    with pytest.raises(
+        ValueError, match="Cannot specify both 'summary' and 'summary_fn'"
+    ):
+        TemporalModel(
+            "m",
+            AdkActivityConfig(summary="static", summary_fn=lambda req: "dynamic"),
+        )
+
+
 @pytest.mark.asyncio
 async def test_agent_outside_workflow():
     """Test that an agent using TemporalModel and activity_tool works outside a Temporal workflow."""

--- a/tests/contrib/google_adk_agents/test_google_adk_agents.py
+++ b/tests/contrib/google_adk_agents/test_google_adk_agents.py
@@ -594,38 +594,40 @@ class SummaryFnModel(TestModel):
 
 
 @workflow.defn
-class SummaryFnWorkflow:
+class SummaryTestWorkflow:
     @workflow.run
-    async def run(self, model_name: str) -> str | None:
-        agent = Agent(
-            name="summary_fn_agent",
-            model=TemporalModel(
-                model_name,
-                summary_fn=lambda req: f"Invoking {req.model}",
-            ),
-        )
-        runner = InMemoryRunner(agent=agent, app_name="summary_fn_app")
-        session = await runner.session_service.create_session(
-            app_name="summary_fn_app", user_id="test"
-        )
-        last_event = None
-        async with Aclosing(
-            runner.run_async(
-                user_id="test",
-                session_id=session.id,
-                new_message=types.Content(role="user", parts=[types.Part(text="hi")]),
+    async def run(self, model_name: str) -> None:
+        modes = [
+            ("dynamic", lambda req: f"Invoking {req.model}"),
+            ("none", lambda req: None),
+            ("empty", lambda req: ""),
+            ("label_fallback", None),
+        ]
+        for mode_name, summary_fn in modes:
+            agent = Agent(
+                name=f"summary_test_{mode_name}",
+                model=TemporalModel(model_name, summary_fn=summary_fn),
             )
-        ) as agen:
-            async for event in agen:
-                last_event = event
-        if last_event and last_event.content and last_event.content.parts:
-            return last_event.content.parts[0].text
-        return None
+            runner = InMemoryRunner(agent=agent, app_name=f"summary_{mode_name}")
+            session = await runner.session_service.create_session(
+                app_name=f"summary_{mode_name}", user_id="test"
+            )
+            async with Aclosing(
+                runner.run_async(
+                    user_id="test",
+                    session_id=session.id,
+                    new_message=types.Content(
+                        role="user", parts=[types.Part(text="hi")]
+                    ),
+                )
+            ) as agen:
+                async for _ in agen:
+                    pass
 
 
 @pytest.mark.asyncio
-async def test_summary_fn_produces_dynamic_summary(client: Client):
-    """summary_fn on TemporalModel sets summary on invoke_model activity."""
+async def test_summary_fn_variants(client: Client):
+    """Test summary_fn with dynamic, None, empty string, and label fallback."""
     new_config = client.config()
     new_config["plugins"] = [GoogleAdkPlugin()]
     client = Client(**new_config)
@@ -633,212 +635,33 @@ async def test_summary_fn_produces_dynamic_summary(client: Client):
 
     async with Worker(
         client,
-        task_queue="adk-summary-fn-test",
-        workflows=[SummaryFnWorkflow],
+        task_queue="adk-summary-test",
+        workflows=[SummaryTestWorkflow],
         max_cached_workflows=0,
     ):
         handle = await client.start_workflow(
-            SummaryFnWorkflow.run,
+            SummaryTestWorkflow.run,
             "summary_fn_model",
-            id=f"summary-fn-{uuid.uuid4()}",
-            task_queue="adk-summary-fn-test",
+            id=f"summary-test-{uuid.uuid4()}",
+            task_queue="adk-summary-test",
             execution_timeout=timedelta(seconds=60),
         )
         await handle.result()
 
-        found = False
+        summaries = []
         async for e in handle.fetch_history_events():
             if e.HasField("activity_task_scheduled_event_attributes"):
                 attrs = e.activity_task_scheduled_event_attributes
                 if attrs.activity_type.name == "invoke_model":
-                    assert (
-                        e.user_metadata.summary.data == b'"Invoking summary_fn_model"'
-                    )
-                    found = True
-        assert found, "No invoke_model activity found in history"
+                    summaries.append(e.user_metadata.summary.data)
 
-
-@workflow.defn
-class SummaryFnNoneWorkflow:
-    @workflow.run
-    async def run(self, model_name: str) -> str | None:
-        agent = Agent(
-            name="none_summary_agent",
-            model=TemporalModel(
-                model_name,
-                summary_fn=lambda req: None,
-            ),
-        )
-        runner = InMemoryRunner(agent=agent, app_name="none_summary_app")
-        session = await runner.session_service.create_session(
-            app_name="none_summary_app", user_id="test"
-        )
-        last_event = None
-        async with Aclosing(
-            runner.run_async(
-                user_id="test",
-                session_id=session.id,
-                new_message=types.Content(role="user", parts=[types.Part(text="hi")]),
-            )
-        ) as agen:
-            async for event in agen:
-                last_event = event
-        if last_event and last_event.content and last_event.content.parts:
-            return last_event.content.parts[0].text
-        return None
-
-
-@pytest.mark.asyncio
-async def test_summary_fn_returning_none(client: Client):
-    """summary_fn returning None means no summary on the activity."""
-    new_config = client.config()
-    new_config["plugins"] = [GoogleAdkPlugin()]
-    client = Client(**new_config)
-    LLMRegistry.register(SummaryFnModel)
-
-    async with Worker(
-        client,
-        task_queue="adk-summary-fn-none-test",
-        workflows=[SummaryFnNoneWorkflow],
-        max_cached_workflows=0,
-    ):
-        handle = await client.start_workflow(
-            SummaryFnNoneWorkflow.run,
-            "summary_fn_model",
-            id=f"summary-fn-none-{uuid.uuid4()}",
-            task_queue="adk-summary-fn-none-test",
-            execution_timeout=timedelta(seconds=60),
-        )
-        await handle.result()
-
-        async for e in handle.fetch_history_events():
-            if e.HasField("activity_task_scheduled_event_attributes"):
-                attrs = e.activity_task_scheduled_event_attributes
-                if attrs.activity_type.name == "invoke_model":
-                    assert not e.user_metadata.summary.data
-
-
-@workflow.defn
-class SummaryFnEmptyStringWorkflow:
-    @workflow.run
-    async def run(self, model_name: str) -> str | None:
-        agent = Agent(
-            name="empty_summary_agent",
-            model=TemporalModel(
-                model_name,
-                summary_fn=lambda req: "",
-            ),
-        )
-        runner = InMemoryRunner(agent=agent, app_name="empty_summary_app")
-        session = await runner.session_service.create_session(
-            app_name="empty_summary_app", user_id="test"
-        )
-        last_event = None
-        async with Aclosing(
-            runner.run_async(
-                user_id="test",
-                session_id=session.id,
-                new_message=types.Content(role="user", parts=[types.Part(text="hi")]),
-            )
-        ) as agen:
-            async for event in agen:
-                last_event = event
-        if last_event and last_event.content and last_event.content.parts:
-            return last_event.content.parts[0].text
-        return None
-
-
-@pytest.mark.asyncio
-async def test_summary_fn_empty_string(client: Client):
-    """summary_fn returning empty string is a valid summary."""
-    new_config = client.config()
-    new_config["plugins"] = [GoogleAdkPlugin()]
-    client = Client(**new_config)
-    LLMRegistry.register(SummaryFnModel)
-
-    async with Worker(
-        client,
-        task_queue="adk-summary-fn-empty-test",
-        workflows=[SummaryFnEmptyStringWorkflow],
-        max_cached_workflows=0,
-    ):
-        handle = await client.start_workflow(
-            SummaryFnEmptyStringWorkflow.run,
-            "summary_fn_model",
-            id=f"summary-fn-empty-{uuid.uuid4()}",
-            task_queue="adk-summary-fn-empty-test",
-            execution_timeout=timedelta(seconds=60),
-        )
-        await handle.result()
-
-        found = False
-        async for e in handle.fetch_history_events():
-            if e.HasField("activity_task_scheduled_event_attributes"):
-                attrs = e.activity_task_scheduled_event_attributes
-                if attrs.activity_type.name == "invoke_model":
-                    assert e.user_metadata.summary.data == b""
-                    found = True
-        assert found, "No invoke_model activity found in history"
-
-
-@workflow.defn
-class LabelFallbackWorkflow:
-    @workflow.run
-    async def run(self, model_name: str) -> str | None:
-        agent = Agent(
-            name="label_fallback_agent",
-            model=TemporalModel(model_name),
-        )
-        runner = InMemoryRunner(agent=agent, app_name="label_fallback_app")
-        session = await runner.session_service.create_session(
-            app_name="label_fallback_app", user_id="test"
-        )
-        last_event = None
-        async with Aclosing(
-            runner.run_async(
-                user_id="test",
-                session_id=session.id,
-                new_message=types.Content(role="user", parts=[types.Part(text="hi")]),
-            )
-        ) as agen:
-            async for event in agen:
-                last_event = event
-        if last_event and last_event.content and last_event.content.parts:
-            return last_event.content.parts[0].text
-        return None
-
-
-@pytest.mark.asyncio
-async def test_adk_agent_name_label_fallback(client: Client):
-    """When no summary or summary_fn, adk_agent_name label is used as summary."""
-    new_config = client.config()
-    new_config["plugins"] = [GoogleAdkPlugin()]
-    client = Client(**new_config)
-    LLMRegistry.register(SummaryFnModel)
-
-    async with Worker(
-        client,
-        task_queue="adk-label-fallback-test",
-        workflows=[LabelFallbackWorkflow],
-        max_cached_workflows=0,
-    ):
-        handle = await client.start_workflow(
-            LabelFallbackWorkflow.run,
-            "summary_fn_model",
-            id=f"label-fallback-{uuid.uuid4()}",
-            task_queue="adk-label-fallback-test",
-            execution_timeout=timedelta(seconds=60),
-        )
-        await handle.result()
-
-        found = False
-        async for e in handle.fetch_history_events():
-            if e.HasField("activity_task_scheduled_event_attributes"):
-                attrs = e.activity_task_scheduled_event_attributes
-                if attrs.activity_type.name == "invoke_model":
-                    assert e.user_metadata.summary.data == b'"label_fallback_agent"'
-                    found = True
-        assert found, "No invoke_model activity found in history"
+        assert len(summaries) == 4
+        assert summaries[0] == b'"Invoking summary_fn_model"'  # dynamic
+        assert summaries[1] == b""  # none
+        assert summaries[2] == b""  # empty
+        assert (
+            summaries[3] == b'"summary_test_label_fallback"'
+        )  # label fallback agent name
 
 
 def test_summary_and_summary_fn_raises():


### PR DESCRIPTION
## Summary

- Add `summary_fn` keyword-only parameter to `TemporalModel` for dynamic per-call activity summaries
- `summary_fn` receives the `LlmRequest` and returns a summary string (or `None`)
- When neither `summary_fn` nor static `summary` is set, falls back to reading `adk_agent_name` from `LlmRequest.config.labels` for zero-config agent name display
- Setting both `summary` (in `ActivityConfig`) and `summary_fn` raises `ValueError`

## Test plan

- [x] `test_summary_fn_produces_dynamic_summary` — integration test verifying dynamic summary in workflow history
- [x] `test_summary_fn_returning_none` — summary_fn returning None produces no summary
- [x] `test_summary_fn_empty_string` — empty string is a valid summary
- [x] `test_adk_agent_name_label_fallback` — integration test verifying zero-config label fallback
- [x] `test_summary_and_summary_fn_raises` — ValueError when both summary and summary_fn set
- [x] Full existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)