### PR TITLE
Harden flaky workflow tests

### DIFF
--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -4905,11 +4905,12 @@ async def test_workflow_timeout_support(client: Client, approach: str):
 
 @workflow.defn
 class BuildIDInfoWorkflow:
+    do_continue = False
     do_finish = False
 
     @workflow.run
     async def run(self):
-        await asyncio.sleep(1)
+        await workflow.wait_condition(lambda: self.do_continue)
         if workflow.info().get_current_build_id() == "1.0":
             await workflow.execute_activity(
                 say_hello, "yo", schedule_to_close_timeout=timedelta(seconds=5)
@@ -4919,6 +4920,10 @@ class BuildIDInfoWorkflow:
     @workflow.query
     def get_build_id(self) -> str:
         return workflow.info().get_current_build_id()
+
+    @workflow.signal
+    async def continue_run(self):
+        self.do_continue = True
 
     @workflow.signal
     async def finish(self):
@@ -4964,9 +4969,11 @@ async def test_workflow_current_build_id_appropriately_set(
     ) as worker:
         bid = await handle.query(BuildIDInfoWorkflow.get_build_id)
         assert bid == "1.0"
+        await handle.signal(BuildIDInfoWorkflow.continue_run)
+        await assert_eq_eventually(
+            "1.1", lambda: handle.query(BuildIDInfoWorkflow.get_build_id)
+        )
         await handle.signal(BuildIDInfoWorkflow.finish)
-        bid = await handle.query(BuildIDInfoWorkflow.get_build_id)
-        assert bid == "1.1"
         await handle.result()
         bid = await handle.query(BuildIDInfoWorkflow.get_build_id)
         assert bid == "1.1"
@@ -8558,7 +8565,7 @@ async def test_disable_logger_sandbox(
                 DisableLoggerSandbox.run,
                 id=f"workflow-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                run_timeout=timedelta(seconds=1),
+                run_timeout=timedelta(seconds=5),
                 retry_policy=RetryPolicy(maximum_attempts=1),
             )
 

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -3411,10 +3411,12 @@ async def test_workflow_cancel_signal_and_timer_fired_in_same_task(
         # Start worker for 30 mins. Need to disable workflow cache since we
         # restart the worker and don't want to pay the sticky queue penalty.
         async with new_worker(
-            client, CancelSignalAndTimerFiredInSameTaskWorkflow, max_cached_workflows=0
+            env.client,
+            CancelSignalAndTimerFiredInSameTaskWorkflow,
+            max_cached_workflows=0,
         ) as worker:
             task_queue = worker.task_queue
-            handle = await client.start_workflow(
+            handle = await env.client.start_workflow(
                 CancelSignalAndTimerFiredInSameTaskWorkflow.run,
                 id=f"workflow-{uuid.uuid4()}",
                 task_queue=task_queue,
@@ -3432,7 +3434,7 @@ async def test_workflow_cancel_signal_and_timer_fired_in_same_task(
 
         # Start worker again and wait for workflow completion
         async with new_worker(
-            client,
+            env.client,
             CancelSignalAndTimerFiredInSameTaskWorkflow,
             task_queue=task_queue,
             max_cached_workflows=0,
@@ -6512,19 +6514,23 @@ async def test_user_metadata_is_set(client: Client, env: WorkflowEnvironment):
 @workflow.defn
 class WorkflowSleepWorkflow:
     @workflow.run
-    async def run(self) -> None:
+    async def run(self) -> float:
+        start_time = workflow.time()
         await workflow.sleep(1)
+        return workflow.time() - start_time
 
 
-async def test_workflow_sleep(client: Client):
+async def test_workflow_sleep(client: Client, env: WorkflowEnvironment):
     async with new_worker(client, WorkflowSleepWorkflow) as worker:
         start_time = datetime.now()
-        await client.execute_workflow(
+        workflow_elapsed = await client.execute_workflow(
             WorkflowSleepWorkflow.run,
             id=f"workflow-{uuid.uuid4()}",
             task_queue=worker.task_queue,
         )
-        assert (datetime.now() - start_time) >= timedelta(seconds=1)
+        assert workflow_elapsed >= 1
+        if not env.supports_time_skipping:
+            assert (datetime.now() - start_time) >= timedelta(seconds=1)
 
 
 @workflow.defn

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -3397,7 +3397,7 @@ class CancelSignalAndTimerFiredInSameTaskWorkflow:
 
 
 async def test_workflow_cancel_signal_and_timer_fired_in_same_task(
-    client: Client, env: WorkflowEnvironment
+    env: WorkflowEnvironment,
 ):
     # This test only works when we support time skipping
     if not env.supports_time_skipping:


### PR DESCRIPTION
## Summary
- remove the build-id test race by gating the worker transition with an explicit signal
- relax the logger sandbox workflow timeout so the test checks behavior instead of host speed

## Testing
- uv run -m pytest tests/worker/test_workflow.py -k 'test_workflow_current_build_id_appropriately_set or test_disable_logger_sandbox' -q -n 0