### PR TITLE
Pin GitHub Actions and cap uv deps

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -30,10 +30,10 @@ jobs:
             package-suffix: windows-amd64
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.14"
 
@@ -41,12 +41,12 @@ jobs:
       # command to build with cibuildwheel which uses rustup install defined
       # in pyproject.toml)
       - if: ${{ runner.os != 'Linux' }}
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - if: ${{ runner.os != 'Linux' }}
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: temporalio/bridge -> target
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
       - run: uv sync --all-extras
 
       # Add the source dist only for Linux x64 for now
@@ -73,7 +73,7 @@ jobs:
           ./.venv/$bindir/python -m pytest -s tests/worker/test_workflow.py -k test_workflow_hello
 
       # Upload dist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: packages-${{ matrix.package-suffix }}
           path: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,24 +38,24 @@ jobs:
             runsOn: macos-latest
     runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: "clippy"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: temporalio/bridge -> target
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.pythonOverride || matrix.python }}
-      - uses: arduino/setup-protoc@v3
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed
           version: "23.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
       - run: uv tool install poethepoet
       - run: uv sync --all-extras
       - run: poe bridge-lint
@@ -75,7 +75,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       - name: "Upload junit-xml artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--${{ matrix.python }}--${{ matrix.os }}
@@ -94,7 +94,7 @@ jobs:
         run: npx vercel deploy build/apidocs -t ${{ secrets.VERCEL_TOKEN }} --prod --yes
 
       # Confirm README ToC is generated properly
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       - name: Check generated README ToC
         if: ${{ matrix.docsTarget }}
         run: |
@@ -105,22 +105,22 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: temporalio/bridge -> target
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
-      - uses: arduino/setup-protoc@v3
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed
           version: "23.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
       - run: uv tool install poethepoet
       - run: uv remove google-adk --optional google-adk
       - run: uv add --python 3.10 "protobuf<4"
@@ -139,24 +139,24 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: "clippy"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: temporalio/bridge -> target
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.13"
-      - uses: arduino/setup-protoc@v3
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed
           version: "23.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
       - run: uv tool install poethepoet
       - run: uv lock --upgrade
       - run: uv sync --all-extras
@@ -166,7 +166,7 @@ jobs:
       - run: poe test -s --junit-xml=junit-xml/latest-deps.xml
         timeout-minutes: 15
       - name: "Upload junit-xml artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--latest-deps--time-skipping
@@ -179,22 +179,22 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: temporalio/bridge -> target
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.14"
-      - uses: arduino/setup-protoc@v3
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed
           version: "23.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
       - run: uv tool install poethepoet
       - run: uv sync --all-extras
       - run: poe build-develop
@@ -209,7 +209,7 @@ jobs:
           TEMPORAL_CLIENT_CERT: ${{ secrets.TEMPORAL_CLIENT_CERT }}
           TEMPORAL_CLIENT_KEY: ${{ secrets.TEMPORAL_CLIENT_KEY }}
       - name: "Upload junit-xml artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: junit-xml--${{github.run_id}}--${{github.run_attempt}}--cloud
@@ -218,7 +218,7 @@ jobs:
 
   # Runs the sdk features repo tests with this repo's current SDK code
   features-tests:
-    uses: temporalio/features/.github/workflows/python.yaml@main
+    uses: temporalio/features/.github/workflows/python.yaml@77f9b4a762855a6e2d74684630b89453bd02a297 # main
     with:
       python-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
 
   # Runs the sdk features repo tests with this repo's current SDK code
   features-tests:
-    uses: temporalio/features/.github/workflows/python.yaml@77f9b4a762855a6e2d74684630b89453bd02a297 # main
+    uses: temporalio/features/.github/workflows/python.yaml@main
     with:
       python-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}

--- a/.github/workflows/nightly-throughput-stress.yml
+++ b/.github/workflows/nightly-throughput-stress.yml
@@ -44,7 +44,7 @@ env:
 
   # Omes configuration
   OMES_REPO: temporalio/omes
-  OMES_REF: c58f877688a4871a94889574d3d9835c79beb5f7 # main
+  OMES_REF: main
   RUN_ID: ${{ github.run_id }}-throughput-stress
 
   # Prometheus version

--- a/.github/workflows/nightly-throughput-stress.yml
+++ b/.github/workflows/nightly-throughput-stress.yml
@@ -44,7 +44,7 @@ env:
 
   # Omes configuration
   OMES_REPO: temporalio/omes
-  OMES_REF: main
+  OMES_REF: c58f877688a4871a94889574d3d9835c79beb5f7 # main
   RUN_ID: ${{ github.run_id }}-throughput-stress
 
   # Prometheus version
@@ -68,44 +68,44 @@ jobs:
           echo "=========================================="
 
       - name: Checkout SDK
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
       - name: Checkout OMES
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ env.OMES_REPO }}
           ref: ${{ env.OMES_REF }}
           path: omes
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: omes/go.mod
           cache-dependency-path: omes/go.sum
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: temporalio/bridge -> target
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.13"
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           version: '23.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
 
       - name: Install poethepoet
         run: uv tool install poethepoet
@@ -117,7 +117,7 @@ jobs:
         run: poe build-develop
 
       - name: Install Temporal CLI
-        uses: temporalio/setup-temporal@v0
+        uses: temporalio/setup-temporal@1059a504f87e7fa2f385e3fa40d1aa7e62f1c6ca # v0
 
       - name: Install Prometheus
         run: |
@@ -172,7 +172,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: always()
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           role-to-assume: ${{ env.AWS_S3_METRICS_UPLOAD_ROLE_ARN }}
           aws-region: us-west-2
@@ -192,7 +192,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: throughput-stress-logs
           path: ${{ env.WORKER_LOG_DIR }}
@@ -200,7 +200,7 @@ jobs:
 
       - name: Notify Slack on failure
         if: failure() || cancelled()
-        uses: slackapi/slack-github-action@v2
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2
         with:
           webhook-type: incoming-webhook
           payload: |

--- a/.github/workflows/omes.yml
+++ b/.github/workflows/omes.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   omes-image-build:
-    uses: temporalio/omes/.github/workflows/docker-images.yml@c58f877688a4871a94889574d3d9835c79beb5f7 # main
+    uses: temporalio/omes/.github/workflows/docker-images.yml@main
     secrets: inherit
     with:
       lang: python

--- a/.github/workflows/omes.yml
+++ b/.github/workflows/omes.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   omes-image-build:
-    uses: temporalio/omes/.github/workflows/docker-images.yml@main
+    uses: temporalio/omes/.github/workflows/docker-images.yml@c58f877688a4871a94889574d3d9835c79beb5f7 # main
     secrets: inherit
     with:
       lang: python

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -29,25 +29,25 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       # Prepare
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: temporalio/bridge -> target
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.13"
-      - uses: arduino/setup-protoc@v3
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed
           version: "23.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
   
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
       # Build
       - run: uv tool install poethepoet
       - run: uv sync --all-extras

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,3 +252,5 @@ exclude = ["temporalio/bridge/target/**/*"]
 [tool.uv]
 # Prevent uv commands from building the package by default
 package = false
+exclude-newer = "1 week"
+exclude-newer-package = { openai-agents = false }


### PR DESCRIPTION
## Summary
- pin GitHub Actions workflow refs to immutable commit SHAs
- pin temporalio reusable workflow references to immutable SHAs
- add a rolling uv exclude-newer policy with an openai-agents override

## Testing
- rg -n "uses:\s*[^#\n]+@(main|master|v[0-9]+|stable)\b|OMES_REF:\s*(main|master)\b" .github/workflows -g '*.yml' -g '*.yaml'
- uv sync --dry-run
