### PR TITLE
Fix flaky LangSmith test deadlock on Windows CI

### DIFF
--- a/tests/contrib/langsmith/test_integration.py
+++ b/tests/contrib/langsmith/test_integration.py
@@ -1222,14 +1222,15 @@ class QueryFilteringWorkflow:
 
 
 class TestBuiltinQueryFiltering:
-    """Verifies __temporal_ prefixed queries are not traced."""
+    """Verifies built-in queries (both __temporal-prefixed and SDK internal) are not traced."""
 
     async def test_temporal_prefixed_query_not_traced(
         self,
         client: Client,
     ) -> None:
-        """__temporal_workflow_metadata query should not produce a trace,
-        but user-defined queries should still be traced.
+        """Queries starting with __temporal (e.g., __temporal_workflow_metadata)
+        and SDK-internal queries (__stack_trace, __enhanced_stack_trace) should
+        not produce traces, but user-defined queries should still be traced.
 
         Uses add_temporal_runs=False on the query client to suppress
         client-side QueryWorkflow traces, isolating the test to
@@ -1249,7 +1250,6 @@ class TestBuiltinQueryFiltering:
             worker_client,
             QueryFilteringWorkflow,
             task_queue=task_queue,
-            max_cached_workflows=0,
         ) as worker:
             handle = await query_client.start_workflow(
                 QueryFilteringWorkflow.run,


### PR DESCRIPTION
## Summary

Fixes a flaky deadlock in `test_temporal_prefixed_query_not_traced` that fails intermittently on Windows/Python 3.10 CI.

**Root cause:** With `max_cached_workflows=0`, every query triggers full sandbox destruction + re-creation + history replay. While sandbox creation itself runs before the 2-second deadlock detection window, the cumulative overhead from 8+ rapid cycles (module re-imports, GC pressure, thread scheduling) can prevent the replay thread from completing within the deadline on resource-constrained Windows/Python 3.10 CI runners.

**Fix:** This test validates query filtering logic (`_interceptor.py:820-824`), not replay behavior — replay safety is already covered by `test_no_duplicate_traces_on_replay`. Removing `max_cached_workflows=0` means queries are handled on the cached workflow without replay, eliminating the conditions that trigger the flaky deadlock. Also improved class and method docstrings to accurately describe both filtering mechanisms (prefix matching via `startswith("__temporal")` and `_BUILTIN_QUERIES` set membership).

## Test plan

- [x] All 82 LangSmith integration tests pass locally
- [x] All 7 linters pass (ruff, pyright, mypy, basedpyright, pydocstyle)
- [ ] CI passes on Windows/Python 3.10 (the previously failing matrix entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)