### PR TITLE
Implement `is_running()` for asyncio loop

### DIFF
--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -2882,6 +2882,9 @@ class _WorkflowInstanceImpl(  # type: ignore[reportImplicitAbstractClass]
     def get_debug(self) -> bool:
         return False
 
+    def is_running(self) -> bool:
+        return True
+
 
 class _WorkflowInboundImpl(WorkflowInboundInterceptor):
     def __init__(  # type: ignore

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -7207,6 +7207,22 @@ async def test_in_workflow_util(client: Client):
         )
 
 
+@workflow.defn
+class LoopIsRunningWorkflow:
+    @workflow.run
+    async def run(self) -> bool:
+        return asyncio.get_running_loop().is_running()
+
+
+async def test_workflow_loop_is_running(client: Client):
+    async with new_worker(client, LoopIsRunningWorkflow) as worker:
+        assert await client.execute_workflow(
+            LoopIsRunningWorkflow.run,
+            id=f"workflow-{uuid.uuid4()}",
+            task_queue=worker.task_queue,
+        )
+
+
 deadlock_interruptible_completed = 0
 
 


### PR DESCRIPTION
- Implements is_running() on the Workflow asyncio loop, returning True, so asyncio.get_running_loop().is_running() works inside Workflows instead of raising NotImplementedError.
- This is needed for the LangGraph plugin, because the `langgraph` package raises this error when run in a Temporal Workflow.
                  
Test plan                                                           

 - New test_workflow_loop_is_running asserts the loop reports running from inside a Workflow
 - Existing Workflow test suite passes
 - LangGraph plugin test suite passes