### PR TITLE
Fix flaky OpenAI test timeouts

### DIFF
--- a/tests/contrib/openai_agents/test_openai.py
+++ b/tests/contrib/openai_agents/test_openai.py
@@ -141,7 +141,7 @@ async def test_hello_world_agent(client: Client, use_local_model: bool):
                 "Tell me about recursion in programming.",
                 id=f"hello-workflow-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=5),
+                execution_timeout=timedelta(seconds=60),
             )
             if use_local_model:
                 assert result == "test"
@@ -1243,7 +1243,7 @@ async def test_input_guardrail(client: Client, use_local_model: bool):
                 ],
                 id=f"input-guardrail-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
+                execution_timeout=timedelta(seconds=60),
             )
             result = await workflow_handle.result()
 


### PR DESCRIPTION
Noticed while working on #1448.  Encountered repeated failures on 3.14/ubuntu-latest with the tests in question here and then no failures of these tests after these changes.

## Summary
- `test_hello_world_agent[False]` had a 5s `execution_timeout` and `test_input_guardrail[False]` had 10s, but both use a 30s activity `start_to_close_timeout`
- The workflow times out before the OpenAI API call can complete on slower CI runners (consistently failing on `ubuntu-latest`)
- Bumped both to 60s to give the real OpenAI API calls enough headroom

## Test plan
- [x] Verify `build-lint-test (3.14, ubuntu-latest)` OpenAI test step passes