### PR TITLE
More TMPRL1104 logging details

### DIFF
--- a/temporalio/converter/_extstore.py
+++ b/temporalio/converter/_extstore.py
@@ -38,11 +38,17 @@ class StorageOperationMetrics:
     total_duration: timedelta = dataclasses.field(default_factory=timedelta)
     """Wall-clock time spent on external storage operations."""
 
-    def record_batch(self, count: int, size: int, duration: timedelta) -> None:
+    driver_names: set[str] = dataclasses.field(default_factory=set)
+    """Names of the drivers that participated in the operations."""
+
+    def record_batch(
+        self, count: int, size: int, duration: timedelta, driver_names: set[str]
+    ) -> None:
         """Record metrics from a batch of storage operations."""
         self.payload_count += count
         self.total_size += size
         self.total_duration += duration
+        self.driver_names.update(driver_names)
 
     @contextlib.contextmanager
     def track(self) -> Generator[Self, None, None]:
@@ -362,7 +368,7 @@ class ExternalStorage:
             )
         reference_payload.external_payloads.add().size_bytes = external_size
 
-        ExternalStorage._record_metrics(1, external_size, start_time)
+        ExternalStorage._record_metrics(1, external_size, start_time, {driver.name()})
 
         return reference_payload
 
@@ -407,6 +413,7 @@ class ExternalStorage:
 
         external_count = 0
         external_size = 0
+        driver_names: set[str] = set()
         for (driver, indexed_payloads), claims in zip(driver_group_list, all_claims):
             indices = [idx for idx, _ in indexed_payloads]
             sizes = [p.ByteSize() for _, p in indexed_payloads]
@@ -428,8 +435,11 @@ class ExternalStorage:
                 external_size += sizes[i]
 
             external_count += len(claims)
+            driver_names.add(driver.name())
 
-        ExternalStorage._record_metrics(external_count, external_size, start_time)
+        ExternalStorage._record_metrics(
+            external_count, external_size, start_time, driver_names
+        )
 
         return results
 
@@ -452,7 +462,9 @@ class ExternalStorage:
 
         stored_payload = stored_payloads[0]
 
-        ExternalStorage._record_metrics(1, stored_payload.ByteSize(), start_time)
+        ExternalStorage._record_metrics(
+            1, stored_payload.ByteSize(), start_time, {driver.name()}
+        )
 
         return stored_payload
 
@@ -501,6 +513,7 @@ class ExternalStorage:
 
         external_count = 0
         external_size = 0
+        driver_names: set[str] = set()
         for (driver, indexed_claims), stored_payloads in zip(
             driver_claim_list, all_stored
         ):
@@ -517,6 +530,7 @@ class ExternalStorage:
                 external_size += stored_payload.ByteSize()
 
             external_count += len(stored_payloads)
+            driver_names.add(driver.name())
 
         retrieve_indices = sorted(stored_by_index.keys())
         stored_list = [stored_by_index[idx] for idx in retrieve_indices]
@@ -524,7 +538,9 @@ class ExternalStorage:
         for i, retrieved_payload in enumerate(stored_list):
             results[retrieve_indices[i]] = retrieved_payload
 
-        ExternalStorage._record_metrics(external_count, external_size, start_time)
+        ExternalStorage._record_metrics(
+            external_count, external_size, start_time, driver_names
+        )
 
         return results
 
@@ -545,9 +561,14 @@ class ExternalStorage:
             )
 
     @staticmethod
-    def _record_metrics(count: int, size: int, start_time: float):
+    def _record_metrics(
+        count: int, size: int, start_time: float, driver_names: set[str]
+    ):
         metrics = _current_storage_metrics.get()
         if metrics is not None:
             metrics.record_batch(
-                count, size, timedelta(seconds=time.monotonic() - start_time)
+                count,
+                size,
+                timedelta(seconds=time.monotonic() - start_time),
+                driver_names,
             )

--- a/temporalio/worker/_workflow.py
+++ b/temporalio/worker/_workflow.py
@@ -485,10 +485,10 @@ class _WorkflowWorker:  # type:ignore[reportUnusedClass]
         )
         msg_details["event_id"] = completed_event_id
         msg_details["workflow_task_duration"] = _fmt_duration(task_duration)
-        msg_details["history_size"] = act.history_size_bytes
+        msg_details["workflow_history_size"] = act.history_size_bytes
         extra["event_id"] = completed_event_id
         extra["workflow_task_duration"] = task_duration
-        extra["history_size"] = act.history_size_bytes
+        extra["workflow_history_size"] = act.history_size_bytes
         if download_metrics.payload_count > 0:
             msg_details["payload_download_count"] = download_metrics.payload_count
             msg_details["payload_download_size"] = download_metrics.total_size

--- a/temporalio/worker/_workflow.py
+++ b/temporalio/worker/_workflow.py
@@ -477,7 +477,7 @@ class _WorkflowWorker:  # type:ignore[reportUnusedClass]
         completed_event_id = act.history_length + 1
         _running = self._running_workflows.get(act.run_id)
         _info = _running.get_info() if _running is not None else None
-        attempt = _info.attempt if _info is not None else "?"
+        attempt = _info.attempt if _info is not None else "unknown"
         log_id = f"{act.run_id}:{completed_event_id}:{attempt}"
         msg_details, extra = temporalio.workflow._build_log_context(
             _info._logger_details() if _info is not None else None,

--- a/temporalio/worker/_workflow.py
+++ b/temporalio/worker/_workflow.py
@@ -302,7 +302,7 @@ class _WorkflowWorker:  # type:ignore[reportUnusedClass]
                         id=workflow_id,
                         run_id=act.run_id,
                         type=(
-                            workflow.workflow_type
+                            workflow.get_info().workflow_type
                             if workflow
                             else (init_job.workflow_type if init_job else None)
                         ),
@@ -326,9 +326,7 @@ class _WorkflowWorker:  # type:ignore[reportUnusedClass]
             if not workflow:
                 assert init_job
                 workflow = _RunningWorkflow(
-                    self._create_workflow_instance(act, init_job),
-                    workflow_id,
-                    workflow_type=init_job.workflow_type,
+                    self._create_workflow_instance(act, init_job), workflow_id
                 )
                 self._running_workflows[act.run_id] = workflow
 
@@ -461,8 +459,8 @@ class _WorkflowWorker:  # type:ignore[reportUnusedClass]
             act, task_start_time, download_metrics, upload_metrics
         )
 
-    @staticmethod
     def _log_workflow_task_duration(
+        self,
         act: temporalio.bridge.proto.workflow_activation.WorkflowActivation,
         task_start_time: float,
         download_metrics: temporalio.converter._extstore.StorageOperationMetrics,
@@ -476,47 +474,60 @@ class _WorkflowWorker:  # type:ignore[reportUnusedClass]
                 return f"{secs:.3f}s"
             return f"{secs * 1000:.3f}ms"
 
-        msg_details: dict[str, object] = {
-            "event_id": act.history_length,
-            "workflow_task_duration": _fmt_duration(task_duration),
-        }
-        extra: dict[str, object] = {
-            "event_id": act.history_length,
-            "workflow_task_duration": task_duration,
-        }
+        completed_event_id = act.history_length + 1
+        _running = self._running_workflows.get(act.run_id)
+        _info = _running.get_info() if _running is not None else None
+        attempt = _info.attempt if _info is not None else "?"
+        log_id = f"{act.run_id}:{completed_event_id}:{attempt}"
+        msg_details, extra = temporalio.workflow._build_log_context(
+            _info._logger_details() if _info is not None else None,
+            full_workflow_info=_info,
+        )
+        msg_details["event_id"] = completed_event_id
+        msg_details["workflow_task_duration"] = _fmt_duration(task_duration)
+        msg_details["history_size"] = act.history_size_bytes
+        extra["event_id"] = completed_event_id
+        extra["workflow_task_duration"] = task_duration
+        extra["history_size"] = act.history_size_bytes
         if download_metrics.payload_count > 0:
             msg_details["payload_download_count"] = download_metrics.payload_count
             msg_details["payload_download_size"] = download_metrics.total_size
             msg_details["payload_download_duration"] = _fmt_duration(
                 download_metrics.total_duration
             )
+            msg_details["payload_download_drivers"] = sorted(
+                download_metrics.driver_names
+            )
             extra["payload_download_count"] = download_metrics.payload_count
             extra["payload_download_size"] = download_metrics.total_size
             extra["payload_download_duration"] = download_metrics.total_duration
+            extra["payload_download_drivers"] = sorted(download_metrics.driver_names)
         if upload_metrics.payload_count > 0:
             msg_details["payload_upload_count"] = upload_metrics.payload_count
             msg_details["payload_upload_size"] = upload_metrics.total_size
             msg_details["payload_upload_duration"] = _fmt_duration(
                 upload_metrics.total_duration
             )
+            msg_details["payload_upload_drivers"] = sorted(upload_metrics.driver_names)
             extra["payload_upload_count"] = upload_metrics.payload_count
             extra["payload_upload_size"] = upload_metrics.total_size
             extra["payload_upload_duration"] = upload_metrics.total_duration
+            extra["payload_upload_drivers"] = sorted(upload_metrics.driver_names)
         if task_duration.total_seconds() > 10:
             logger.warning(
-                "[TMPRL1104] Workflow task exceeded 10 seconds (%s)",
+                f"[TMPRL1104] {log_id} Workflow task exceeded 10 seconds (%s)",
                 msg_details,
                 extra=extra,
             )
         elif task_duration.total_seconds() > 5:
             logger.info(
-                "[TMPRL1104] Workflow task exceeded 5 seconds (%s)",
+                f"[TMPRL1104] {log_id} Workflow task exceeded 5 seconds (%s)",
                 msg_details,
                 extra=extra,
             )
         else:
             logger.debug(
-                "[TMPRL1104] Workflow task duration information (%s)",
+                f"[TMPRL1104] {log_id} Workflow task duration information (%s)",
                 msg_details,
                 extra=extra,
             )
@@ -822,14 +833,15 @@ class _RunningWorkflow:
         self,
         instance: WorkflowInstance,
         workflow_id: str,
-        workflow_type: str | None = None,
     ):
         self.instance = instance
         self.workflow_id = workflow_id
-        self.workflow_type = workflow_type
         self.deadlocked_activation_task: Awaitable | None = None
         self._deadlock_can_be_interrupted_lock = threading.Lock()
         self._deadlock_can_be_interrupted = False
+
+    def get_info(self) -> temporalio.workflow.Info:
+        return self.instance.get_info()
 
     def activate(
         self, act: temporalio.bridge.proto.workflow_activation.WorkflowActivation

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -198,6 +198,11 @@ class WorkflowInstance(ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def get_info(self) -> temporalio.workflow.Info:
+        """Return the workflow info for this instance."""
+        raise NotImplementedError
+
     def get_thread_id(self) -> int | None:
         """Return the thread identifier that this workflow is running on.
 
@@ -1201,6 +1206,9 @@ class _WorkflowInstanceImpl(  # type: ignore[reportImplicitAbstractClass]
             build_id=self._deployment_version_for_current_task.build_id,
             deployment_name=self._deployment_version_for_current_task.deployment_name,
         )
+
+    def get_info(self) -> temporalio.workflow.Info:
+        return self._info
 
     def workflow_get_current_history_length(self) -> int:
         return self._current_history_length

--- a/temporalio/worker/workflow_sandbox/_runner.py
+++ b/temporalio/worker/workflow_sandbox/_runner.py
@@ -187,6 +187,9 @@ class _Instance(WorkflowInstance):
             for k, v in extra_globals.items():
                 self.globals_and_locals.pop(k, None)
 
+    def get_info(self) -> temporalio.workflow.Info:
+        return self.instance_details.info
+
     def get_thread_id(self) -> int | None:
         return self._current_thread_id
 

--- a/temporalio/workflow.py
+++ b/temporalio/workflow.py
@@ -1635,6 +1635,41 @@ class unsafe:
             _sandbox_import_notification_policy_override.value = original_policy
 
 
+def _build_log_context(
+    workflow_details: Mapping[str, Any] | None,
+    update_details: Mapping[str, Any] | None = None,
+    *,
+    workflow_info_on_message: bool = True,
+    workflow_info_on_extra: bool = True,
+    full_workflow_info: Info | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build the msg_extra suffix and extra dict entries for a temporal log record.
+
+    Returns:
+        (msg_extra, extra) where msg_extra should be appended to the log message
+        and extra should be merged into the log record's extra dict.
+    """
+    msg_extra: dict[str, Any] = {}
+    extra: dict[str, Any] = {}
+
+    if workflow_details is not None:
+        if workflow_info_on_message:
+            msg_extra.update(workflow_details)
+        if workflow_info_on_extra:
+            extra["temporal_workflow"] = dict(workflow_details)
+
+    if update_details is not None:
+        if workflow_info_on_message:
+            msg_extra.update(update_details)
+        if workflow_info_on_extra:
+            extra.setdefault("temporal_workflow", {}).update(update_details)
+
+    if full_workflow_info is not None:
+        extra["workflow_info"] = full_workflow_info
+
+    return msg_extra, extra
+
+
 class LoggerAdapter(logging.LoggerAdapter):
     """Adapter that adds details to the log about the running workflow.
 
@@ -1671,8 +1706,8 @@ class LoggerAdapter(logging.LoggerAdapter):
         self, msg: Any, kwargs: MutableMapping[str, Any]
     ) -> tuple[Any, MutableMapping[str, Any]]:
         """Override to add workflow details."""
-        extra: dict[str, Any] = {}
         msg_extra: dict[str, Any] = {}
+        extra: dict[str, Any] = {}
 
         if (
             self.workflow_info_on_message
@@ -1680,21 +1715,16 @@ class LoggerAdapter(logging.LoggerAdapter):
             or self.full_workflow_info_on_extra
         ):
             runtime = _Runtime.maybe_current()
-            if runtime:
-                workflow_details = runtime.logger_details
-                if self.workflow_info_on_message:
-                    msg_extra.update(workflow_details)
-                if self.workflow_info_on_extra:
-                    extra["temporal_workflow"] = workflow_details
-                if self.full_workflow_info_on_extra:
-                    extra["workflow_info"] = runtime.workflow_info()
             update_info = current_update_info()
-            if update_info:
-                update_details = update_info._logger_details
-                if self.workflow_info_on_message:
-                    msg_extra.update(update_details)
-                if self.workflow_info_on_extra:
-                    extra.setdefault("temporal_workflow", {}).update(update_details)
+            msg_extra, extra = _build_log_context(
+                runtime.logger_details if runtime else None,
+                update_info._logger_details if update_info else None,
+                workflow_info_on_message=self.workflow_info_on_message,
+                workflow_info_on_extra=self.workflow_info_on_extra,
+                full_workflow_info=runtime.workflow_info()
+                if runtime and self.full_workflow_info_on_extra
+                else None,
+            )
 
         kwargs["extra"] = {**extra, **(kwargs.get("extra") or {})}
         if msg_extra:

--- a/tests/worker/test_extstore.py
+++ b/tests/worker/test_extstore.py
@@ -1,5 +1,6 @@
 import dataclasses
 import logging
+import re
 import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -665,8 +666,9 @@ async def test_tmprl1104_no_extstore(env: WorkflowEnvironment) -> None:
     records = _tmprl1104_records(capturer)
     assert len(records) == 1
     record = records[0]
-    assert record.getMessage().startswith(
-        "[TMPRL1104] Workflow task duration information ("
+    assert re.match(
+        r"\[TMPRL1104\] [^:]+:\d+:\d+ Workflow task duration information \(",
+        record.getMessage(),
     )
     assert hasattr(record, "workflow_task_duration")
     assert hasattr(record, "event_id")
@@ -719,10 +721,9 @@ async def test_tmprl1104_with_extstore_download(env: WorkflowEnvironment) -> Non
     assert len(records) == 2
 
     # WFT 1: retrieves the externalized workflow input
-    assert (
-        records[0]
-        .getMessage()
-        .startswith("[TMPRL1104] Workflow task duration information (")
+    assert re.match(
+        r"\[TMPRL1104\] [^:]+:\d+:\d+ Workflow task duration information \(",
+        records[0].getMessage(),
     )
     assert getattr(records[0], "payload_download_count") == 1
     assert getattr(records[0], "payload_download_size") == expected_input_size
@@ -730,10 +731,9 @@ async def test_tmprl1104_with_extstore_download(env: WorkflowEnvironment) -> Non
     assert not hasattr(records[0], "payload_upload_count")
 
     # WFT 2: activity result is small — no external storage
-    assert (
-        records[1]
-        .getMessage()
-        .startswith("[TMPRL1104] Workflow task duration information (")
+    assert re.match(
+        r"\[TMPRL1104\] [^:]+:\d+:\d+ Workflow task duration information \(",
+        records[1].getMessage(),
     )
     assert not hasattr(records[1], "payload_download_count")
     assert not hasattr(records[1], "payload_upload_count")
@@ -779,19 +779,17 @@ async def test_tmprl1104_with_extstore_upload(env: WorkflowEnvironment) -> None:
     assert len(records) == 2
 
     # WFT 1: small input — no external storage
-    assert (
-        records[0]
-        .getMessage()
-        .startswith("[TMPRL1104] Workflow task duration information (")
+    assert re.match(
+        r"\[TMPRL1104\] [^:]+:\d+:\d+ Workflow task duration information \(",
+        records[0].getMessage(),
     )
     assert not hasattr(records[0], "payload_download_count")
     assert not hasattr(records[0], "payload_upload_count")
 
     # WFT 2: workflow returns large result → uploaded
-    assert (
-        records[1]
-        .getMessage()
-        .startswith("[TMPRL1104] Workflow task duration information (")
+    assert re.match(
+        r"\[TMPRL1104\] [^:]+:\d+:\d+ Workflow task duration information \(",
+        records[1].getMessage(),
     )
     assert not hasattr(records[1], "payload_download_count")
     assert getattr(records[1], "payload_upload_count") == 1
@@ -843,10 +841,9 @@ async def test_tmprl1104_with_extstore_download_and_upload(
     assert len(records) == 2
 
     # WFT 1: retrieves externalized workflow input
-    assert (
-        records[0]
-        .getMessage()
-        .startswith("[TMPRL1104] Workflow task duration information (")
+    assert re.match(
+        r"\[TMPRL1104\] [^:]+:\d+:\d+ Workflow task duration information \(",
+        records[0].getMessage(),
     )
     assert getattr(records[0], "payload_download_count") == 1
     assert getattr(records[0], "payload_download_size") == expected_input_size
@@ -854,10 +851,9 @@ async def test_tmprl1104_with_extstore_download_and_upload(
     assert not hasattr(records[0], "payload_upload_count")
 
     # WFT 2: uploads externalized workflow result
-    assert (
-        records[1]
-        .getMessage()
-        .startswith("[TMPRL1104] Workflow task duration information (")
+    assert re.match(
+        r"\[TMPRL1104\] [^:]+:\d+:\d+ Workflow task duration information \(",
+        records[1].getMessage(),
     )
     assert not hasattr(records[1], "payload_download_count")
     assert getattr(records[1], "payload_upload_count") == 1

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -1637,6 +1637,9 @@ class CustomWorkflowInstance(WorkflowInstance):
     ) -> temporalio.converter._extstore.StorageDriverStoreContext:
         return self._unsandboxed.get_external_store_context(command_info)
 
+    def get_info(self) -> temporalio.workflow.Info:
+        return self._unsandboxed.get_info()
+
 
 async def test_workflow_with_custom_runner(client: Client):
     runner = CustomWorkflowRunner()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Include more data in the log message and structured logging of the TMPRL1104 log messages:
  - Include same data that `workflow.logger` would include, namely attempt, namespace, run_id, task_queue, workflow_id, and workflow_type.
  - Add workflow history size
  - Add download and update driver names
- Add a log identifier that Temporal UI can use to refer to precise workflow task completion attempt consisting of the run ID, the completion event ID, and the attempt number.

Example log output:

> [TMPRL1104] 019db345-f8f8-76c6-919f-631a00c4b031:4:1 Workflow task duration information ({'attempt': 1, 'namespace': 'default', 'run_id': '019db345-f8f8-76c6-919f-631a00c4b031', 'task_queue': '7a1a95c7-7170-45f5-a06b-b7d91dd06a5f', 'workflow_id': 'workflow-69cada2a-aa45-4280-9339-75fd32a3f0a3', 'workflow_type': 'ExtStoreWorkflow', 'event_id': 4, 'workflow_task_duration': '58.561ms', 'history_size': 472, 'payload_download_count': 1, 'payload_download_size': 1167, 'payload_download_duration': '21.199ms', 'payload_download_drivers': ['test-driver']})

## Why?

- Give customers more contextual data to better understand the precise workflow task to which the latency data is associated.
- Allow Temporal UI to easily reference a specific task completion if workflow task latency is a concern.

## Checklist

1. How was this tested: Existing tests and updates to external storage tests.
1. Any docs updates needed? No
