### PR TITLE
Extend Workflow timeout for test_customer_service_workflow

### DIFF
--- a/tests/contrib/openai_agents/test_openai.py
+++ b/tests/contrib/openai_agents/test_openai.py
@@ -1016,7 +1016,7 @@ async def test_customer_service_workflow(client: Client, use_local_model: bool):
                 CustomerServiceWorkflow.run,
                 id=f"customer-service-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=30),
+                execution_timeout=timedelta(seconds=60),
             )
             history: list[Any] = []
             for q in questions:


### PR DESCRIPTION
Ran into a flaky failure for this test [here](https://github.com/temporalio/sdk-python/actions/runs/24806298174/job/72601151767?pr=1473). Same as 7e36940d. We'll want to rewrite this to use a mock in the future.