### PR TITLE
External storage: Improved debuggability for region problems.

### DIFF
--- a/temporalio/contrib/aws/s3driver/README.md
+++ b/temporalio/contrib/aws/s3driver/README.md
@@ -25,8 +25,8 @@ from temporalio.converter import DataConverter, ExternalStorage
 session = aioboto3.Session()
 # Credentials are resolved automatically from the standard AWS credential chain
 # (environment variables, ~/.aws/config, IAM instance profile, and so on).
-# Region must be set explicitly -- either via `AWS_REGION` in the environment
-# or `region = ...` under the profile in ~/.aws/config. See Notes below.
+# Region is obtained either via `AWS_REGION` in the environment
+# or `region = ...` under the profile in ~/.aws/config.
 async with session.client("s3") as s3_client:
     driver = S3StorageDriver(
         client=new_aioboto3_client(s3_client),
@@ -67,7 +67,6 @@ Payloads are stored under content-addressable keys derived from a SHA-256 hash o
 
 * Any driver used to store payloads must also be configured on the component that retrieves them. If the client stores workflow inputs using this driver, the worker must include it in its `ExternalStorage.drivers` list to retrieve them.
 * The target S3 bucket must already exist; the driver will not create it.
-* The aioboto3 client does not auto-detect the bucket's region. Unlike the `aws` CLI, boto3 does not fall back to a `HeadBucket` redirect — it signs the first request to whatever region it resolves and fails with `403 Forbidden` on a cross-region call. Set `region = ...` in the profile in `~/.aws/config` or export `AWS_REGION`. `sso_region` in an SSO session block does not count; it governs only the SSO token endpoint.
 * Identical serialized bytes within the same namespace and workflow (or activity) share the same S3 object — the key is content-addressable within that scope. The same bytes used across different workflows or namespaces produce distinct S3 objects because the key includes the namespace and workflow/activity identifiers.
 * Only payloads at or above `ExternalStorage.payload_size_threshold` (default: 256 KiB) are offloaded; smaller payloads are stored inline. Set `ExternalStorage.payload_size_threshold` to `0` to offload every payload regardless of size.
 * `S3StorageDriver.max_payload_size` (default: 50 MiB) sets a hard upper limit on the serialized size of any single payload. A `ValueError` is raised at store time if a payload exceeds this limit. Increase it if your workflows produce payloads larger than 50 MiB.

--- a/temporalio/contrib/aws/s3driver/README.md
+++ b/temporalio/contrib/aws/s3driver/README.md
@@ -23,8 +23,10 @@ from temporalio.contrib.aws.s3driver.aioboto3 import new_aioboto3_client
 from temporalio.converter import DataConverter, ExternalStorage
 
 session = aioboto3.Session()
-# Credentials and region are resolved automatically from the standard AWS credential
-# chain e.g. environment variables, ~/.aws/config, IAM instance profile, and so on.
+# Credentials are resolved automatically from the standard AWS credential chain
+# (environment variables, ~/.aws/config, IAM instance profile, and so on).
+# Region must be set explicitly -- either via `AWS_REGION` in the environment
+# or `region = ...` under the profile in ~/.aws/config. See Notes below.
 async with session.client("s3") as s3_client:
     driver = S3StorageDriver(
         client=new_aioboto3_client(s3_client),
@@ -65,6 +67,7 @@ Payloads are stored under content-addressable keys derived from a SHA-256 hash o
 
 * Any driver used to store payloads must also be configured on the component that retrieves them. If the client stores workflow inputs using this driver, the worker must include it in its `ExternalStorage.drivers` list to retrieve them.
 * The target S3 bucket must already exist; the driver will not create it.
+* The aioboto3 client does not auto-detect the bucket's region. Unlike the `aws` CLI, boto3 does not fall back to a `HeadBucket` redirect — it signs the first request to whatever region it resolves and fails with `403 Forbidden` on a cross-region call. Set `region = ...` in the profile in `~/.aws/config` or export `AWS_REGION`. `sso_region` in an SSO session block does not count; it governs only the SSO token endpoint.
 * Identical serialized bytes within the same namespace and workflow (or activity) share the same S3 object — the key is content-addressable within that scope. The same bytes used across different workflows or namespaces produce distinct S3 objects because the key includes the namespace and workflow/activity identifiers.
 * Only payloads at or above `ExternalStorage.payload_size_threshold` (default: 256 KiB) are offloaded; smaller payloads are stored inline. Set `ExternalStorage.payload_size_threshold` to `0` to offload every payload regardless of size.
 * `S3StorageDriver.max_payload_size` (default: 50 MiB) sets a hard upper limit on the serialized size of any single payload. A `ValueError` is raised at store time if a payload exceeds this limit. Increase it if your workflows produce payloads larger than 50 MiB.

--- a/temporalio/contrib/aws/s3driver/README.md
+++ b/temporalio/contrib/aws/s3driver/README.md
@@ -23,10 +23,9 @@ from temporalio.contrib.aws.s3driver.aioboto3 import new_aioboto3_client
 from temporalio.converter import DataConverter, ExternalStorage
 
 session = aioboto3.Session()
-# Credentials are resolved automatically from the standard AWS credential chain
-# (environment variables, ~/.aws/config, IAM instance profile, and so on).
-# Region is obtained either via `AWS_REGION` in the environment
-# or `region = ...` under the profile in ~/.aws/config.
+# To see how to set credentials and region via environment, config objects, or configuration files, 
+# see:
+# https://docs.aws.amazon.com/boto3/latest/guide/configuration.html
 async with session.client("s3") as s3_client:
     driver = S3StorageDriver(
         client=new_aioboto3_client(s3_client),

--- a/temporalio/contrib/aws/s3driver/_client.py
+++ b/temporalio/contrib/aws/s3driver/_client.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 
 
 class S3StorageDriverClient(ABC):
@@ -30,3 +31,11 @@ class S3StorageDriverClient(ABC):
     @abstractmethod
     async def get_object(self, *, bucket: str, key: str) -> bytes:
         """Download and return the bytes stored at the given S3 *bucket* and *key*."""
+
+    def describe(self) -> Mapping[str, str]:
+        """Return client-specific diagnostic metadata (e.g. region, credentials
+        source) that the driver appends to error messages. Implementations may
+        override this to surface configuration that is useful for debugging
+        common misconfigurations. Returns an empty mapping by default.
+        """
+        return {}

--- a/temporalio/contrib/aws/s3driver/_driver.py
+++ b/temporalio/contrib/aws/s3driver/_driver.py
@@ -26,6 +26,20 @@ from temporalio.converter import (
 _T = TypeVar("_T")
 
 
+def _format_client_context(client: S3StorageDriverClient) -> str:
+    """Format the client's ``describe()`` output as ", k=v, k=v" for error
+    messages. Returns an empty string when the client reports no metadata or
+    describe itself raises (diagnostic output must never mask the real error).
+    """
+    try:
+        info = client.describe()
+    except Exception:
+        return ""
+    if not info:
+        return ""
+    return "".join(f", {k}={v}" for k, v in info.items())
+
+
 async def _gather_with_cancellation(
     coros: Sequence[Coroutine[Any, Any, _T]],
 ) -> list[_T]:
@@ -156,7 +170,8 @@ class S3StorageDriver(StorageDriver):
                     )
             except Exception as e:
                 raise RuntimeError(
-                    f"S3StorageDriver store failed [bucket={bucket}, key={key}]"
+                    f"S3StorageDriver store failed [bucket={bucket}, key={key}"
+                    f"{_format_client_context(self._client)}]"
                 ) from e
 
             return StorageDriverClaim(
@@ -185,7 +200,8 @@ class S3StorageDriver(StorageDriver):
                 payload_bytes = await self._client.get_object(bucket=bucket, key=key)
             except Exception as e:
                 raise RuntimeError(
-                    f"S3StorageDriver retrieve failed [bucket={bucket}, key={key}]"
+                    f"S3StorageDriver retrieve failed [bucket={bucket}, key={key}"
+                    f"{_format_client_context(self._client)}]"
                 ) from e
 
             hash_algorithm = claim.claim_data.get("hash_algorithm")

--- a/temporalio/contrib/aws/s3driver/aioboto3.py
+++ b/temporalio/contrib/aws/s3driver/aioboto3.py
@@ -34,33 +34,13 @@ class _Aioboto3StorageDriverClient(S3StorageDriverClient):
                 ``aioboto3.Session().client("s3")``.
         """
         self._client = client
-        self._credentials_method: str | None = None
-        self._credentials_resolved = False
 
     def describe(self) -> Mapping[str, str]:
-        """Region and credentials source for the wrapped aioboto3 client.
-
-        The two most common misconfigurations that surface as opaque 403s
-        are wrong region and unexpected credential source; surfacing both
-        in driver error messages short-circuits those diagnoses.
+        """Region of the wrapped aioboto3 client, surfaced in driver error
+        messages to short-circuit the most common silent 403 misconfiguration.
         """
-        info: dict[str, str] = {}
         region = self._client.meta.region_name
-        if region:
-            info["region"] = region
-        if not self._credentials_resolved:
-            self._credentials_resolved = True
-            try:
-                import boto3
-
-                creds = boto3.Session().get_credentials()
-                if creds is not None:
-                    self._credentials_method = creds.method
-            except Exception:
-                pass
-        if self._credentials_method:
-            info["credentials"] = self._credentials_method
-        return info
+        return {"region": region} if region else {}
 
     async def object_exists(self, *, bucket: str, key: str) -> bool:
         """Check existence via aioboto3's ``head_object``."""

--- a/temporalio/contrib/aws/s3driver/aioboto3.py
+++ b/temporalio/contrib/aws/s3driver/aioboto3.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import io
+from collections.abc import Mapping
 
 from botocore.exceptions import ClientError
 from types_aiobotocore_s3.client import S3Client
@@ -33,6 +34,33 @@ class _Aioboto3StorageDriverClient(S3StorageDriverClient):
                 ``aioboto3.Session().client("s3")``.
         """
         self._client = client
+        self._credentials_method: str | None = None
+        self._credentials_resolved = False
+
+    def describe(self) -> Mapping[str, str]:
+        """Region and credentials source for the wrapped aioboto3 client.
+
+        The two most common misconfigurations that surface as opaque 403s
+        are wrong region and unexpected credential source; surfacing both
+        in driver error messages short-circuits those diagnoses.
+        """
+        info: dict[str, str] = {}
+        region = self._client.meta.region_name
+        if region:
+            info["region"] = region
+        if not self._credentials_resolved:
+            self._credentials_resolved = True
+            try:
+                import boto3
+
+                creds = boto3.Session().get_credentials()
+                if creds is not None:
+                    self._credentials_method = creds.method
+            except Exception:
+                pass
+        if self._credentials_method:
+            info["credentials"] = self._credentials_method
+        return info
 
     async def object_exists(self, *, bucket: str, key: str) -> bool:
         """Check existence via aioboto3's ``head_object``."""

--- a/tests/contrib/aws/s3driver/test_s3driver.py
+++ b/tests/contrib/aws/s3driver/test_s3driver.py
@@ -26,6 +26,8 @@ from temporalio.contrib.aws.s3driver import (
     S3StorageDriver,
     S3StorageDriverClient,
 )
+from temporalio.contrib.aws.s3driver._driver import _format_client_context
+from temporalio.contrib.aws.s3driver.aioboto3 import _Aioboto3StorageDriverClient
 from temporalio.converter import (
     JSONPlainPayloadConverter,
     StorageDriverActivityInfo,
@@ -34,7 +36,7 @@ from temporalio.converter import (
     StorageDriverStoreContext,
     StorageDriverWorkflowInfo,
 )
-from tests.contrib.aws.s3driver.conftest import BUCKET
+from tests.contrib.aws.s3driver.conftest import BUCKET, REGION
 
 _CONVERTER = JSONPlainPayloadConverter()
 
@@ -42,6 +44,7 @@ _CONVERTER = JSONPlainPayloadConverter()
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 
 def make_payload(value: str = "hello") -> Payload:
@@ -618,7 +621,7 @@ class TestS3StorageDriverErrors:
             await driver.store(make_store_context(), [payload])
         assert (
             str(exc_info.value)
-            == f"S3StorageDriver store failed [bucket={bucket}, key={expected_key}]"
+            == f"S3StorageDriver store failed [bucket={bucket}, key={expected_key}, region={REGION}]"
         )
         assert isinstance(exc_info.value.__cause__, ClientError)
         assert (
@@ -636,7 +639,7 @@ class TestS3StorageDriverErrors:
             await driver.retrieve(StorageDriverRetrieveContext(), [claim])
         assert (
             str(exc_info.value)
-            == f"S3StorageDriver retrieve failed [bucket={BUCKET}, key={key}]"
+            == f"S3StorageDriver retrieve failed [bucket={BUCKET}, key={key}, region={REGION}]"
         )
         assert isinstance(exc_info.value.__cause__, ClientError)
         assert (
@@ -655,7 +658,7 @@ class TestS3StorageDriverErrors:
             await driver.retrieve(StorageDriverRetrieveContext(), [claim])
         assert (
             str(exc_info.value)
-            == f"S3StorageDriver retrieve failed [bucket={bucket}, key={key}]"
+            == f"S3StorageDriver retrieve failed [bucket={bucket}, key={key}, region={REGION}]"
         )
         assert isinstance(exc_info.value.__cause__, ClientError)
         assert (
@@ -839,3 +842,49 @@ class TestS3StorageDriverConcurrency:
         assert (
             len(faulty_client.cancelled) == 2
         ), "Expected 2 remaining tasks to be cancelled"
+
+
+# ---------------------------------------------------------------------------
+# TestAioboto3StorageDriverClientDescribe
+# ---------------------------------------------------------------------------
+
+
+class TestAioboto3StorageDriverClientDescribe:
+    def _make_client(self, region: str | None) -> _Aioboto3StorageDriverClient:
+        mock_s3 = MagicMock()
+        mock_s3.meta.region_name = region
+        return _Aioboto3StorageDriverClient(mock_s3)
+
+    def test_returns_region(self) -> None:
+        client = self._make_client(region="ap-southeast-1")
+        assert client.describe() == {"region": "ap-southeast-1"}
+
+    def test_omits_region_when_none(self) -> None:
+        client = self._make_client(region=None)
+        assert client.describe() == {}
+
+    def test_omits_region_when_empty_string(self) -> None:
+        client = self._make_client(region="")
+        assert client.describe() == {}
+
+
+# ---------------------------------------------------------------------------
+# TestFormatClientContext
+# ---------------------------------------------------------------------------
+
+
+class TestFormatClientContext:
+    def test_formats_entry(self) -> None:
+        client = MagicMock(spec=S3StorageDriverClient)
+        client.describe.return_value = {"region": "us-east-1"}
+        assert _format_client_context(client) == ", region=us-east-1"
+
+    def test_returns_empty_string_for_empty_describe(self) -> None:
+        client = MagicMock(spec=S3StorageDriverClient)
+        client.describe.return_value = {}
+        assert _format_client_context(client) == ""
+
+    def test_returns_empty_string_when_describe_raises(self) -> None:
+        client = MagicMock(spec=S3StorageDriverClient)
+        client.describe.side_effect = RuntimeError("oops")
+        assert _format_client_context(client) == ""

--- a/tests/contrib/aws/s3driver/test_s3driver.py
+++ b/tests/contrib/aws/s3driver/test_s3driver.py
@@ -46,7 +46,6 @@ _CONVERTER = JSONPlainPayloadConverter()
 # ---------------------------------------------------------------------------
 
 
-
 def make_payload(value: str = "hello") -> Payload:
     p = _CONVERTER.to_payload(value)
     assert p is not None

--- a/tests/contrib/aws/s3driver/test_s3driver_worker.py
+++ b/tests/contrib/aws/s3driver/test_s3driver_worker.py
@@ -506,4 +506,4 @@ async def test_s3_store_failure_surfaces_in_workflow_history(
     msg = app_error.message
     assert f"S3StorageDriver store failed [bucket={bad_bucket}, key=" in msg
     assert f"/wt/LargeOutputNoRetryWorkflow/wi/{workflow_id}/ri/" in msg
-    assert f"/d/sha256/{expected_hash}]" in msg
+    assert f"/d/sha256/{expected_hash}, region={REGION}]" in msg


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
* Link README out to S3 docs to help users discover where region comes from.
* Add region to the error message for S3 Driver errors for easier debugging.
* To accomplish this, add a `describe` method to the clients, so that clients such as `S3StorageDriverClient` can provide context to the diagnostics.

## Why?
<!-- Tell your future self why have you made these changes -->
* Had a big debugging sesh with Claude where it took a while to diagnose a region mismatch.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Tested e2e using https://github.com/drewhoskins-temporal/external-storage-demo

Example output:

```
botocore.exceptions.TokenRetrievalError: Error when retrieving token from sso: Token has expired and refresh failed

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/drewhoskins/python-temporal/external-storage-demo/.venv/lib/python3.12/site-packages/temporalio/worker/_activity.py", line 362, in _handle_start_activity_task
    [payload] = await data_converter.encode([result])
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<snip>
    raise RuntimeError(
RuntimeError: S3StorageDriver store failed [bucket=s3-replay-demo-drew, key=v0/ns/default/wt/ExpenseAuditWorkflow/wi/audit-emp-013-1777423444/ri/019dd6b1-6b17-7a96-9f9e-96580354fe0b/d/sha256/e0766c48e681f0c5fa72af7bf33fcd2dbefff82b36ad3d9dd2b3522b0b8b4b88, region=us-west-2]
```


New integration tests in the PR.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
