### PR TITLE
Say 'client_region' in S3 diagnostics for clarity

### DIFF
--- a/temporalio/contrib/aws/s3driver/aioboto3.py
+++ b/temporalio/contrib/aws/s3driver/aioboto3.py
@@ -40,7 +40,7 @@ class _Aioboto3StorageDriverClient(S3StorageDriverClient):
         messages to short-circuit the most common silent 403 misconfiguration.
         """
         region = self._client.meta.region_name
-        return {"region": region} if region else {}
+        return {"client_region": region} if region else {}
 
     async def object_exists(self, *, bucket: str, key: str) -> bool:
         """Check existence via aioboto3's ``head_object``."""

--- a/tests/contrib/aws/s3driver/conftest.py
+++ b/tests/contrib/aws/s3driver/conftest.py
@@ -14,7 +14,7 @@ from temporalio.contrib.aws.s3driver import S3StorageDriverClient
 from temporalio.contrib.aws.s3driver.aioboto3 import new_aioboto3_client
 
 BUCKET = "test-bucket"
-REGION = "us-east-1"
+CLIENT_REGION = "us-east-1"
 
 
 def _find_free_port() -> int:
@@ -50,7 +50,7 @@ async def aioboto3_client(moto_server_url: str) -> AsyncIterator[S3Client]:
     session = aioboto3.Session()
     async with session.client(
         "s3",
-        region_name=REGION,
+        region_name=CLIENT_REGION,
         endpoint_url=moto_server_url,
         aws_access_key_id="testing",
         aws_secret_access_key="testing",

--- a/tests/contrib/aws/s3driver/test_s3driver.py
+++ b/tests/contrib/aws/s3driver/test_s3driver.py
@@ -36,7 +36,7 @@ from temporalio.converter import (
     StorageDriverStoreContext,
     StorageDriverWorkflowInfo,
 )
-from tests.contrib.aws.s3driver.conftest import BUCKET, REGION
+from tests.contrib.aws.s3driver.conftest import BUCKET, CLIENT_REGION
 
 _CONVERTER = JSONPlainPayloadConverter()
 
@@ -620,7 +620,7 @@ class TestS3StorageDriverErrors:
             await driver.store(make_store_context(), [payload])
         assert (
             str(exc_info.value)
-            == f"S3StorageDriver store failed [bucket={bucket}, key={expected_key}, region={REGION}]"
+            == f"S3StorageDriver store failed [bucket={bucket}, key={expected_key}, client_region={CLIENT_REGION}]"
         )
         assert isinstance(exc_info.value.__cause__, ClientError)
         assert (
@@ -638,7 +638,7 @@ class TestS3StorageDriverErrors:
             await driver.retrieve(StorageDriverRetrieveContext(), [claim])
         assert (
             str(exc_info.value)
-            == f"S3StorageDriver retrieve failed [bucket={BUCKET}, key={key}, region={REGION}]"
+            == f"S3StorageDriver retrieve failed [bucket={BUCKET}, key={key}, client_region={CLIENT_REGION}]"
         )
         assert isinstance(exc_info.value.__cause__, ClientError)
         assert (
@@ -657,7 +657,7 @@ class TestS3StorageDriverErrors:
             await driver.retrieve(StorageDriverRetrieveContext(), [claim])
         assert (
             str(exc_info.value)
-            == f"S3StorageDriver retrieve failed [bucket={bucket}, key={key}, region={REGION}]"
+            == f"S3StorageDriver retrieve failed [bucket={bucket}, key={key}, client_region={CLIENT_REGION}]"
         )
         assert isinstance(exc_info.value.__cause__, ClientError)
         assert (
@@ -856,7 +856,7 @@ class TestAioboto3StorageDriverClientDescribe:
 
     def test_returns_region(self) -> None:
         client = self._make_client(region="ap-southeast-1")
-        assert client.describe() == {"region": "ap-southeast-1"}
+        assert client.describe() == {"client_region": "ap-southeast-1"}
 
     def test_omits_region_when_none(self) -> None:
         client = self._make_client(region=None)

--- a/tests/contrib/aws/s3driver/test_s3driver_worker.py
+++ b/tests/contrib/aws/s3driver/test_s3driver_worker.py
@@ -25,7 +25,7 @@ from temporalio.contrib.aws.s3driver.aioboto3 import new_aioboto3_client
 from temporalio.converter import ExternalStorage, JSONPlainPayloadConverter
 from temporalio.exceptions import ActivityError, ApplicationError
 from temporalio.testing import WorkflowEnvironment
-from tests.contrib.aws.s3driver.conftest import BUCKET, REGION
+from tests.contrib.aws.s3driver.conftest import BUCKET, CLIENT_REGION
 from tests.contrib.aws.s3driver.workflows import (
     LARGE,
     ChildWorkflow,
@@ -463,7 +463,7 @@ async def test_s3_store_failure_surfaces_in_workflow_history(
     session = aioboto3.Session()
     async with session.client(
         "s3",
-        region_name=REGION,
+        region_name=CLIENT_REGION,
         endpoint_url=moto_server_url,
         aws_access_key_id="testing",
         aws_secret_access_key="testing",
@@ -506,4 +506,4 @@ async def test_s3_store_failure_surfaces_in_workflow_history(
     msg = app_error.message
     assert f"S3StorageDriver store failed [bucket={bad_bucket}, key=" in msg
     assert f"/wt/LargeOutputNoRetryWorkflow/wi/{workflow_id}/ri/" in msg
-    assert f"/d/sha256/{expected_hash}, region={REGION}]" in msg
+    assert f"/d/sha256/{expected_hash}, client_region={CLIENT_REGION}]" in msg


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Clarify `client_region` in the S3 diagnostic to differentiate from the region of the bucket.

## Why?
<!-- Tell your future self why have you made these changes -->

@jmaeagle99 made a good suggestion in https://github.com/temporalio/sdk-python/pull/1487/changes

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

`uv run pytest tests/contrib/aws/s3driver/test_s3driver_worker.py`
`uv run pytest --extra aioboto3 tests/contrib/aws/s3driver/test_s3driver.py`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
