### PR TITLE
Fix CI, bump openinference-instrumentation-google-adk to 0.1.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,10 +75,7 @@ dev = [
   "openai-agents>=0.14.0; python_version >= '3.14'",
   "openai-agents[litellm]>=0.14.0; python_version < '3.14'",
   "litellm>=1.83.0",
-  "openinference-instrumentation-google-adk>=0.1.8",
-  # openinference-instrumentation-google-adk 0.1.10 patches `trace_tool_call`,
-  # which was removed in google-adk 1.32. Cap until upstream catches up.
-  "google-adk<1.32",
+  "openinference-instrumentation-google-adk>=0.1.11",
   "googleapis-common-protos==1.70.0",
   "pytest-rerunfailures>=16.1",
   "pytest-xdist>=3.6,<4",
@@ -259,4 +256,4 @@ exclude = ["temporalio/bridge/target/**/*"]
 # Prevent uv commands from building the package by default
 package = false
 exclude-newer = "1 week"
-exclude-newer-package = { openai-agents = false }
+exclude-newer-package = { openai-agents = false, openinference-instrumentation-google-adk = false }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ dev = [
   "openai-agents[litellm]>=0.14.0; python_version < '3.14'",
   "litellm>=1.83.0",
   "openinference-instrumentation-google-adk>=0.1.8",
+  # openinference-instrumentation-google-adk 0.1.10 patches `trace_tool_call`,
+  # which was removed in google-adk 1.32. Cap until upstream catches up.
+  "google-adk<1.32",
   "googleapis-common-protos==1.70.0",
   "pytest-rerunfailures>=16.1",
   "pytest-xdist>=3.6,<4",

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-23T17:46:27.746666Z"
+exclude-newer = "2026-05-01T16:44:01.967317Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -5198,6 +5198,7 @@ dev = [
     { name = "async-timeout", marker = "python_full_version < '3.11'" },
     { name = "basedpyright" },
     { name = "cibuildwheel" },
+    { name = "google-adk" },
     { name = "googleapis-common-protos" },
     { name = "grpcio-tools" },
     { name = "httpx" },
@@ -5263,6 +5264,7 @@ dev = [
     { name = "async-timeout", marker = "python_full_version < '3.11'", specifier = ">=4.0,<6" },
     { name = "basedpyright", specifier = "==1.34.0" },
     { name = "cibuildwheel", specifier = ">=2.22.0,<3" },
+    { name = "google-adk", specifier = "<1.32" },
     { name = "googleapis-common-protos", specifier = "==1.70.0" },
     { name = "grpcio-tools", specifier = ">=1.48.2,<2" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -9,11 +9,12 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-01T16:44:01.967317Z"
+exclude-newer = "2026-05-01T17:48:32.303305Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
 openai-agents = false
+openinference-instrumentation-google-adk = false
 
 [[package]]
 name = "aioboto3"
@@ -3452,7 +3453,7 @@ wheels = [
 
 [[package]]
 name = "openinference-instrumentation-google-adk"
-version = "0.1.10"
+version = "0.1.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "openinference-instrumentation" },
@@ -3463,9 +3464,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/7a/bba3337066dcd391f7091d840c6d22e351a9f8412bb8de4b901cc6443aa9/openinference_instrumentation_google_adk-0.1.10.tar.gz", hash = "sha256:5ccb61d58532b2d829b71b411a997b573ddc2b03dcd5481fb2f9f67ec7368a97", size = 12383, upload-time = "2026-03-03T08:07:34.296Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/7e/a6a6c7dc7bd01e098374cdee69b10b6586d2f7a481ed34f8a283fcbfd830/openinference_instrumentation_google_adk-0.1.11.tar.gz", hash = "sha256:b36310d4e8b8143d41fe5c74be04c09f367710ec8019471f232bb721ede143b1", size = 14473, upload-time = "2026-05-05T06:43:34.828Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/82/8ee4f5f40d2353ac643668c4f6a98e0ce51a76afeab1cfba2dab1976d7c4/openinference_instrumentation_google_adk-0.1.10-py3-none-any.whl", hash = "sha256:d97be628ce60b8eeab017f34ffaa2ec6fdaa11c64f3d0a032706ef74659e2a3e", size = 14201, upload-time = "2026-03-03T08:07:33.406Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/51/0d4df97fd0fb3ac2282dc268e9a11f82523f881e623264291d6abf2fd5ed/openinference_instrumentation_google_adk-0.1.11-py3-none-any.whl", hash = "sha256:8dd546f9db3a6589106287b8a99b99f06361ac95e6e0b32305e6ce1a76f98630", size = 16384, upload-time = "2026-05-05T06:43:33.836Z" },
 ]
 
 [[package]]
@@ -5198,7 +5199,6 @@ dev = [
     { name = "async-timeout", marker = "python_full_version < '3.11'" },
     { name = "basedpyright" },
     { name = "cibuildwheel" },
-    { name = "google-adk" },
     { name = "googleapis-common-protos" },
     { name = "grpcio-tools" },
     { name = "httpx" },
@@ -5264,7 +5264,6 @@ dev = [
     { name = "async-timeout", marker = "python_full_version < '3.11'", specifier = ">=4.0,<6" },
     { name = "basedpyright", specifier = "==1.34.0" },
     { name = "cibuildwheel", specifier = ">=2.22.0,<3" },
-    { name = "google-adk", specifier = "<1.32" },
     { name = "googleapis-common-protos", specifier = "==1.70.0" },
     { name = "grpcio-tools", specifier = ">=1.48.2,<2" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -5277,7 +5276,7 @@ dev = [
     { name = "mypy-protobuf", specifier = ">=3.3.0,<4" },
     { name = "openai-agents", marker = "python_full_version >= '3.14'", specifier = ">=0.14.0" },
     { name = "openai-agents", extras = ["litellm"], marker = "python_full_version < '3.14'", specifier = ">=0.14.0" },
-    { name = "openinference-instrumentation-google-adk", specifier = ">=0.1.8" },
+    { name = "openinference-instrumentation-google-adk", specifier = ">=0.1.11" },
     { name = "openinference-instrumentation-openai-agents", specifier = ">=0.1.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.11.1,<2" },
     { name = "opentelemetry-sdk-extension-aws", specifier = ">=2.0.0,<3" },


### PR DESCRIPTION
Fix for CI, broken on main: https://github.com/temporalio/sdk-python/actions/runs/25458141468/job/75054841611

Pull in the changes from https://github.com/Arize-ai/openinference/pull/3048