### PR TITLE
Cap openai-agents at <0.17.1 to unblock test-latest-deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 grpc = ["grpcio>=1.48.2,<2"]
 opentelemetry = ["opentelemetry-api>=1.11.1,<2", "opentelemetry-sdk>=1.11.1,<2"]
 pydantic = ["pydantic>=2.0.0,<3"]
-openai-agents = ["openai-agents>=0.14.0", "mcp>=1.9.4, <2"]
+openai-agents = ["openai-agents>=0.14.0,<0.17.1", "mcp>=1.9.4, <2"]
 google-adk = ["google-adk>=1.27.0,<2"]
 langgraph = ["langgraph>=1.1.0"]
 langsmith = ["langsmith>=0.7.0,<0.8"]
@@ -72,8 +72,8 @@ dev = [
   "pytest-cov>=6.1.1",
   "httpx>=0.28.1",
   "pytest-pretty>=1.3.0",
-  "openai-agents>=0.14.0; python_version >= '3.14'",
-  "openai-agents[litellm]>=0.14.0; python_version < '3.14'",
+  "openai-agents>=0.14.0,<0.17.1; python_version >= '3.14'",
+  "openai-agents[litellm]>=0.14.0,<0.17.1; python_version < '3.14'",
   "litellm>=1.83.0",
   "openinference-instrumentation-google-adk>=0.1.11",
   "googleapis-common-protos==1.70.0",

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-01T17:48:32.303305Z"
+exclude-newer = "2026-05-04T19:41:35.334574Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -5242,7 +5242,7 @@ requires-dist = [
     { name = "langsmith", marker = "extra == 'langsmith'", specifier = ">=0.7.0,<0.8" },
     { name = "mcp", marker = "extra == 'openai-agents'", specifier = ">=1.9.4,<2" },
     { name = "nexus-rpc", specifier = "==1.4.0" },
-    { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.14.0" },
+    { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.14.0,<0.17.1" },
     { name = "opentelemetry-api", marker = "extra == 'lambda-worker-otel'", specifier = ">=1.11.1,<2" },
     { name = "opentelemetry-api", marker = "extra == 'opentelemetry'", specifier = ">=1.11.1,<2" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'lambda-worker-otel'", specifier = ">=1.11.1,<2" },
@@ -5274,8 +5274,8 @@ dev = [
     { name = "moto", extras = ["s3", "server"], specifier = ">=5" },
     { name = "mypy", specifier = "==1.18.2" },
     { name = "mypy-protobuf", specifier = ">=3.3.0,<4" },
-    { name = "openai-agents", marker = "python_full_version >= '3.14'", specifier = ">=0.14.0" },
-    { name = "openai-agents", extras = ["litellm"], marker = "python_full_version < '3.14'", specifier = ">=0.14.0" },
+    { name = "openai-agents", marker = "python_full_version >= '3.14'", specifier = ">=0.14.0,<0.17.1" },
+    { name = "openai-agents", extras = ["litellm"], marker = "python_full_version < '3.14'", specifier = ">=0.14.0,<0.17.1" },
     { name = "openinference-instrumentation-google-adk", specifier = ">=0.1.11" },
     { name = "openinference-instrumentation-openai-agents", specifier = ">=0.1.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.11.1,<2" },


### PR DESCRIPTION
## Summary

`openai-agents` 0.17.1 (released today) added a `timeout` parameter to `SynchronousMultiTracingProcessor.shutdown`, which makes basedpyright report `reportIncompatibleMethodOverride` on `_TemporalTracingProcessor.shutdown` in `temporalio/contrib/openai_agents/_temporal_trace_provider.py`. This is breaking the `test-latest-deps` CI job on `main` and on every open PR.

Cap the dependency at `<0.17.1` so the resolver stays on `0.17.0` (which still has the old `shutdown(self) -> None`). When we want to support 0.17.1+, update the override to accept and forward `timeout` and lift the cap.

## Test plan

- [x] `poe lint` (basedpyright/pyright/mypy/ruff/pydocstyle) passes against pinned 0.14.8
- [x] `poe lint` passes after `uv lock --upgrade` (resolver picks 0.17.0, no override mismatch)
- [x] `uv run pydoctor --quiet` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)