### PR TITLE
Pick up shutdown fix cherry-pick for v1.24.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,8 +171,9 @@ jobs:
 
   # Runs the sdk features repo tests with this repo's current SDK code
   features-tests:
-    uses: temporalio/features/.github/workflows/python.yaml@be582e6f3acd344c0c96d637c48680dd4e3747d4
+    uses: temporalio/features/.github/workflows/python.yaml@0e2e288970313e88899e5f0e816e0837d5a3fadc
     with:
       python-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}
+      features-repo-ref: 0e2e288970313e88899e5f0e816e0837d5a3fadc
       version-is-repo-ref: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
 
   # Runs the sdk features repo tests with this repo's current SDK code
   features-tests:
-    uses: temporalio/features/.github/workflows/python.yaml@main
+    uses: temporalio/features/.github/workflows/python.yaml@be582e6f3acd344c0c96d637c48680dd4e3747d4
     with:
       python-repo-path: ${{github.event.pull_request.head.repo.full_name}}
       version: ${{github.event.pull_request.head.ref}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "nexus-rpc==1.4.0",
   "protobuf>=3.20,<7.0.0",
   "python-dateutil>=2.8.2,<3 ; python_version < '3.11'",
-  "types-protobuf>=3.20",
+  "types-protobuf>=3.20,<=6.32.1.20250918",
   "typing-extensions>=4.2.0,<5",
 ]
 classifiers = [

--- a/temporalio/bridge/src/worker.rs
+++ b/temporalio/bridge/src/worker.rs
@@ -683,6 +683,7 @@ impl WorkerRef {
     }
 
     fn initiate_shutdown(&self) -> PyResult<()> {
+        enter_sync!(self.runtime);
         let worker = self.worker.as_ref().unwrap().clone();
         worker.initiate_shutdown();
         Ok(())

--- a/uv.lock
+++ b/uv.lock
@@ -4338,7 +4338,7 @@ requires-dist = [
     { name = "protobuf", specifier = ">=3.20,<7.0.0" },
     { name = "pydantic", marker = "extra == 'pydantic'", specifier = ">=2.0.0,<3" },
     { name = "python-dateutil", marker = "python_full_version < '3.11'", specifier = ">=2.8.2,<3" },
-    { name = "types-protobuf", specifier = ">=3.20" },
+    { name = "types-protobuf", specifier = ">=3.20,<=6.32.1.20250918" },
     { name = "typing-extensions", specifier = ">=4.2.0,<5" },
 ]
 provides-extras = ["grpc", "opentelemetry", "pydantic", "openai-agents", "google-adk"]


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Point core to https://github.com/temporalio/sdk-rust/tree/backport/poller-shutdown/5f79ef2, which has a worker shutdown fix backported via https://github.com/temporalio/sdk-rust/pull/1260

Pointed the `features` repo in CI to pre-S3 driver sample code, since that isn't in this older version, and also set a roof for types-protobuf to match what was available during the release, since newer version is causing CI to now fail

## Why?
<!-- Tell your future self why have you made these changes -->
fix shutdown

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Rust worker shutdown plumbing in the Python bridge, which can affect runtime/thread behavior and shutdown correctness. The remaining changes are CI/dependency pinning to stabilize tests.
> 
> **Overview**
> Fixes worker shutdown behavior in the Rust Python bridge by ensuring `WorkerRef::initiate_shutdown` enters the tokio runtime context (matching other sync bridge calls).
> 
> Stabilizes CI for this release line by pinning the `temporalio/features` workflow (and passing `features-repo-ref`) to a specific commit, and by adding an upper bound to `types-protobuf` in `pyproject.toml`/`uv.lock` to avoid newer stubs breaking older builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9f2440a17172401c86ee16f1b0f9fefac9d241b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->