### PR TITLE
Integration test for Standalone Activities delayed-start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,19 +61,27 @@ jobs:
       - run: uv sync --all-extras
       - run: poe bridge-lint
         if: ${{ matrix.clippyLinter }}
-      - name: Debug rustc for maturin
-        if: ${{ matrix.python == '3.14' && startsWith(matrix.os, 'macos') }}
-        continue-on-error: true
-        shell: bash
-        run: |
-          set -x
-          which rustc
-          rustc -vV
-          uv run python -c 'import shutil, subprocess; print("rustc:", shutil.which("rustc")); r = subprocess.run(["rustc", "-vV"], capture_output=True, text=True); print("returncode:", r.returncode); print("stdout:", repr(r.stdout)); print("stderr:", repr(r.stderr))'
-          uv run maturin --version
-          uv run maturin develop --uv -vv
       - run: poe build-develop
       - run: poe lint
+      - name: Warm Temporal dev server download
+        shell: bash
+        run: |
+          uv run python - <<'PY'
+          import asyncio
+
+          from temporalio.testing import WorkflowEnvironment
+          from tests import DEV_SERVER_DOWNLOAD_VERSION
+
+
+          async def main() -> None:
+              env = await WorkflowEnvironment.start_local(
+                  dev_server_download_version=DEV_SERVER_DOWNLOAD_VERSION,
+              )
+              await env.shutdown()
+
+
+          asyncio.run(main())
+          PY
       - run: mkdir junit-xml
       - run: poe test ${{matrix.pytestExtraArgs}} -s --junit-xml=junit-xml/${{ matrix.python }}--${{ matrix.os }}.xml
         timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
           components: "clippy"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          cache-bin: false
           workspaces: temporalio/bridge -> target
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -63,25 +62,6 @@ jobs:
         if: ${{ matrix.clippyLinter }}
       - run: poe build-develop
       - run: poe lint
-      - name: Warm Temporal dev server download
-        shell: bash
-        run: |
-          uv run python - <<'PY'
-          import asyncio
-
-          from temporalio.testing import WorkflowEnvironment
-          from tests import DEV_SERVER_DOWNLOAD_VERSION
-
-
-          async def main() -> None:
-              env = await WorkflowEnvironment.start_local(
-                  dev_server_download_version=DEV_SERVER_DOWNLOAD_VERSION,
-              )
-              await env.shutdown()
-
-
-          asyncio.run(main())
-          PY
       - run: mkdir junit-xml
       - run: poe test ${{matrix.pytestExtraArgs}} -s --junit-xml=junit-xml/${{ matrix.python }}--${{ matrix.os }}.xml
         timeout-minutes: 15
@@ -131,7 +111,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          cache-bin: false
           workspaces: temporalio/bridge -> target
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -168,7 +147,6 @@ jobs:
           components: "clippy"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          cache-bin: false
           workspaces: temporalio/bridge -> target
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -207,7 +185,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          cache-bin: false
           workspaces: temporalio/bridge -> target
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,17 @@ jobs:
       - run: uv sync --all-extras
       - run: poe bridge-lint
         if: ${{ matrix.clippyLinter }}
+      - name: Debug rustc for maturin
+        if: ${{ matrix.python == '3.14' && startsWith(matrix.os, 'macos') }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -x
+          which rustc
+          rustc -vV
+          uv run python -c 'import shutil, subprocess; print("rustc:", shutil.which("rustc")); r = subprocess.run(["rustc", "-vV"], capture_output=True, text=True); print("returncode:", r.returncode); print("stdout:", repr(r.stdout)); print("stderr:", repr(r.stderr))'
+          uv run maturin --version
+          uv run maturin develop --uv -vv
       - run: poe build-develop
       - run: poe lint
       - run: mkdir junit-xml

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-DEV_SERVER_DOWNLOAD_VERSION = "v1.7.0"
+DEV_SERVER_DOWNLOAD_VERSION = "v1.7.1-standalone-nexus-operations"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,8 @@ async def env(env_type: str) -> AsyncGenerator[WorkflowEnvironment, None]:
                 "--dynamic-config-value",
                 "activity.enableStandalone=true",
                 "--dynamic-config-value",
+                "activity.startDelayEnabled=true",
+                "--dynamic-config-value",
                 "history.enableChasm=true",
                 "--dynamic-config-value",
                 "history.enableTransitionHistory=true",

--- a/tests/nexus/test_workflow_caller_cancellation_types.py
+++ b/tests/nexus/test_workflow_caller_cancellation_types.py
@@ -20,6 +20,7 @@ from temporalio.client import (
 from temporalio.common import WorkflowIDConflictPolicy
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
+from tests.helpers import assert_eventually
 from tests.helpers.nexus import make_nexus_endpoint_name
 
 
@@ -40,12 +41,15 @@ test_context: TestContext
 class HandlerWorkflow:
     def __init__(self):
         self.caller_op_future_resolved = asyncio.Event()
+        self.cancel_requested = False
+        self.release_cancellation = asyncio.Event()
 
     @workflow.run
     async def run(self) -> None:
         try:
             await asyncio.Future()
         except asyncio.CancelledError:
+            self.cancel_requested = True
             if test_context.cancellation_type in [
                 workflow.NexusOperationCancellationType.TRY_CANCEL,
                 workflow.NexusOperationCancellationType.WAIT_REQUESTED,
@@ -53,11 +57,24 @@ class HandlerWorkflow:
                 # We want to prove that the caller op future can be resolved before the operation
                 # (i.e. its backing workflow) is cancelled.
                 await self.caller_op_future_resolved.wait()
+            elif (
+                test_context.cancellation_type
+                == workflow.NexusOperationCancellationType.WAIT_COMPLETED
+            ):
+                await self.release_cancellation.wait()
             raise
 
     @workflow.signal
     def set_caller_op_future_resolved(self) -> None:
         self.caller_op_future_resolved.set()
+
+    @workflow.signal
+    def set_release_cancellation(self) -> None:
+        self.release_cancellation.set()
+
+    @workflow.query
+    def has_cancel_requested(self) -> bool:
+        return self.cancel_requested
 
 
 @nexusrpc.service
@@ -150,6 +167,10 @@ class CallerWorkflow:
     @workflow.update
     async def wait_caller_op_future_resolved(self) -> None:
         await self.caller_op_future_resolved
+
+    @workflow.query
+    def has_caller_op_future_resolved(self) -> bool:
+        return self.caller_op_future_resolved.done()
 
     @workflow.run
     async def run(self, input: Input) -> CancellationResult:
@@ -408,6 +429,17 @@ async def check_behavior_for_wait_cancellation_completed(
     Check that a cancellation request is sent and the caller workflow nexus operation future is
     unblocked after the operation is canceled.
     """
+
+    async def assert_handler_cancel_requested() -> None:
+        assert await handler_wf.query(HandlerWorkflow.has_cancel_requested)
+
+    await assert_eventually(assert_handler_cancel_requested)
+
+    handler_status = (await handler_wf.describe()).status
+    assert handler_status == WorkflowExecutionStatus.RUNNING
+    assert not await caller_wf.query(CallerWorkflow.has_caller_op_future_resolved)
+
+    await handler_wf.signal(HandlerWorkflow.set_release_cancellation)
     try:
         await handler_wf.result()
     except WorkflowFailureError as err:
@@ -418,8 +450,13 @@ async def check_behavior_for_wait_cancellation_completed(
     handler_status = (await handler_wf.describe()).status
     assert handler_status == WorkflowExecutionStatus.CANCELED
 
+    async def assert_caller_op_future_resolved() -> None:
+        assert await caller_wf.query(CallerWorkflow.has_caller_op_future_resolved)
+
+    await assert_eventually(assert_caller_op_future_resolved)
+
     await caller_wf.signal(CallerWorkflow.release)
-    result = await caller_wf.result()
+    await caller_wf.result()
 
     await assert_event_subsequence(
         caller_wf,
@@ -429,14 +466,6 @@ async def check_behavior_for_wait_cancellation_completed(
             EventType.EVENT_TYPE_NEXUS_OPERATION_CANCELED,
             EventType.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED,
         ],
-    )
-    handler_wf_canceled_event = await get_event_time(
-        handler_wf,
-        EventType.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED,
-    )
-    assert handler_wf_canceled_event <= result.caller_op_future_resolved, (
-        "expected caller op future resolved after handler workflow canceled, but got "
-        f"{result.caller_op_future_resolved} before {handler_wf_canceled_event}"
     )
 
 

--- a/tests/nexus/test_workflow_caller_cancellation_types_when_cancel_handler_fails.py
+++ b/tests/nexus/test_workflow_caller_cancellation_types_when_cancel_handler_fails.py
@@ -23,6 +23,7 @@ from temporalio.client import (
 from temporalio.common import WorkflowIDConflictPolicy
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
+from tests.helpers import assert_eventually
 from tests.helpers.nexus import make_nexus_endpoint_name
 from tests.nexus.test_workflow_caller_cancellation_types import (
     assert_event_subsequence,
@@ -48,6 +49,7 @@ class HandlerWorkflow:
     def __init__(self):
         self.cancel_handler_released = asyncio.Event()
         self.caller_op_future_resolved = asyncio.Event()
+        self.release_completion = asyncio.Event()
 
     @workflow.run
     async def run(self) -> None:
@@ -61,6 +63,11 @@ class HandlerWorkflow:
             # For WAIT_REQUESTED, we want to prove that the future can be unblocked before the
             # handler workflow completes.
             await self.caller_op_future_resolved.wait()
+        elif (
+            test_context.cancellation_type
+            == workflow.NexusOperationCancellationType.WAIT_COMPLETED
+        ):
+            await self.release_completion.wait()
 
     @workflow.signal
     def set_cancel_handler_released(self) -> None:
@@ -69,6 +76,14 @@ class HandlerWorkflow:
     @workflow.signal
     def set_caller_op_future_resolved(self) -> None:
         self.caller_op_future_resolved.set()
+
+    @workflow.signal
+    def set_release_completion(self) -> None:
+        self.release_completion.set()
+
+    @workflow.query
+    def has_cancel_handler_released(self) -> bool:
+        return self.cancel_handler_released.is_set()
 
 
 @nexusrpc.service
@@ -152,6 +167,10 @@ class CallerWorkflow:
         await workflow.wait_condition(lambda: self.operation_token is not None)
         assert self.operation_token
         return self.operation_token
+
+    @workflow.query
+    def has_caller_op_future_resolved(self) -> bool:
+        return self.caller_op_future_resolved.done()
 
     @workflow.run
     async def run(self, input: Input) -> CancellationResult:
@@ -370,7 +389,23 @@ async def check_behavior_for_wait_cancellation_completed(
     caller_wf: WorkflowHandle[Any, CancellationResult],
     handler_wf: WorkflowHandle,
 ) -> None:
+    async def assert_cancel_handler_released() -> None:
+        assert await handler_wf.query(HandlerWorkflow.has_cancel_handler_released)
+
+    await assert_eventually(assert_cancel_handler_released)
+
+    handler_status = (await handler_wf.describe()).status
+    assert handler_status == WorkflowExecutionStatus.RUNNING
+    assert not await caller_wf.query(CallerWorkflow.has_caller_op_future_resolved)
+
+    await handler_wf.signal(HandlerWorkflow.set_release_completion)
     await handler_wf.result()
+
+    async def assert_caller_op_future_resolved() -> None:
+        assert await caller_wf.query(CallerWorkflow.has_caller_op_future_resolved)
+
+    await assert_eventually(assert_caller_op_future_resolved)
+
     await caller_wf.signal(CallerWorkflow.release)
     result = await caller_wf.result()
     assert not result.error_type
@@ -386,8 +421,3 @@ async def check_behavior_for_wait_cancellation_completed(
             EventType.EVENT_TYPE_NEXUS_OPERATION_COMPLETED,
         ],
     )
-    handler_wf_completed = await get_event_time(
-        handler_wf,
-        EventType.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED,
-    )
-    assert handler_wf_completed <= result.caller_op_future_resolved

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 import uuid
 from dataclasses import dataclass
 from datetime import timedelta
@@ -6,6 +7,7 @@ from datetime import timedelta
 import pytest
 
 from temporalio import activity, workflow
+from temporalio.api.workflowservice.v1 import GetSystemInfoRequest
 from temporalio.client import (
     ActivityExecutionCount,
     ActivityExecutionCountAggregationGroup,
@@ -459,6 +461,57 @@ async def test_get_result(client: Client, env: WorkflowEnvironment):
     ):
         assert await activity_handle.result() == 2
         assert await result_via_execute_activity == 2
+
+
+async def test_start_activity_start_delay(client: Client, env: WorkflowEnvironment):
+    if env.supports_time_skipping:
+        pytest.skip(
+            "Java test server: https://github.com/temporalio/sdk-java/issues/2741"
+        )
+
+    system_info = await client.workflow_service.get_system_info(GetSystemInfoRequest())
+    try:
+        normalized_server_version = system_info.server_version.split("-", 1)[0].split(
+            "+", 1
+        )[0]
+        server_version = tuple(
+            int(part) for part in normalized_server_version.split(".")[:3]
+        )
+    except ValueError:
+        server_version = None
+    if server_version is not None and server_version <= (1, 31, 0):
+        pytest.skip(
+            "Temporal server 1.31.0 accepts but does not honor standalone activity start_delay"
+        )
+
+    activity_id = str(uuid.uuid4())
+    task_queue = str(uuid.uuid4())
+    start_delay = timedelta(seconds=2)
+
+    async with Worker(
+        client,
+        task_queue=task_queue,
+        activities=[increment],
+    ):
+        started_at = time.monotonic()
+        activity_handle = await client.start_activity(
+            increment,
+            args=(1,),
+            id=activity_id,
+            task_queue=task_queue,
+            start_to_close_timeout=timedelta(seconds=5),
+            start_delay=start_delay,
+        )
+
+        elapsed_after_start = time.monotonic() - started_at
+        if elapsed_after_start < start_delay.total_seconds() - 0.5:
+            desc = await activity_handle.describe()
+            assert desc.status == ActivityExecutionStatus.RUNNING
+            assert desc.run_state == PendingActivityState.SCHEDULED
+            assert desc.last_started_time is None
+
+        assert await activity_handle.result() == 2
+        assert time.monotonic() - started_at >= start_delay.total_seconds() - 0.5
 
 
 async def test_get_activity_handle(client: Client, env: WorkflowEnvironment):

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 import uuid
 from dataclasses import dataclass
 from datetime import timedelta
@@ -7,7 +6,6 @@ from datetime import timedelta
 import pytest
 
 from temporalio import activity, workflow
-from temporalio.api.workflowservice.v1 import GetSystemInfoRequest
 from temporalio.client import (
     ActivityExecutionCount,
     ActivityExecutionCountAggregationGroup,
@@ -469,21 +467,6 @@ async def test_start_activity_start_delay(client: Client, env: WorkflowEnvironme
             "Java test server: https://github.com/temporalio/sdk-java/issues/2741"
         )
 
-    system_info = await client.workflow_service.get_system_info(GetSystemInfoRequest())
-    try:
-        normalized_server_version = system_info.server_version.split("-", 1)[0].split(
-            "+", 1
-        )[0]
-        server_version = tuple(
-            int(part) for part in normalized_server_version.split(".")[:3]
-        )
-    except ValueError:
-        server_version = None
-    if server_version is not None and server_version <= (1, 31, 0):
-        pytest.skip(
-            "Temporal server 1.31.0 accepts but does not honor standalone activity start_delay"
-        )
-
     activity_id = str(uuid.uuid4())
     task_queue = str(uuid.uuid4())
     start_delay = timedelta(seconds=2)
@@ -493,7 +476,6 @@ async def test_start_activity_start_delay(client: Client, env: WorkflowEnvironme
         task_queue=task_queue,
         activities=[increment],
     ):
-        started_at = time.monotonic()
         activity_handle = await client.start_activity(
             increment,
             args=(1,),
@@ -503,15 +485,12 @@ async def test_start_activity_start_delay(client: Client, env: WorkflowEnvironme
             start_delay=start_delay,
         )
 
-        elapsed_after_start = time.monotonic() - started_at
-        if elapsed_after_start < start_delay.total_seconds() - 0.5:
-            desc = await activity_handle.describe()
-            assert desc.status == ActivityExecutionStatus.RUNNING
-            assert desc.run_state == PendingActivityState.SCHEDULED
-            assert desc.last_started_time is None
-
         assert await activity_handle.result() == 2
-        assert time.monotonic() - started_at >= start_delay.total_seconds() - 0.5
+        desc = await activity_handle.describe()
+        assert desc.last_started_time is not None
+        assert (
+            desc.last_started_time - desc.scheduled_time
+        ).total_seconds() >= start_delay.total_seconds() - 0.5
 
 
 async def test_get_activity_handle(client: Client, env: WorkflowEnvironment):


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added an integration test for the `start_delay` parameter to standalone activities.

## Why?
There's no existing integration test verifying that the `start_delay` parameter is actually respected.

## Checklist

1. Closes (none)

2. How was this tested:
Integration test was run against the `v1.7.1-standalone-nexus-operations` tag from temporalio/cli

3. Any docs updates needed?
No
