### PR TITLE
[backport 1.25.1] Update core to pickup shutdown fix 

### DIFF
--- a/temporalio/bridge/src/worker.rs
+++ b/temporalio/bridge/src/worker.rs
@@ -684,6 +684,7 @@ impl WorkerRef {
     }
 
     fn initiate_shutdown(&self) -> PyResult<()> {
+        enter_sync!(self.runtime);
         let worker = self.worker.as_ref().unwrap().clone();
         worker.initiate_shutdown();
         Ok(())


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Pick up shutdown fix cherry-pick for v1.14.1 patch release, https://github.com/temporalio/sdk-rust/pull/1259

## Why?
<!-- Tell your future self why have you made these changes -->
fix shutdown bug

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-line change aligning `initiate_shutdown` with other sync worker methods to avoid shutdown being triggered outside the Tokio runtime context.
> 
> **Overview**
> Fixes a shutdown edge case in the Python bridge by adding `enter_sync!(self.runtime);` to `WorkerRef::initiate_shutdown`, ensuring the Tokio runtime (and trace subscriber) is set up on the calling thread before invoking core shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6236de6aa2fae039d60018cbf1451dc8010fc8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->