### PR TITLE
[backport 1.26.1] Update core to pickup shutdown fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 grpc = ["grpcio>=1.48.2,<2"]
 opentelemetry = ["opentelemetry-api>=1.11.1,<2", "opentelemetry-sdk>=1.11.1,<2"]
 pydantic = ["pydantic>=2.0.0,<3"]
-openai-agents = ["openai-agents>=0.14.0", "mcp>=1.9.4, <2"]
+openai-agents = ["openai-agents>=0.17.1", "mcp>=1.9.4, <2"]
 google-adk = ["google-adk>=1.27.0,<2"]
 langsmith = ["langsmith>=0.7.0,<0.8"]
 lambda-worker-otel = [
@@ -79,7 +79,7 @@ dev = [
   "pytest-rerunfailures>=16.1",
   "pytest-xdist>=3.6,<4",
   "moto[s3,server]>=5",
-  "langsmith>=0.7.0,<0.8",
+  "langsmith>=0.7.0,<0.7.34",
   "setuptools<82",
   "opentelemetry-exporter-otlp-proto-grpc>=1.11.1,<2",
   "opentelemetry-semantic-conventions>=0.40b0,<1",

--- a/temporalio/bridge/src/worker.rs
+++ b/temporalio/bridge/src/worker.rs
@@ -684,6 +684,7 @@ impl WorkerRef {
     }
 
     fn initiate_shutdown(&self) -> PyResult<()> {
+        enter_sync!(self.runtime);
         let worker = self.worker.as_ref().unwrap().clone();
         worker.initiate_shutdown();
         Ok(())

--- a/temporalio/contrib/openai_agents/_temporal_trace_provider.py
+++ b/temporalio/contrib/openai_agents/_temporal_trace_provider.py
@@ -124,8 +124,8 @@ class _TemporalTracingProcessor(SynchronousMultiTracingProcessor):
 
         self._impl.on_span_end(span)
 
-    def shutdown(self) -> None:
-        self._impl.shutdown()
+    def shutdown(self, timeout: float | None = None) -> None:
+        self._impl.shutdown(timeout)
 
     def force_flush(self) -> None:
         self._impl.force_flush()

--- a/uv.lock
+++ b/uv.lock
@@ -3298,7 +3298,7 @@ wheels = [
 
 [[package]]
 name = "openai-agents"
-version = "0.14.0"
+version = "0.17.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffelib" },
@@ -3310,9 +3310,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/3c/965968ab53d6afc1d6e4223b6b2e8cdfca15f39fdcc20cfe5dd526ea99f4/openai_agents-0.14.0.tar.gz", hash = "sha256:d82cbafbeea5b189712c243664552268df16082fa14f1778af40f706eb976692", size = 5192284, upload-time = "2026-04-15T17:12:10.191Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/cd/14acaf94c6a438cfe72c5ea043bfbc77d7fbb9514ab7796d82f2180d1518/openai_agents-0.17.2.tar.gz", hash = "sha256:5e11414bdd8c20c8e9192d21f78265d30e65992f4537f940309eca9255804449", size = 5403689, upload-time = "2026-05-12T03:14:57.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/3e/0be9a884d3b770114572e0be101ab8adb04a7f1a99620261e7393b72a655/openai_agents-0.14.0-py3-none-any.whl", hash = "sha256:5a1dad74de95970efbf4a3f89dfd50d6a22202d9105b81d7abb25a0be3d493c7", size = 795734, upload-time = "2026-04-15T17:12:08.001Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/71/5ba9afa4b6a0d250bfdbdd1cf9a5255ae131a7f82915c634ac50c0633c3a/openai_agents-0.17.2-py3-none-any.whl", hash = "sha256:1b3560c1690bcee635a487f77ebfb8b4fb2dd52a653e045a86e51974ab87faf3", size = 838225, upload-time = "2026-05-12T03:14:55.149Z" },
 ]
 
 [package.optional-dependencies]
@@ -5099,7 +5099,7 @@ requires-dist = [
     { name = "langsmith", marker = "extra == 'langsmith'", specifier = ">=0.7.0,<0.8" },
     { name = "mcp", marker = "extra == 'openai-agents'", specifier = ">=1.9.4,<2" },
     { name = "nexus-rpc", specifier = "==1.4.0" },
-    { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.14.0" },
+    { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.17.1" },
     { name = "opentelemetry-api", marker = "extra == 'lambda-worker-otel'", specifier = ">=1.11.1,<2" },
     { name = "opentelemetry-api", marker = "extra == 'opentelemetry'", specifier = ">=1.11.1,<2" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'lambda-worker-otel'", specifier = ">=1.11.1,<2" },
@@ -5123,7 +5123,7 @@ dev = [
     { name = "googleapis-common-protos", specifier = "==1.70.0" },
     { name = "grpcio-tools", specifier = ">=1.48.2,<2" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "langsmith", specifier = ">=0.7.0,<0.8" },
+    { name = "langsmith", specifier = ">=0.7.0,<0.7.34" },
     { name = "litellm", specifier = ">=1.83.0" },
     { name = "maturin", specifier = ">=1.8.2" },
     { name = "moto", extras = ["s3", "server"], specifier = ">=5" },


### PR DESCRIPTION
## What was changed
Pick up shutdown fix cherry-pick for v1.14.1 patch release, https://github.com/temporalio/sdk-rust/pull/1256

## Why?
bug fix

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches worker shutdown sequencing in the Rust bridge and bumps third-party tracing dependencies; regressions could surface as shutdown hangs/errors or integration incompatibilities.
> 
> **Overview**
> Ensures `WorkerRef.initiate_shutdown` in the Rust bridge enters the Tokio runtime (`enter_sync!`) before triggering core shutdown, aligning shutdown calls with other synchronous bridge methods.
> 
> Updates dependency constraints and lockfile: bumps the optional `openai-agents` extra to `>=0.17.1` (lock to `0.17.2`), adjusts the OpenAI Agents trace provider `shutdown` signature to accept an optional `timeout`, and tightens the dev `langsmith` upper bound to `<0.7.34`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea22cfdfa74500ff56c430750d5e4443aad8ec3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->