### PR TITLE
fix: pre-bind handle variables to avoid Python 3.14 NameError in closure cells

### DIFF
--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -1887,7 +1887,11 @@ class _WorkflowInstanceImpl(  # type: ignore[reportImplicitAbstractClass]
                 "Activity must have start_to_close_timeout or schedule_to_close_timeout"
             )
 
-        handle: _ActivityHandle
+        # Pre-bind handle to None so the closure cell is not empty when
+        # Python 3.14's asyncio.Task inspects it eagerly during task naming.
+        # The coroutine only executes after the real _ActivityHandle is assigned
+        # below, so handle is always the correct object by the time it is used.
+        handle = cast(_ActivityHandle, None)
 
         # Function that runs in the handle
         async def run_activity() -> Any:
@@ -1977,7 +1981,9 @@ class _WorkflowInstanceImpl(  # type: ignore[reportImplicitAbstractClass]
     async def _outbound_start_child_workflow(
         self, input: StartChildWorkflowInput
     ) -> _ChildWorkflowHandle:
-        handle: _ChildWorkflowHandle
+        # Pre-bind handle to None so the closure cell is not empty when
+        # Python 3.14's asyncio.Task inspects it eagerly during task naming.
+        handle = cast(_ChildWorkflowHandle, None)
 
         # Common code for handling cancel for start and run
         def apply_child_cancel_error() -> None:
@@ -2042,7 +2048,9 @@ class _WorkflowInstanceImpl(  # type: ignore[reportImplicitAbstractClass]
         # resolved with an operation token). See comments in tests/worker/test_nexus.py for worked
         # examples of the evolution of the resulting handle state machine in the sync and async
         # Nexus response cases.
-        handle: _NexusOperationHandle[OutputT]
+        # Pre-bind handle to None so the closure cell is not empty when
+        # Python 3.14's asyncio.Task inspects it eagerly during task naming.
+        handle = cast(_NexusOperationHandle[OutputT], None)
 
         async def operation_handle_fn() -> OutputT:
             while True:


### PR DESCRIPTION
## Summary

Closes #1517.

Python 3.14 changed `asyncio.Task` to **eagerly inspect a coroutine's closure cells** when `task.set_name()` is called (CPython [gh-126004](https://github.com/python/cpython/issues/126004)). If a cell is unbound at that moment the interpreter raises:

```
NameError: cannot access free variable 'handle' where it is not
associated with a value in enclosing scope
```

Three methods in `_workflow_instance.py` had this pattern:

```python
handle: _ActivityHandle          # annotation only — cell is EMPTY

async def run_activity() -> Any:
    handle._started = True       # closure over the empty cell

handle = _ActivityHandle(self, input, run_activity())
# ↑ constructor calls _register_task → task.set_name()
#   Python 3.14 inspects run_activity's cells → NameError
```

The same pattern exists in `_outbound_start_child_workflow` (`_ChildWorkflowHandle`) and `_outbound_start_nexus_operation` (`_NexusOperationHandle`).

## Fix

Replace the bare annotation with a `cast`-annotated assignment:

```python
handle = cast(_ActivityHandle, None)   # cell is now BOUND (to None)
```

`cast` is already imported; it is a no-op at runtime (returns its second argument) but preserves the static type. By the time the coroutine actually runs, the outer `handle = _ActivityHandle(...)` line has completed and the variable holds the real object, so no code ever observes the temporary `None`.

## Changes

`temporalio/worker/_workflow_instance.py`

| Location | Handle type | Change |
|---|---|---|
| `_outbound_schedule_activity` | `_ActivityHandle` | `handle: _ActivityHandle` → `handle = cast(_ActivityHandle, None)` |
| `_outbound_start_child_workflow` | `_ChildWorkflowHandle` | same pattern |
| `_outbound_start_nexus_operation` | `_NexusOperationHandle[OutputT]` | same pattern |

## Test plan

- [x] Reproducer from #1517 no longer raises `NameError` on Python 3.14
- [x] Existing unit tests pass (`python -m pytest tests/`)
- [x] No changes to public API or wire protocol