### PR TITLE
Format LangSmith tracing env override test

### DIFF
--- a/tests/contrib/langsmith/test_tracing_env_override.py
+++ b/tests/contrib/langsmith/test_tracing_env_override.py
@@ -238,6 +238,6 @@ class TestTracingEnvOverride:
             result = await handle.result()
 
         assert result == "response to: hello"
-        assert (
-            len(collector.runs) > 0
-        ), "Expected LangSmith runs when LANGSMITH_TRACING=true, but got none"
+        assert len(collector.runs) > 0, (
+            "Expected LangSmith runs when LANGSMITH_TRACING=true, but got none"
+        )


### PR DESCRIPTION
## Summary
- Apply Ruff formatting to tests/contrib/langsmith/test_tracing_env_override.py

## Validation
- uv run ruff format --check tests/contrib/langsmith/test_tracing_env_override.py
- uv run ruff check --select I tests/contrib/langsmith/test_tracing_env_override.py