### PR TITLE
Fix ruff format in test_tracing_env_override.py

### DIFF
--- a/tests/contrib/langsmith/test_tracing_env_override.py
+++ b/tests/contrib/langsmith/test_tracing_env_override.py
@@ -238,6 +238,6 @@ class TestTracingEnvOverride:
             result = await handle.result()
 
         assert result == "response to: hello"
-        assert (
-            len(collector.runs) > 0
-        ), "Expected LangSmith runs when LANGSMITH_TRACING=true, but got none"
+        assert len(collector.runs) > 0, (
+            "Expected LangSmith runs when LANGSMITH_TRACING=true, but got none"
+        )


### PR DESCRIPTION
## Summary
- Reformat `tests/contrib/langsmith/test_tracing_env_override.py` to satisfy `ruff format --check` (added in `92cab10e`).

## Test plan
- [x] `uv run poe lint` passes