### PR TITLE
Release 1.25.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "temporalio"
-version = "1.25.0"
+version = "1.25.1"
 description = "Temporal.io Python SDK"
 authors = [{ name = "Temporal Technologies Inc", email = "sdk@temporal.io" }]
 requires-python = ">=3.10"

--- a/temporalio/service.py
+++ b/temporalio/service.py
@@ -24,7 +24,7 @@ import temporalio.exceptions
 import temporalio.runtime
 from temporalio.bridge.client import RPCError as BridgeRPCError
 
-__version__ = "1.25.0"
+__version__ = "1.25.1"
 
 ServiceRequest = TypeVar("ServiceRequest", bound=google.protobuf.message.Message)
 ServiceResponse = TypeVar("ServiceResponse", bound=google.protobuf.message.Message)

--- a/uv.lock
+++ b/uv.lock
@@ -4912,7 +4912,7 @@ wheels = [
 
 [[package]]
 name = "temporalio"
-version = "1.25.0"
+version = "1.25.1"
 source = { virtual = "." }
 dependencies = [
     { name = "nexus-rpc" },


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Bump to 1.25.1

## Why?
Backport patch release to add cherry-picked commit from core for a poller shutdown fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates version metadata in the package config, runtime `__version__`, and lockfile, with no functional code changes.
> 
> **Overview**
> Bumps the SDK release from `1.25.0` to `1.25.1` by updating the version in `pyproject.toml`, `temporalio/service.py` (`__version__`), and `uv.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b11baaa8c5ebfc16084957501c9a7d6cbd04ed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->