### PR TITLE
release 1.24.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "temporalio"
-version = "1.24.1"
+version = "1.24.2"
 description = "Temporal.io Python SDK"
 authors = [{ name = "Temporal Technologies Inc", email = "sdk@temporal.io" }]
 requires-python = ">=3.10"

--- a/temporalio/service.py
+++ b/temporalio/service.py
@@ -24,7 +24,7 @@ import temporalio.exceptions
 import temporalio.runtime
 from temporalio.bridge.client import RPCError as BridgeRPCError
 
-__version__ = "1.24.1"
+__version__ = "1.24.2"
 
 ServiceRequest = TypeVar("ServiceRequest", bound=google.protobuf.message.Message)
 ServiceResponse = TypeVar("ServiceResponse", bound=google.protobuf.message.Message)

--- a/uv.lock
+++ b/uv.lock
@@ -4386,7 +4386,7 @@ wheels = [
 
 [[package]]
 name = "temporalio"
-version = "1.24.1"
+version = "1.24.2"
 source = { virtual = "." }
 dependencies = [
     { name = "nexus-rpc" },


### PR DESCRIPTION
## What was changed
Bump to 1.24.2

## Why?
Fix bad dep ceiling

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping change limited to version metadata and `uv.lock` updates; no runtime logic changes beyond reporting the new version.
> 
> **Overview**
> Updates the SDK release version from `1.24.1` to `1.24.2` in `pyproject.toml` and `temporalio/service.py` (`__version__`).
> 
> Refreshes `uv.lock` to reflect the new package version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9684f8633249526dc7223658785d09f863fe691. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->