### PR TITLE
(CI) Disable caching cargo binaries

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -45,6 +45,7 @@ jobs:
       - if: ${{ runner.os != 'Linux' }}
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           workspaces: temporalio/bridge -> target
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
       - run: uv sync --all-extras

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           components: "clippy"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           workspaces: temporalio/bridge -> target
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -111,6 +112,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           workspaces: temporalio/bridge -> target
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -147,6 +149,7 @@ jobs:
           components: "clippy"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           workspaces: temporalio/bridge -> target
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -185,6 +188,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           workspaces: temporalio/bridge -> target
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:

--- a/.github/workflows/nightly-throughput-stress.yml
+++ b/.github/workflows/nightly-throughput-stress.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           workspaces: temporalio/bridge -> target
 
       - name: Setup Python

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -37,6 +37,7 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           workspaces: temporalio/bridge -> target
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Sets `cache-bin: false` option in `Swatinem/rust-cache` GH action to disable caching

## Why?
<!-- Tell your future self why have you made these changes -->
Mitigates macos runner issue: https://github.com/actions/runner-images/issues/14097

Also since we're using `dtolnay/rust-toolchain` action, we shouldn't cache cargo/rustc binaries anyway.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
A similar PR fixed problems in .Net SDK: https://github.com/temporalio/sdk-dotnet/pull/695