### PR TITLE
Release 1.26.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "temporalio"
-version = "1.26.0"
+version = "1.26.1"
 description = "Temporal.io Python SDK"
 authors = [{ name = "Temporal Technologies Inc", email = "sdk@temporal.io" }]
 requires-python = ">=3.10"

--- a/temporalio/service.py
+++ b/temporalio/service.py
@@ -24,7 +24,7 @@ import temporalio.exceptions
 import temporalio.runtime
 from temporalio.bridge.client import RPCError as BridgeRPCError
 
-__version__ = "1.26.0"
+__version__ = "1.26.1"
 
 ServiceRequest = TypeVar("ServiceRequest", bound=google.protobuf.message.Message)
 ServiceResponse = TypeVar("ServiceResponse", bound=google.protobuf.message.Message)

--- a/uv.lock
+++ b/uv.lock
@@ -5011,7 +5011,7 @@ wheels = [
 
 [[package]]
 name = "temporalio"
-version = "1.26.0"
+version = "1.26.1"
 source = { virtual = "." }
 dependencies = [
     { name = "nexus-rpc" },


### PR DESCRIPTION
## What was changed
Bump to 1.26.1

## Why?
Backport patch release to add cherry-picked commit from core for a poller shutdown fix.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates package/version metadata and the lockfile, with no functional code changes beyond the reported version string.
> 
> **Overview**
> Bumps the SDK release from **1.26.0** to **1.26.1** by updating the version in `pyproject.toml` and the runtime `__version__` in `temporalio/service.py`.
> 
> Updates `uv.lock` to reflect the new local package version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 093d4734c064a57f580fdb45104bcbfc352584fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->