### PR TITLE
Stress Nexus WAIT_COMPLETED cancellation test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   # Build and test the project
   build-lint-test:
+    if: ${{ false }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -144,6 +145,7 @@ jobs:
           done
 
   check-protos:
+    if: ${{ false }}
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
@@ -179,6 +181,7 @@ jobs:
           TEMPORAL_TEST_PROTO3: 1
 
   test-latest-deps:
+    if: ${{ false }}
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
@@ -219,7 +222,7 @@ jobs:
 
   # Run tests against Temporal Cloud (skipped on forks)
   cloud-test:
-    if: ${{ github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-python' }}
+    if: ${{ false }}
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
@@ -263,6 +266,7 @@ jobs:
 
   # Runs the sdk features repo tests with this repo's current SDK code
   features-tests:
+    if: ${{ false }}
     uses: temporalio/features/.github/workflows/python.yaml@main
     with:
       python-repo-path: ${{github.event.pull_request.head.repo.full_name}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,47 @@ jobs:
           npx doctoc README.md
           [[ -z $(git status --porcelain README.md) ]] || (git diff README.md; echo "README changed"; exit 1)
 
+  nexus-wait-completed-cancellation-stress:
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.14"]
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-bin: false
+          workspaces: temporalio/bridge -> target
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+        with:
+          # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed
+          version: "23.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
+      - run: uv tool install poethepoet
+      - run: uv sync --all-extras
+      - run: poe build-develop
+      - name: Stress test Nexus WAIT_COMPLETED cancellation ordering
+        shell: bash
+        run: |
+          for i in $(seq 1 50); do
+            echo "::group::WAIT_COMPLETED stress iteration ${i}"
+            poe test \
+              -s \
+              --workflow-environment time-skipping \
+              "tests/nexus/test_workflow_caller_cancellation_types.py::test_cancellation_type[WAIT_COMPLETED]"
+            echo "::endgroup::"
+          done
+
   check-protos:
     timeout-minutes: 30
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,16 +152,9 @@ jobs:
       - run: uv sync --all-extras
       - run: poe build-develop
       - name: Stress test Nexus WAIT_COMPLETED cancellation ordering
-        shell: bash
-        run: |
-          for i in $(seq 1 100); do
-            echo "::group::WAIT_COMPLETED stress iteration ${i} (${{ matrix.workflowEnvironment }})"
-            uv run pytest \
-              -s \
-              --workflow-environment "${{ matrix.workflowEnvironment }}" \
-              "tests/nexus/test_workflow_caller_cancellation_types.py::test_cancellation_type[WAIT_COMPLETED]"
-            echo "::endgroup::"
-          done
+        run: uv run pytest -s --workflow-environment "${{ matrix.workflowEnvironment }}" "tests/nexus/test_workflow_caller_cancellation_types.py::test_cancellation_type[WAIT_COMPLETED]"
+        env:
+          TEMPORAL_NEXUS_CANCELLATION_STRESS_RUNS: 100
 
   check-protos:
     if: ${{ false }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Stress test Nexus WAIT_COMPLETED cancellation ordering
         shell: bash
         run: |
-          for i in $(seq 1 30); do
+          for i in $(seq 1 100); do
             echo "::group::WAIT_COMPLETED stress iteration ${i} (${{ matrix.workflowEnvironment }})"
             uv run pytest \
               -s \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,13 +104,32 @@ jobs:
           [[ -z $(git status --porcelain README.md) ]] || (git diff README.md; echo "README changed"; exit 1)
 
   nexus-wait-completed-cancellation-stress:
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10", "3.14"]
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+        include:
+          - python: "3.10"
+            os: ubuntu-latest
+            workflowEnvironment: local
+          - python: "3.14"
+            os: ubuntu-latest
+            workflowEnvironment: time-skipping
+          - python: "3.10"
+            os: windows-latest
+            workflowEnvironment: local
+          - python: "3.14"
+            os: windows-latest
+            workflowEnvironment: time-skipping
+          - python: "3.10"
+            os: macos-intel
+            runsOn: macos-15-intel
+            workflowEnvironment: local
+          - python: "3.14"
+            os: macos-intel
+            runsOn: macos-15-intel
+            workflowEnvironment: time-skipping
+    runs-on: ${{ matrix.runsOn || matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -135,11 +154,11 @@ jobs:
       - name: Stress test Nexus WAIT_COMPLETED cancellation ordering
         shell: bash
         run: |
-          for i in $(seq 1 50); do
-            echo "::group::WAIT_COMPLETED stress iteration ${i}"
-            poe test \
+          for i in $(seq 1 30); do
+            echo "::group::WAIT_COMPLETED stress iteration ${i} (${{ matrix.workflowEnvironment }})"
+            uv run pytest \
               -s \
-              --workflow-environment time-skipping \
+              --workflow-environment "${{ matrix.workflowEnvironment }}" \
               "tests/nexus/test_workflow_caller_cancellation_types.py::test_cancellation_type[WAIT_COMPLETED]"
             echo "::endgroup::"
           done

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-DEV_SERVER_DOWNLOAD_VERSION = "v1.7.0"
+DEV_SERVER_DOWNLOAD_VERSION = "v1.7.1-standalone-nexus-operations"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,8 @@ async def env(env_type: str) -> AsyncGenerator[WorkflowEnvironment, None]:
                 "--dynamic-config-value",
                 "activity.enableStandalone=true",
                 "--dynamic-config-value",
+                "activity.startDelayEnabled=true",
+                "--dynamic-config-value",
                 "history.enableChasm=true",
                 "--dynamic-config-value",
                 "history.enableTransitionHistory=true",

--- a/tests/nexus/test_workflow_caller_cancellation_types.py
+++ b/tests/nexus/test_workflow_caller_cancellation_types.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -235,6 +236,20 @@ class CallerWorkflow:
     ],
 )
 async def test_cancellation_type(
+    env: WorkflowEnvironment,
+    cancellation_type_name: str,
+):
+    stress_runs = int(os.getenv("TEMPORAL_NEXUS_CANCELLATION_STRESS_RUNS", "1"))
+    for i in range(stress_runs):
+        if stress_runs > 1:
+            print(
+                f"WAIT_COMPLETED cancellation stress iteration "
+                f"{i + 1}/{stress_runs}"
+            )
+        await _run_cancellation_type_test(env, cancellation_type_name)
+
+
+async def _run_cancellation_type_test(
     env: WorkflowEnvironment,
     cancellation_type_name: str,
 ):


### PR DESCRIPTION
Adds a temporary CI stress job for investigating flaky Nexus WAIT_COMPLETED cancellation ordering.\n\nThe new job runs:\n\n```\npoe test -s --workflow-environment time-skipping tests/nexus/test_workflow_caller_cancellation_types.py::test_cancellation_type[WAIT_COMPLETED]\n```\n\n50 times across Python 3.10/3.14 on ubuntu-latest and windows-latest. This is intended to make the observed CI failure more reliable before applying a fix.