### PR TITLE
Fix link to workflow streams docs

### DIFF
--- a/temporalio/contrib/workflow_streams/README.md
+++ b/temporalio/contrib/workflow_streams/README.md
@@ -22,7 +22,7 @@ that hand stream state across Workflow runs.
 ## Documentation
 
 📖 **The full guide lives in the Temporal documentation site:**
-**[Workflow Streams — Python SDK](https://docs.temporal.io/develop/python/libraries/workflow-streams)**
+**[Workflow Streams — Python SDK](https://docs.temporal.io/develop/python/workflows/workflow-streams)**
 
 It covers installation, enabling streaming on a Workflow, publishing from
 Workflows and Activities, subscribing, continue-as-new, delivery semantics,


### PR DESCRIPTION
WISOTT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a README hyperlink; no runtime or API behavior is affected.
> 
> **Overview**
> Updates the `temporalio/contrib/workflow_streams` README to point the **Workflow Streams** documentation link to the new `.../develop/python/workflows/workflow-streams` URL instead of the old `.../develop/python/libraries/workflow-streams` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f4b8b1416a5a47fcc70c42e3d1709c1f4857c21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->