### PR TITLE
Address Flake in test_workflow_history_info

### DIFF
--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -329,6 +329,24 @@ async def test_workflow_history_info(
         await handle.signal(
             HistoryInfoWorkflow.bunch_of_events, continue_as_new_suggest_history_count
         )
+
+        # Wait for the first signal's timers to be committed so the next
+        # signal creates a post-timer workflow task with updated workflow.info().
+        # This avoids a race where both signals are accepted before the worker
+        # processes the first one and both make it into the same activation.
+        # If that occurs, the query will have the stale history that the
+        # final signal is intended to avoid.
+        async def timer_events_recorded() -> None:
+            timer_started_count = 0
+            async for event in handle.fetch_history_events():
+                if event.HasField("timer_started_event_attributes"):
+                    timer_started_count += 1
+                    if timer_started_count >= continue_as_new_suggest_history_count:
+                        return
+            assert timer_started_count >= continue_as_new_suggest_history_count
+
+        await assert_eventually(timer_events_recorded)
+
         # Send one more event to trigger the WFT update. We have to do this
         # because just a query will have a stale representation of history
         # counts, but signal forces a new WFT.


### PR DESCRIPTION
Add polling for expected history before sending final signal in test_workflow_history_info

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Wait for the first signal's timers to be committed so the next signal creates a post-timer workflow task with updated workflow.info().

## Why?
<!-- Tell your future self why have you made these changes -->

This avoids a race where both signals are accepted before the worker processes the first one and both make it into the same activation. If that occurs, the query will have the stale history that the final signal is intended to avoid.


## Checklist

1. How was this tested?

I created a repro locally that:
1. started the workflow
2. shut down the worker so nothing was polling
3. Sent both signals ensuring they'd be batched together
4. started a new worker and performed the query

After reproducing that way, I was able to confirm the fix that waiting for the signals to appear in history before sending the second signal addressed the issue.

