### PR TITLE
Narrow overloads on the SANO client

### DIFF
--- a/temporalio/client/_nexus.py
+++ b/temporalio/client/_nexus.py
@@ -484,7 +484,6 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         id: str,
         id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
         id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
-        result_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
         schedule_to_start_timeout: timedelta | None = None,
         start_to_close_timeout: timedelta | None = None,
@@ -531,7 +530,6 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         id: str,
         id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
         id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
-        result_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
         schedule_to_start_timeout: timedelta | None = None,
         start_to_close_timeout: timedelta | None = None,
@@ -556,7 +554,6 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         id: str,
         id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
         id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
-        result_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
         schedule_to_start_timeout: timedelta | None = None,
         start_to_close_timeout: timedelta | None = None,
@@ -581,7 +578,6 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         id: str,
         id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
         id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
-        result_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
         schedule_to_start_timeout: timedelta | None = None,
         start_to_close_timeout: timedelta | None = None,
@@ -605,7 +601,6 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         id: str,
         id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
         id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
-        result_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
         schedule_to_start_timeout: timedelta | None = None,
         start_to_close_timeout: timedelta | None = None,
@@ -647,7 +642,8 @@ class NexusClient(ABC, Generic[NexusServiceType]):
             id: Unique identifier for this operation.
             id_reuse_policy: Policy for reusing operation IDs.
             id_conflict_policy: Policy for handling ID conflicts.
-            result_type: The result type to deserialize into.
+            result_type: For string operation names, this can set the specific
+                result type hint to deserialize into.
             schedule_to_close_timeout: End-to-end timeout for the Nexus
                 operation. If unset, defaults to the maximum allowed by the
                 Temporal server.
@@ -680,7 +676,6 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         id: str,
         id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
         id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
-        result_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
         schedule_to_start_timeout: timedelta | None = None,
         start_to_close_timeout: timedelta | None = None,
@@ -727,7 +722,6 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         id: str,
         id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
         id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
-        result_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
         schedule_to_start_timeout: timedelta | None = None,
         start_to_close_timeout: timedelta | None = None,
@@ -752,7 +746,6 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         id: str,
         id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
         id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
-        result_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
         schedule_to_start_timeout: timedelta | None = None,
         start_to_close_timeout: timedelta | None = None,
@@ -777,7 +770,6 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         id: str,
         id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
         id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
-        result_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
         schedule_to_start_timeout: timedelta | None = None,
         start_to_close_timeout: timedelta | None = None,
@@ -802,7 +794,6 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         id: str,
         id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
         id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
-        result_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
         schedule_to_start_timeout: timedelta | None = None,
         start_to_close_timeout: timedelta | None = None,
@@ -846,7 +837,8 @@ class NexusClient(ABC, Generic[NexusServiceType]):
             id: Unique identifier for this operation.
             id_reuse_policy: Policy for reusing operation IDs.
             id_conflict_policy: Policy for handling ID conflicts.
-            result_type: The result type to deserialize into.
+            result_type: For string operation names, this can set the specific
+                result type hint to deserialize into.
             schedule_to_close_timeout: End-to-end timeout for the Nexus
                 operation. If unset, defaults to the maximum allowed by the
                 Temporal server.
@@ -933,7 +925,9 @@ class _NexusClient(NexusClient[NexusServiceType]):  # pyright: ignore[reportUnus
            This API is experimental and unstable.
         """
         op_name, output_type = self._resolve_operation(operation)
-        final_result_type: type | None = result_type or output_type
+        final_result_type: type | None = (
+            result_type if isinstance(operation, str) else output_type
+        )
 
         return await self._client._impl.start_nexus_operation(
             StartNexusOperationInput(

--- a/temporalio/client/_nexus.py
+++ b/temporalio/client/_nexus.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Generic, cast, overload
@@ -473,7 +473,7 @@ class NexusClient(ABC, Generic[NexusServiceType]):
     Use :py:meth:`Client.create_nexus_client` to create a client.
     """
 
-    # Overload for nexusrpc.Operation with input
+    # Overload for nexusrpc.Operation
     @overload
     @abstractmethod
     async def start_operation(
@@ -484,6 +484,7 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         id: str,
         id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
         id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
+        result_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
         schedule_to_start_timeout: timedelta | None = None,
         start_to_close_timeout: timedelta | None = None,
@@ -494,50 +495,7 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         rpc_timeout: timedelta | None = None,
     ) -> NexusOperationHandle[OutputT]: ...
 
-    # Overload for Callable with result_type
-    @overload
-    @abstractmethod
-    async def start_operation(
-        self,
-        operation: Callable[..., Any],
-        arg: Any,
-        *,
-        id: str,
-        id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
-        id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
-        result_type: type[OutputT],
-        schedule_to_close_timeout: timedelta | None = None,
-        schedule_to_start_timeout: timedelta | None = None,
-        start_to_close_timeout: timedelta | None = None,
-        search_attributes: temporalio.common.TypedSearchAttributes | None = None,
-        summary: str | None = None,
-        headers: Mapping[str, str] | None = None,
-        rpc_metadata: Mapping[str, str | bytes] = {},
-        rpc_timeout: timedelta | None = None,
-    ) -> NexusOperationHandle[OutputT]: ...
-
-    # Overload for Callable without result_type
-    @overload
-    @abstractmethod
-    async def start_operation(
-        self,
-        operation: Callable[..., Any],
-        arg: Any,
-        *,
-        id: str,
-        id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
-        id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
-        schedule_to_close_timeout: timedelta | None = None,
-        schedule_to_start_timeout: timedelta | None = None,
-        start_to_close_timeout: timedelta | None = None,
-        search_attributes: temporalio.common.TypedSearchAttributes | None = None,
-        summary: str | None = None,
-        headers: Mapping[str, str] | None = None,
-        rpc_metadata: Mapping[str, str | bytes] = {},
-        rpc_timeout: timedelta | None = None,
-    ) -> NexusOperationHandle[Any]: ...
-
-    # Overload for str with result_type
+    # Overload for string operation name
     @overload
     @abstractmethod
     async def start_operation(
@@ -548,7 +506,7 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         id: str,
         id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
         id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
-        result_type: type[OutputT],
+        result_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
         schedule_to_start_timeout: timedelta | None = None,
         start_to_close_timeout: timedelta | None = None,
@@ -559,17 +517,21 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         rpc_timeout: timedelta | None = None,
     ) -> NexusOperationHandle[OutputT]: ...
 
-    # Overload for str without result_type
+    # Overload for workflow_run_operation methods
     @overload
     @abstractmethod
     async def start_operation(
         self,
-        operation: str,
-        arg: Any,
+        operation: Callable[
+            [NexusServiceType, temporalio.nexus.WorkflowRunOperationContext, InputT],
+            Awaitable[temporalio.nexus.WorkflowHandle[OutputT]],
+        ],
+        arg: InputT,
         *,
         id: str,
         id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
         id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
+        result_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
         schedule_to_start_timeout: timedelta | None = None,
         start_to_close_timeout: timedelta | None = None,
@@ -578,7 +540,81 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         headers: Mapping[str, str] | None = None,
         rpc_metadata: Mapping[str, str | bytes] = {},
         rpc_timeout: timedelta | None = None,
-    ) -> NexusOperationHandle[Any]: ...
+    ) -> NexusOperationHandle[OutputT]: ...
+
+    # Overload for sync_operation methods (async def)
+    @overload
+    @abstractmethod
+    async def start_operation(
+        self,
+        operation: Callable[
+            [NexusServiceType, nexusrpc.handler.StartOperationContext, InputT],
+            Awaitable[OutputT],
+        ],
+        arg: InputT,
+        *,
+        id: str,
+        id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
+        id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
+        result_type: type[OutputT] | None = None,
+        schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
+        search_attributes: temporalio.common.TypedSearchAttributes | None = None,
+        summary: str | None = None,
+        headers: Mapping[str, str] | None = None,
+        rpc_metadata: Mapping[str, str | bytes] = {},
+        rpc_timeout: timedelta | None = None,
+    ) -> NexusOperationHandle[OutputT]: ...
+
+    # Overload for sync_operation methods (def)
+    @overload
+    @abstractmethod
+    async def start_operation(
+        self,
+        operation: Callable[
+            [NexusServiceType, nexusrpc.handler.StartOperationContext, InputT],
+            OutputT,
+        ],
+        arg: InputT,
+        *,
+        id: str,
+        id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
+        id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
+        result_type: type[OutputT] | None = None,
+        schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
+        search_attributes: temporalio.common.TypedSearchAttributes | None = None,
+        summary: str | None = None,
+        headers: Mapping[str, str] | None = None,
+        rpc_metadata: Mapping[str, str | bytes] = {},
+        rpc_timeout: timedelta | None = None,
+    ) -> NexusOperationHandle[OutputT]: ...
+
+    # Overload for operation_handler
+    @overload
+    @abstractmethod
+    async def start_operation(
+        self,
+        operation: Callable[
+            [NexusServiceType], nexusrpc.handler.OperationHandler[InputT, OutputT]
+        ],
+        arg: InputT,
+        *,
+        id: str,
+        id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
+        id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
+        result_type: type[OutputT] | None = None,
+        schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
+        search_attributes: temporalio.common.TypedSearchAttributes | None = None,
+        summary: str | None = None,
+        headers: Mapping[str, str] | None = None,
+        rpc_metadata: Mapping[str, str | bytes] = {},
+        rpc_timeout: timedelta | None = None,
+    ) -> NexusOperationHandle[OutputT]: ...
 
     @abstractmethod
     async def start_operation(
@@ -633,7 +669,7 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         """
         ...
 
-    # Overload for nexusrpc.Operation with input
+    # Overload for nexusrpc.Operation
     @overload
     @abstractmethod
     async def execute_operation(
@@ -644,6 +680,7 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         id: str,
         id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
         id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
+        result_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
         schedule_to_start_timeout: timedelta | None = None,
         start_to_close_timeout: timedelta | None = None,
@@ -654,50 +691,7 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         rpc_timeout: timedelta | None = None,
     ) -> OutputT: ...
 
-    # Overload for Callable with result_type
-    @overload
-    @abstractmethod
-    async def execute_operation(
-        self,
-        operation: Callable[..., Any],
-        arg: Any,
-        *,
-        id: str,
-        id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
-        id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
-        result_type: type[OutputT],
-        schedule_to_close_timeout: timedelta | None = None,
-        schedule_to_start_timeout: timedelta | None = None,
-        start_to_close_timeout: timedelta | None = None,
-        search_attributes: temporalio.common.TypedSearchAttributes | None = None,
-        summary: str | None = None,
-        headers: Mapping[str, str] | None = None,
-        rpc_metadata: Mapping[str, str | bytes] = {},
-        rpc_timeout: timedelta | None = None,
-    ) -> OutputT: ...
-
-    # Overload for Callable without result_type
-    @overload
-    @abstractmethod
-    async def execute_operation(
-        self,
-        operation: Callable[..., Any],
-        arg: Any,
-        *,
-        id: str,
-        id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
-        id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
-        schedule_to_close_timeout: timedelta | None = None,
-        schedule_to_start_timeout: timedelta | None = None,
-        start_to_close_timeout: timedelta | None = None,
-        search_attributes: temporalio.common.TypedSearchAttributes | None = None,
-        summary: str | None = None,
-        headers: Mapping[str, str] | None = None,
-        rpc_metadata: Mapping[str, str | bytes] = {},
-        rpc_timeout: timedelta | None = None,
-    ) -> Any: ...
-
-    # Overload for str with result_type
+    # Overload for string operation name
     @overload
     @abstractmethod
     async def execute_operation(
@@ -708,7 +702,7 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         id: str,
         id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
         id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
-        result_type: type[OutputT],
+        result_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
         schedule_to_start_timeout: timedelta | None = None,
         start_to_close_timeout: timedelta | None = None,
@@ -719,17 +713,21 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         rpc_timeout: timedelta | None = None,
     ) -> OutputT: ...
 
-    # Overload for str without result_type
+    # Overload for workflow_run_operation methods
     @overload
     @abstractmethod
     async def execute_operation(
         self,
-        operation: str,
-        arg: Any,
+        operation: Callable[
+            [NexusServiceType, temporalio.nexus.WorkflowRunOperationContext, InputT],
+            Awaitable[temporalio.nexus.WorkflowHandle[OutputT]],
+        ],
+        arg: InputT,
         *,
         id: str,
         id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
         id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
+        result_type: type[OutputT] | None = None,
         schedule_to_close_timeout: timedelta | None = None,
         schedule_to_start_timeout: timedelta | None = None,
         start_to_close_timeout: timedelta | None = None,
@@ -738,7 +736,82 @@ class NexusClient(ABC, Generic[NexusServiceType]):
         headers: Mapping[str, str] | None = None,
         rpc_metadata: Mapping[str, str | bytes] = {},
         rpc_timeout: timedelta | None = None,
-    ) -> Any: ...
+    ) -> OutputT: ...
+
+    # Overload for sync_operation methods (async def)
+    @overload
+    @abstractmethod
+    async def execute_operation(
+        self,
+        operation: Callable[
+            [NexusServiceType, nexusrpc.handler.StartOperationContext, InputT],
+            Awaitable[OutputT],
+        ],
+        arg: InputT,
+        *,
+        id: str,
+        id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
+        id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
+        result_type: type[OutputT] | None = None,
+        schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
+        search_attributes: temporalio.common.TypedSearchAttributes | None = None,
+        summary: str | None = None,
+        headers: Mapping[str, str] | None = None,
+        rpc_metadata: Mapping[str, str | bytes] = {},
+        rpc_timeout: timedelta | None = None,
+    ) -> OutputT: ...
+
+    # Overload for sync_operation methods (async def)
+    @overload
+    @abstractmethod
+    async def execute_operation(
+        self,
+        operation: Callable[
+            [NexusServiceType, nexusrpc.handler.StartOperationContext, InputT],
+            OutputT,
+        ],
+        arg: InputT,
+        *,
+        id: str,
+        id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
+        id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
+        result_type: type[OutputT] | None = None,
+        schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
+        search_attributes: temporalio.common.TypedSearchAttributes | None = None,
+        summary: str | None = None,
+        headers: Mapping[str, str] | None = None,
+        rpc_metadata: Mapping[str, str | bytes] = {},
+        rpc_timeout: timedelta | None = None,
+    ) -> OutputT: ...
+
+    # Overload for operation_handler
+    @overload
+    @abstractmethod
+    async def execute_operation(
+        self,
+        operation: Callable[
+            [NexusServiceType],
+            nexusrpc.handler.OperationHandler[InputT, OutputT],
+        ],
+        arg: InputT,
+        *,
+        id: str,
+        id_reuse_policy: temporalio.common.NexusOperationIDReusePolicy = temporalio.common.NexusOperationIDReusePolicy.ALLOW_DUPLICATE,
+        id_conflict_policy: temporalio.common.NexusOperationIDConflictPolicy = temporalio.common.NexusOperationIDConflictPolicy.FAIL,
+        result_type: type[OutputT] | None = None,
+        schedule_to_close_timeout: timedelta | None = None,
+        schedule_to_start_timeout: timedelta | None = None,
+        start_to_close_timeout: timedelta | None = None,
+        search_attributes: temporalio.common.TypedSearchAttributes | None = None,
+        summary: str | None = None,
+        headers: Mapping[str, str] | None = None,
+        rpc_metadata: Mapping[str, str | bytes] = {},
+        rpc_timeout: timedelta | None = None,
+    ) -> OutputT: ...
 
     @abstractmethod
     async def execute_operation(

--- a/tests/nexus/test_nexus_type_errors.py
+++ b/tests/nexus/test_nexus_type_errors.py
@@ -238,16 +238,6 @@ async def standalone_operation_type_tests():
         start_to_close_timeout=timedelta(seconds=2),
     )
 
-    # result_type overrides output type from operation definition
-    # conflicting result_type and annotation on variable cause type error
-    # assert-type-error-pyright: 'Type "str" is not assignable to declared type "MyOutput"'
-    _bad_result_type_output: MyOutput = await nexus_client.execute_operation(  # type: ignore
-        MyServiceHandler.my_sync_operation,
-        MyInput(),
-        id="op-1",
-        result_type=str,  # type: ignore
-    )
-
     # string operation name and result_type infers output type
     _str_op_result_type_output: MyOutput = await nexus_client.execute_operation(
         "my_sync_operation", MyInput(), id="op-1", result_type=MyOutput
@@ -336,20 +326,6 @@ async def standalone_operation_type_tests():
         start_to_close_timeout=timedelta(seconds=2),
     )
     _defn_handle_output: MyOutput = await _defn_handle.result()
-
-    # result_type overrides output type from operation definition
-    # conflicting result_type and annotation on variable cause type error
-    _result_type_handle: NexusOperationHandle[
-        MyOutput
-        # assert-type-error-pyright: 'Type "NexusOperationHandle\[str\]" is not assignable to declared type "NexusOperationHandle\[MyOutput\]"'
-    ] = await nexus_client.start_operation(  # type: ignore
-        MyServiceHandler.my_sync_operation,
-        MyInput(),
-        id="op-1",
-        result_type=str,  # type: ignore
-    )
-    # handle still respects type declaration on the variable
-    _result_type_handle_output: MyOutput = await _result_type_handle.result()
 
     # starting with string operation name and result_type infers output type on the handle
     # and result from the handle

--- a/tests/nexus/test_nexus_type_errors.py
+++ b/tests/nexus/test_nexus_type_errors.py
@@ -394,7 +394,7 @@ async def standalone_operation_type_tests():
 
     # functions with invalid signatures produce a type error
     class InvalidServiceHandler:
-        async def invalid(self, ctx: str, input: str) -> str:
+        async def invalid(self, _ctx: str, _input: str) -> str:
             raise NotImplementedError()
 
     # assert-type-error-pyright: 'No overloads for "start_operation" match'

--- a/tests/nexus/test_nexus_type_errors.py
+++ b/tests/nexus/test_nexus_type_errors.py
@@ -238,6 +238,15 @@ async def standalone_operation_type_tests():
         start_to_close_timeout=timedelta(seconds=2),
     )
 
+    # result_type is not allowed when an operation is provided
+    await nexus_client.execute_operation(
+        # assert-type-error-pyright: 'cannot be assigned to parameter "operation" of type "str"'
+        MyService.my_sync_operation,  # type: ignore
+        MyInput(),
+        id="op-1",
+        result_type=str,
+    )
+
     # string operation name and result_type infers output type
     _str_op_result_type_output: MyOutput = await nexus_client.execute_operation(
         "my_sync_operation", MyInput(), id="op-1", result_type=MyOutput
@@ -326,6 +335,15 @@ async def standalone_operation_type_tests():
         start_to_close_timeout=timedelta(seconds=2),
     )
     _defn_handle_output: MyOutput = await _defn_handle.result()
+
+    # result_type is not allowed when an operation is provided
+    await nexus_client.start_operation(
+        # assert-type-error-pyright: 'cannot be assigned to parameter "operation" of type "str"'
+        MyServiceHandler.my_sync_operation,  # type: ignore
+        MyInput(),
+        id="op-1",
+        result_type=str,
+    )
 
     # starting with string operation name and result_type infers output type on the handle
     # and result from the handle

--- a/tests/nexus/test_nexus_type_errors.py
+++ b/tests/nexus/test_nexus_type_errors.py
@@ -383,11 +383,30 @@ async def standalone_operation_type_tests():
         )
     )
 
-    # mismatched types on get_nexus_operation_handle produces type error
+    # mismatched types on get_nexus_operation_handle produce a type error
     # assert-type-error-pyright: 'Type "NexusOperationHandle\[str\]" is not assignable to declared type "NexusOperationHandle\[MyOutput\]"'
     _mismatch_handle: NexusOperationHandle[MyOutput] = (
         client.get_nexus_operation_handle(  # type: ignore
             "op-1",
             result_type=str,  # type: ignore
         )
+    )
+
+    # functions with invalid signatures produce a type error
+    class InvalidServiceHandler:
+        async def invalid(self, ctx: str, input: str) -> str:
+            raise NotImplementedError()
+
+    # assert-type-error-pyright: 'No overloads for "start_operation" match'
+    _invalid_handle: NexusOperationHandle[str] = await nexus_client.start_operation(
+        InvalidServiceHandler.invalid,  # type: ignore
+        "foo",
+        id="invalid",
+    )
+
+    # assert-type-error-pyright: 'No overloads for "execute_operation" match'
+    _invalid_result: str = await nexus_client.execute_operation(
+        InvalidServiceHandler.invalid,  # type: ignore
+        "foo",
+        id="invalid",
     )


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Remove broad callable overloads on the SANO Nexus Client.

## Why?
<!-- Tell your future self why have you made these changes -->

The SANO Nexus Client should be more opinionated the types of callables it receives and how it derives output.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

- Existing tests
- Update some test cases in the type tests that demonstrated conflicting types between passed callables and result_types to demonstrate that it isn't supported

