### PR TITLE
ci: key Rust cache on resolved Python version

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           submodules: recursive
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        id: setup-python
         with:
           python-version: "3.14"
 
@@ -47,6 +48,7 @@ jobs:
         with:
           cache-bin: false
           workspaces: temporalio/bridge -> target
+          key: py-${{ steps.setup-python.outputs.python-version }}
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
       - run: uv sync --all-extras
 

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           submodules: recursive
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        id: setup-python
         with:
           python-version: "3.14"
 
@@ -48,7 +47,7 @@ jobs:
         with:
           cache-bin: false
           workspaces: temporalio/bridge -> target
-          key: py-${{ steps.setup-python.outputs.python-version }}
+          key: ${{ env.pythonLocation }}
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
       - run: uv sync --all-extras
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: "clippy"
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        id: setup-python
+        with:
+          python-version: ${{ matrix.pythonOverride || matrix.python }}
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: temporalio/bridge -> target
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: ${{ matrix.pythonOverride || matrix.python }}
+          key: py-${{ steps.setup-python.outputs.python-version }}
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed
@@ -107,12 +109,14 @@ jobs:
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        id: setup-python
+        with:
+          python-version: "3.10"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: temporalio/bridge -> target
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.10"
+          key: py-${{ steps.setup-python.outputs.python-version }}
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed
@@ -143,12 +147,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: "clippy"
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        id: setup-python
+        with:
+          python-version: "3.13"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: temporalio/bridge -> target
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.13"
+          key: py-${{ steps.setup-python.outputs.python-version }}
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed
@@ -181,12 +187,14 @@ jobs:
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        id: setup-python
+        with:
+          python-version: "3.14"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: temporalio/bridge -> target
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.14"
+          key: py-${{ steps.setup-python.outputs.python-version }}
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,12 @@ jobs:
         with:
           components: "clippy"
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        id: setup-python
         with:
           python-version: ${{ matrix.pythonOverride || matrix.python }}
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: temporalio/bridge -> target
-          key: py-${{ steps.setup-python.outputs.python-version }}
+          key: ${{ env.pythonLocation }}
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed
@@ -110,13 +109,12 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        id: setup-python
         with:
           python-version: "3.10"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: temporalio/bridge -> target
-          key: py-${{ steps.setup-python.outputs.python-version }}
+          key: ${{ env.pythonLocation }}
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed
@@ -148,13 +146,12 @@ jobs:
         with:
           components: "clippy"
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        id: setup-python
         with:
           python-version: "3.13"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: temporalio/bridge -> target
-          key: py-${{ steps.setup-python.outputs.python-version }}
+          key: ${{ env.pythonLocation }}
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed
@@ -188,13 +185,12 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        id: setup-python
         with:
           python-version: "3.14"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: temporalio/bridge -> target
-          key: py-${{ steps.setup-python.outputs.python-version }}
+          key: ${{ env.pythonLocation }}
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -36,14 +36,13 @@ jobs:
         with:
           toolchain: stable
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        id: setup-python
         with:
           python-version: "3.13"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-bin: false
           workspaces: temporalio/bridge -> target
-          key: py-${{ steps.setup-python.outputs.python-version }}
+          key: ${{ env.pythonLocation }}
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -35,13 +35,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        id: setup-python
+        with:
+          python-version: "3.13"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-bin: false
           workspaces: temporalio/bridge -> target
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.13"
+          key: py-${{ steps.setup-python.outputs.python-version }}
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           # TODO(cretz): Can upgrade proto when https://github.com/arduino/setup-protoc/issues/99 fixed


### PR DESCRIPTION
## Summary
- The `Swatinem/rust-cache` key didn't include Python's patch version, so when the GitHub runner image bumped Python (e.g. 3.14.4 → 3.14.5) the restored build artifacts kept absolute `LIBPATH` entries pointing at the prior install dir and the link step failed with `LNK1181: cannot open input file 'python3.lib'` (observed on Windows in [run 26251630920](https://github.com/temporalio/sdk-python/actions/runs/26251630920)).
- Reorder `setup-python` to run before `rust-cache` in each workflow and append `env.pythonLocation` (the full install path, which includes the patch version) to the cache key. Applied to all four `rust-cache` uses in `ci.yml` plus `build-binaries.yml` and `run-bench.yml`.

## Test plan
- [ ] CI passes on this PR (which will populate fresh caches under the new keys).
- [ ] Confirm the Windows `build-lint-test` job no longer references a stale Python path in its linker invocation.