### PR TITLE
Expose JSON type converter unhandled sentinel type

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ class IPv4AddressJSONEncoder(AdvancedJSONEncoder):
 class IPv4AddressJSONTypeConverter(JSONTypeConverter):
     def to_typed_value(
         self, hint: Type, value: Any
-    ) -> Union[Optional[Any], _JSONTypeConverterUnhandled]:
+    ) -> Union[Optional[Any], JSONTypeConverterUnhandled]:
         if issubclass(hint, ipaddress.IPv4Address):
             return ipaddress.IPv4Address(value)
         return JSONTypeConverter.Unhandled

--- a/temporalio/converter/__init__.py
+++ b/temporalio/converter/__init__.py
@@ -31,6 +31,7 @@ from temporalio.converter._payload_converter import (
     JSONPlainPayloadConverter,
     JSONProtoPayloadConverter,
     JSONTypeConverter,
+    JSONTypeConverterUnhandled,
     PayloadConverter,
     value_to_type,
 )
@@ -76,6 +77,7 @@ __all__ = [
     "JSONPlainPayloadConverter",
     "JSONProtoPayloadConverter",
     "JSONTypeConverter",
+    "JSONTypeConverterUnhandled",
     "PayloadCodec",
     "PayloadConverter",
     "PayloadLimitsConfig",

--- a/temporalio/converter/_payload_converter.py
+++ b/temporalio/converter/_payload_converter.py
@@ -548,7 +548,10 @@ class AdvancedJSONEncoder(json.JSONEncoder):
         return super().default(o)
 
 
-_JSONTypeConverterUnhandled = NewType("_JSONTypeConverterUnhandled", object)
+JSONTypeConverterUnhandled = NewType("JSONTypeConverterUnhandled", object)
+"""Type of :py:attr:`JSONTypeConverter.Unhandled`."""
+
+_JSONTypeConverterUnhandled = JSONTypeConverterUnhandled
 
 
 class JSONTypeConverter(ABC):
@@ -556,7 +559,9 @@ class JSONTypeConverter(ABC):
     result (e.g. scalar, list, or dict) to a known type.
     """
 
-    Unhandled = _JSONTypeConverterUnhandled(object())
+    Unhandled: ClassVar[JSONTypeConverterUnhandled] = JSONTypeConverterUnhandled(
+        object()
+    )
     """Sentinel value that must be used as the result of
     :py:meth:`to_typed_value` to say the given type is not handled by this
     converter."""
@@ -564,7 +569,7 @@ class JSONTypeConverter(ABC):
     @abstractmethod
     def to_typed_value(
         self, hint: type, value: Any
-    ) -> Any | None | _JSONTypeConverterUnhandled:
+    ) -> Any | None | JSONTypeConverterUnhandled:
         """Convert the given value to a type based on the given hint.
 
         Args:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -16,6 +16,8 @@ from typing import (
     Dict,  # type:ignore[reportDeprecated]
     Literal,
     NewType,
+    get_args,
+    get_type_hints,
 )
 from uuid import UUID, uuid4
 
@@ -40,12 +42,12 @@ from temporalio.converter import (
     DefaultPayloadConverter,
     JSONPlainPayloadConverter,
     JSONTypeConverter,
+    JSONTypeConverterUnhandled,
     PayloadCodec,
     decode_search_attributes,
     encode_search_attribute_values,
     value_to_type,
 )
-from temporalio.converter._payload_converter import _JSONTypeConverterUnhandled
 from temporalio.exceptions import (
     ApplicationError,
     FailureError,
@@ -869,10 +871,20 @@ class IPv4AddressJSONEncoder(AdvancedJSONEncoder):
 class IPv4AddressJSONTypeConverter(JSONTypeConverter):
     def to_typed_value(
         self, hint: type, value: Any
-    ) -> Any | None | _JSONTypeConverterUnhandled:
+    ) -> Any | None | JSONTypeConverterUnhandled:
         if inspect.isclass(hint) and issubclass(hint, ipaddress.IPv4Address):
             return ipaddress.IPv4Address(value)
         return JSONTypeConverter.Unhandled
+
+
+def test_json_type_converter_unhandled_type_public():
+    return_type = get_type_hints(JSONTypeConverter.to_typed_value)["return"]
+
+    assert JSONTypeConverterUnhandled.__name__ == "JSONTypeConverterUnhandled"
+    assert JSONTypeConverterUnhandled in get_args(return_type)
+    assert JSONTypeConverterUnhandled(JSONTypeConverter.Unhandled) is (
+        JSONTypeConverter.Unhandled
+    )
 
 
 async def test_json_type_converter():


### PR DESCRIPTION
## Summary
- expose a public JSONTypeConverterUnhandled type for JSONTypeConverter.Unhandled
- keep the old private _JSONTypeConverterUnhandled name as an internal compatibility alias
- update the README and converter tests to use the public return type

Fixes #1434

## Validation
- .venv/bin/ruff format --check temporalio/converter/_payload_converter.py temporalio/converter/__init__.py tests/test_converter.py
- .venv/bin/ruff check temporalio/converter/_payload_converter.py temporalio/converter/__init__.py tests/test_converter.py
- git diff --check
- .venv/bin/python -m py_compile temporalio/converter/_payload_converter.py temporalio/converter/__init__.py tests/test_converter.py
- direct source validation for public JSONTypeConverterUnhandled import and to_typed_value return annotation
- direct source validation for a custom JSONTypeConverter with value_to_type

Note: I attempted the focused pytest coverage, but this local checkout cannot run repo pytest without the Temporal Rust bridge/test harness being built. The checkout has an empty sdk-core submodule and this machine does not have cargo available, so CI is the authoritative full test run.