### PR TITLE
Fix concurrent local activity replay nondeterminism

### DIFF
--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -461,8 +461,30 @@ class _WorkflowInstanceImpl(  # type: ignore[reportImplicitAbstractClass]
             for index, job_set in enumerate(job_sets):
                 if not job_set:
                     continue
+                # Separate local-activity resolutions from other jobs.
+                # Local activity results may arrive in non-deterministic
+                # order (completion order varies between first-execution
+                # and replay). Sort them by sequence number so coroutines
+                # always resume in scheduling order, ensuring deterministic
+                # interleaving regardless of execution mode.
+                local_activity_jobs = []
+                other_jobs = []
                 for job in job_set:
-                    # Let errors bubble out of these to the caller to fail the task
+                    if (
+                        job.HasField("resolve_activity")
+                        and job.resolve_activity.is_local
+                    ):
+                        local_activity_jobs.append(job)
+                    else:
+                        other_jobs.append(job)
+
+                # Apply non-local-activity jobs first
+                for job in other_jobs:
+                    self._apply(job)
+
+                # Apply local activity resolutions sorted by seq number.
+                local_activity_jobs.sort(key=lambda j: j.resolve_activity.seq)
+                for job in local_activity_jobs:
                     self._apply(job)
 
                 # Run one iteration of the loop. We do not allow conditions to

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -114,6 +114,7 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import (
     ExecuteWorkflowInput,
     HandleSignalInput,
+    Replayer,
     UnsandboxedWorkflowRunner,
     Worker,
     WorkflowInstance,
@@ -890,6 +891,98 @@ async def test_workflow_simple_local_activity(client: Client):
             task_queue=worker.task_queue,
         )
         assert result == "Hello, Temporal!"
+
+
+@activity.defn
+async def local_activity_slow(index: int) -> None:
+    if index % 2 == 0:
+        await asyncio.sleep(0.05)
+
+
+@activity.defn
+async def local_activity_fast(index: int) -> None:
+    return None
+
+
+@activity.defn
+async def local_activity_gate() -> None:
+    await asyncio.sleep(0.05)
+
+
+@workflow.defn
+class ConcurrentLocalActivityReplayWorkflow:
+    """Workflow that runs two concurrent coroutines with local activities.
+
+    This reproduces a replay nondeterminism bug: during first execution,
+    local activities take real time, creating a deterministic interleaving.
+    During replay, all local activities return instantly from markers, which
+    can reorder coroutine scheduling and produce a different command sequence.
+    """
+
+    @workflow.run
+    async def run(self) -> list[int]:
+        async def lifecycle_a(index: int) -> int:
+            await workflow.execute_local_activity(
+                local_activity_slow,
+                args=[index * 2],
+                start_to_close_timeout=timedelta(seconds=5),
+            )
+            await workflow.execute_local_activity(
+                local_activity_fast,
+                args=[index * 2],
+                start_to_close_timeout=timedelta(seconds=5),
+            )
+            return index * 2
+
+        async def lifecycle_b(index: int) -> int:
+            await workflow.execute_local_activity(
+                local_activity_gate,
+                start_to_close_timeout=timedelta(seconds=5),
+            )
+            await workflow.execute_local_activity(
+                local_activity_slow,
+                args=[index * 2 + 1],
+                start_to_close_timeout=timedelta(seconds=5),
+            )
+            await workflow.execute_local_activity(
+                local_activity_fast,
+                args=[index * 2 + 1],
+                start_to_close_timeout=timedelta(seconds=5),
+            )
+            return index * 2 + 1
+
+        results: list[int] = []
+        for index in range(20):
+            results.extend(await asyncio.gather(lifecycle_a(index), lifecycle_b(index)))
+        return results
+
+
+async def test_workflow_concurrent_local_activity_replay(client: Client):
+    """Test that concurrent local activities replay deterministically.
+
+    Runs a workflow with two concurrent coroutines that each issue multiple
+    local activities, then replays the history. Without the fix, replay
+    fails with NondeterminismError because the local activity command order
+    diverges from the recorded marker order.
+    """
+    async with new_worker(
+        client,
+        ConcurrentLocalActivityReplayWorkflow,
+        activities=[local_activity_slow, local_activity_fast, local_activity_gate],
+    ) as worker:
+        handle = await client.start_workflow(
+            ConcurrentLocalActivityReplayWorkflow.run,
+            id=f"workflow-{uuid.uuid4()}",
+            task_queue=worker.task_queue,
+        )
+        expected = [v for i in range(20) for v in (i * 2, i * 2 + 1)]
+        assert await handle.result() == expected
+
+        history = await handle.fetch_history()
+
+    await Replayer(
+        workflows=[ConcurrentLocalActivityReplayWorkflow],
+    ).replay_workflow(history)
 
 
 @activity.defn


### PR DESCRIPTION
## Problem

When multiple coroutines issue local activities concurrently (e.g. via `asyncio.gather`), replay can fail with `NondeterminismError`.

During first execution, local activity `resolve_activity` jobs arrive in **completion order** (wall-clock timing). During replay, they arrive in **sequence number order**. This ordering difference causes coroutines to resume in a different order, assigning different sequence numbers to subsequent commands, which no longer match the recorded markers.

## Fix

Sort local activity `resolve_activity` jobs by sequence number before processing them in `_WorkflowInstanceImpl.activate()`. This ensures coroutines always resume in scheduling order regardless of execution mode (first-execution vs replay).

The fix is safe for existing workflows:
- **Without concurrent local activities**: sorting a single item is a no-op.
- **With concurrent local activities that replayed correctly** (completion order happened to match seq order): the new code produces the same interleaving.
- **With concurrent local activities that already failed on replay**: they were hitting `NondeterminismError` anyway.

## Test

Added `test_workflow_concurrent_local_activity_replay`: runs a workflow with two concurrent coroutines each issuing multiple sequential local activities, then replays the recorded history. Without the fix, replay fails with `NondeterminismError`.