### PR TITLE
Add CHANGELOG and document the update process

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## [Unreleased]
+
+<!--
+High-level release notes.
+Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+When your PR includes a user-facing change, add an entry below under the
+appropriate heading (create the heading if it does not yet exist). Within
+each heading content can be free-form. Feel free to include examples, links
+to docs, or any other relevant information.
+
+### Added            — new features
+### Changed          — changes in existing functionality
+### Deprecated       — soon-to-be-removed features
+### Breaking Changes — removed or backwards-incompatible features
+### Fixed            — notable bug fixes
+### Security         — notable security fixes
+-->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-# Changelog
-
-## [Unreleased]
-
 <!--
 High-level release notes.
 Loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
@@ -18,3 +14,7 @@ to docs, or any other relevant information.
 ### Fixed            — notable bug fixes
 ### Security         — notable security fixes
 -->
+
+# Changelog
+
+## [Unreleased]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to the Temporal Python SDK
+
+Thanks for your interest in contributing!
+
+All contributors must complete the Temporal Contributor License Agreement (CLA) before changes
+can be merged. A link to the CLA will be posted in the PR.
+
+See the [README](README.md) for build and development instructions.
+
+## Changelog
+
+User-facing changes are recorded in [`CHANGELOG.md`](CHANGELOG.md), loosely following the
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+
+If your PR includes a user-facing change (new feature, behavior change, deprecation, breaking
+change, notable bug fix, or security fix), add a short, high-level entry to the `## [Unreleased]`
+section at the top of `CHANGELOG.md` under the appropriate heading, creating it if needed:
+Added, Changed, Deprecated, Breaking Changes, Fixed, or Security.
+
+Keep entries high-level and written for users. The full commit log is appended at release time,
+so internal-only changes (refactors, tests, CI, docs) don't need an entry.


### PR DESCRIPTION
## What

Adds a `CHANGELOG.md` and a lightweight process for keeping it current.

- **`CHANGELOG.md`** at the repo root with an `## [Unreleased]` section, loosely
  following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
  Entries are grouped under free-form headings (Added, Changed, Deprecated,
  Breaking Changes, Fixed, Security), created as needed.
- **`.gitattributes`** marks `CHANGELOG.md` as `merge=union` so entries added by
  concurrent PRs append instead of conflicting.
- **`CONTRIBUTING.md`** documents when to add an entry (any user-facing change)
  and how.

## Why

Today release drivers reconstruct notes by hand at release time. Capturing
high-level notes incrementally in each PR makes releases faster and more
reliable: the GitHub release notes become the `[Unreleased]` section plus the
commit log.

## Notes

- Docs and config only; no code or behavior changes. The changelog starts fresh;
historical release notes remain available through GitHub Releases.
- We can backfill the changelog if necessary.