### PR TITLE
Use ActivitySerializationContext when describing a Standalone Activity

### DIFF
--- a/temporalio/client/_impl.py
+++ b/temporalio/client/_impl.py
@@ -693,14 +693,22 @@ class _ClientImpl(OutboundInterceptor):  # pyright: ignore[reportUnusedClass]
             metadata=input.rpc_metadata,
             timeout=input.rpc_timeout,
         )
+        activity_type = (
+            resp.info.activity_type.name if resp.info.HasField("activity_type") else ""
+        )
         return await ActivityExecutionDescription._from_execution_info(
             info=resp.info,
             long_poll_token=resp.long_poll_token or None,
             namespace=self._client.namespace,
             data_converter=self._client.data_converter.with_context(
-                WorkflowSerializationContext(
+                ActivitySerializationContext(
                     namespace=self._client.namespace,
-                    workflow_id=input.activity_id,  # Using activity_id as workflow_id for activities not started by a workflow
+                    activity_id=resp.info.activity_id,
+                    activity_task_queue=resp.info.task_queue,
+                    activity_type=activity_type,
+                    workflow_id=None,
+                    workflow_type=None,
+                    is_local=False,
                 )
             ),
         )

--- a/temporalio/client/_impl.py
+++ b/temporalio/client/_impl.py
@@ -693,9 +693,6 @@ class _ClientImpl(OutboundInterceptor):  # pyright: ignore[reportUnusedClass]
             metadata=input.rpc_metadata,
             timeout=input.rpc_timeout,
         )
-        activity_type = (
-            resp.info.activity_type.name if resp.info.HasField("activity_type") else ""
-        )
         return await ActivityExecutionDescription._from_execution_info(
             info=resp.info,
             long_poll_token=resp.long_poll_token or None,
@@ -705,7 +702,7 @@ class _ClientImpl(OutboundInterceptor):  # pyright: ignore[reportUnusedClass]
                     namespace=self._client.namespace,
                     activity_id=resp.info.activity_id,
                     activity_task_queue=resp.info.task_queue,
-                    activity_type=activity_type,
+                    activity_type=resp.info.activity_type.name,
                     workflow_id=None,
                     workflow_type=None,
                     is_local=False,


### PR DESCRIPTION


## What was changed
<!-- Describe what has changed in this PR -->
Use ActivitySerializationContext when describing a Standalone Activity.

## Why?
<!-- Tell your future self why have you made these changes -->
Using a WorkflowSerializationContext where the workflow_id is really an activity_id seems like a bug.

