### PR TITLE
Propagate OTEL trace id across client-workflow boundary

### DIFF
--- a/temporalio/contrib/openai_agents/_otel_trace_interceptor.py
+++ b/temporalio/contrib/openai_agents/_otel_trace_interceptor.py
@@ -45,10 +45,11 @@ class OTelOpenAIAgentsContextPropagationInterceptor(
         otel_span = opentelemetry.trace.get_current_span()
 
         if otel_span and otel_span.get_span_context().is_valid:
-            otel_span_id = otel_span.get_span_context().span_id
+            span_context = otel_span.get_span_context()
             return {
                 **super().header_contents(),
-                "otelSpanId": otel_span_id,
+                "otelSpanId": span_context.span_id,
+                "otelTraceId": span_context.trace_id,
             }
         else:
             return super().header_contents()
@@ -63,6 +64,12 @@ class OTelOpenAIAgentsContextPropagationInterceptor(
         if span_info is None:
             return
         otel_span_id = span_info.get("otelSpanId")
+        otel_trace_id = span_info.get("otelTraceId")
+
+        # Seed the trace id before the trace is reconstructed so the workflow's root
+        # OTEL span shares the caller's trace id rather than generating a new one.
+        if otel_trace_id and self._otel_id_generator:
+            self._otel_id_generator.seed_trace_id(otel_trace_id)
 
         # If only a trace was propagated from the caller, we need to seed for trace context
         if otel_span_id and self._otel_id_generator and span_info.get("spanId") is None:


### PR DESCRIPTION
## What

The OTEL-aware OpenAI Agents interceptor (`_otel_trace_interceptor.py`) propagated and seeded the OTEL **span id** across the client→workflow boundary (`otelSpanId` → `seed_span_id`), but never propagated the **trace id**. As a result the client-side "Client SDK trace" root span (created outside a workflow, so it gets a *random* trace id) and the workflow's reconstructed spans (created inside a workflow, so they get a *deterministic* workflow-random trace id) ended up in **different traces**.

This made `test_sdk_trace_to_otel_span_parenting` flaky: its "all spans belong to the same trace" assertion only failed when context-var timing caused the client-side root span to be exported and picked by `next(...)`, which is why it was intermittent on CI ([example failure](https://github.com/temporalio/sdk-python/actions/runs/27432588766/job/81086412642)).

## Fix

Wire up the already-present-but-unused `seed_trace_id`:

- `header_contents`: also emit `otelTraceId` from the current span's context.
- `context_from_header`: call `seed_trace_id(otel_trace_id)` **before** the trace is reconstructed, so the workflow's root OTEL span reuses the caller's trace id.

Now every span shares one trace id regardless of which root span the test selects — fixing the flake at its source rather than in the test.

## Testing

`tests/contrib/openai_agents/test_openai_tracing.py` passes (7/7), including the workflow→activity span-propagation cases. Ran the target test repeatedly to confirm stability.