### PR TITLE
Grant explicit actions:read to features reusable-workflow caller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,9 @@ jobs:
 
   # Runs the sdk features repo tests with this repo's current SDK code
   features-tests:
+    permissions:
+      contents: read
+      actions: read
     uses: temporalio/features/.github/workflows/python.yaml@main
     with:
       python-repo-path: ${{github.event.pull_request.head.repo.full_name}}


### PR DESCRIPTION
## What 
Adds a job-level permissions block granting `contents: read` and `actions: read` to the job that calls the temporalio/features workflow. 

## Why
The org default GITHUB_TOKEN permissions are now restrictive (`actions: none`), so without this grant the reusable workflow fails validation at parse time and the check never starts.