### PR TITLE
Retry release smoke package install

### DIFF
--- a/.github/scripts/install_release_package.py
+++ b/.github/scripts/install_release_package.py
@@ -6,19 +6,41 @@ import argparse
 import importlib.metadata
 import subprocess
 import sys
+import time
 from collections.abc import Sequence
+
+RELEASE_INSTALL_ATTEMPTS = 31
+RELEASE_INSTALL_RETRY_SECONDS = 30
 
 
 def _pip_install(args: Sequence[str]) -> None:
     subprocess.check_call([sys.executable, "-m", "pip", "install", *args])
 
 
+def _pip_install_with_retries(args: Sequence[str]) -> None:
+    for attempt in range(1, RELEASE_INSTALL_ATTEMPTS + 1):
+        try:
+            _pip_install(args)
+            return
+        except subprocess.CalledProcessError:
+            if attempt == RELEASE_INSTALL_ATTEMPTS:
+                raise
+            print(
+                "Package was not installable yet; retrying in "
+                f"{RELEASE_INSTALL_RETRY_SECONDS}s "
+                f"({attempt}/{RELEASE_INSTALL_ATTEMPTS})",
+                flush=True,
+            )
+            time.sleep(RELEASE_INSTALL_RETRY_SECONDS)
+
+
 def install_package(args: argparse.Namespace) -> None:
     package = f"temporalio=={args.version}"
     if args.dependency_index_url:
-        _pip_install(
+        _pip_install_with_retries(
             [
                 "--prefer-binary",
+                "--no-cache-dir",
                 "--index-url",
                 args.index_url,
                 "--no-deps",
@@ -37,7 +59,15 @@ def install_package(args: argparse.Namespace) -> None:
                 ]
             )
     else:
-        _pip_install(["--prefer-binary", "--index-url", args.index_url, package])
+        _pip_install_with_retries(
+            [
+                "--prefer-binary",
+                "--no-cache-dir",
+                "--index-url",
+                args.index_url,
+                package,
+            ]
+        )
 
     subprocess.check_call([sys.executable, "-m", "pip", "check"])
 


### PR DESCRIPTION
## What changed

- Adds a bounded retry loop around the initial release package install in the shared smoke-test helper.
- Uses `--no-cache-dir` for that install so retries re-check the package index.
- Leaves dependency installation and `pip check` fail-fast after the release package resolves.

This covers both TestPyPI and PyPI smoke tests because both use `.github/actions/release-smoke-package`.

## Why

The `1.29.0` release run uploaded successfully to TestPyPI, but the immediate smoke install saw a stale simple index that still ended at `1.28.0`. A rerun several minutes later hit the same cached index from the runner. Retrying the package install handles package-index propagation without sleeping longer than needed.

## Validation

- `uv run ruff check .github/scripts/install_release_package.py`
- `uv run ruff format --check .github/scripts/install_release_package.py`
- `python3 -m py_compile .github/scripts/install_release_package.py`
- Exercised `_pip_install_with_retries` with mocked transient failures
- Installed `temporalio==1.29.0` from TestPyPI in a temporary venv with `.github/scripts/install_release_package.py`
