### PR TITLE
Prepare release 1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ to include examples, links to docs, or any other relevant information.
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Breaking Changes
+
+### Fixed
+
+### Security
+
+## [1.30.0] - 2026-07-01
+
+### Added
+
 - Nexus operation link propagation for signals. When a Nexus operation handler signals a workflow
   (including signal-with-start), the inbound Nexus request links are now forwarded onto the signaled
   workflow so its history events link back to the caller, and the link the server returns for the
@@ -36,18 +50,12 @@ to include examples, links to docs, or any other relevant information.
   with the selected optional dependencies.
 - Standalone Nexus operation links are now forwarded on start workflow and signal requests.
 
-### Deprecated
-
 ### Breaking Changes
 
 - AWS Lambda worker `configure` parameter has been changed to be invoked
   per-invocation of the worker instead of only at startup. It is advised that
   any shared, heavy-weight operations are performed outside of the callback
   before `run_worker` is invoked.
-
-### Fixed
-
-### Security
 
 ## [1.29.0] - 2026-06-17
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "temporalio"
-version = "1.29.0"
+version = "1.30.0"
 description = "Temporal.io Python SDK"
 authors = [{ name = "Temporal Technologies Inc", email = "sdk@temporal.io" }]
 requires-python = ">=3.10"

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -78,7 +78,7 @@ def finalize_changelog_release(
 
 def replace_project_version(text: str, version: str) -> str:
     return _replace_once(
-        r'(?m)^version = "[^"]+"\s*$',
+        r'(?m)^version = "[^"]+"[^\S\r\n]*$',
         f'version = "{validate_version(version)}"',
         text,
         description="project version",
@@ -87,7 +87,7 @@ def replace_project_version(text: str, version: str) -> str:
 
 def replace_service_version(text: str, version: str) -> str:
     return _replace_once(
-        r'(?m)^__version__ = "[^"]+"\s*$',
+        r'(?m)^__version__ = "[^"]+"[^\S\r\n]*$',
         f'__version__ = "{validate_version(version)}"',
         text,
         description="service version",

--- a/temporalio/service.py
+++ b/temporalio/service.py
@@ -24,7 +24,7 @@ import temporalio.exceptions
 import temporalio.runtime
 from temporalio.bridge.client import RPCError as BridgeRPCError
 
-__version__ = "1.29.0"
+__version__ = "1.30.0"
 
 ServiceRequest = TypeVar("ServiceRequest", bound=google.protobuf.message.Message)
 ServiceResponse = TypeVar("ServiceResponse", bound=google.protobuf.message.Message)

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -73,3 +73,10 @@ def test_replace_versions() -> None:
         replace_service_version('__version__ = "1.29.0"\n', "1.30.0")
         == '__version__ = "1.30.0"'
     )
+    assert (
+        replace_service_version(
+            '__version__ = "1.29.0"\n\nServiceRequest = TypeVar("ServiceRequest")\n',
+            "1.30.0",
+        )
+        == '__version__ = "1.30.0"\n\nServiceRequest = TypeVar("ServiceRequest")'
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-16T15:22:43.641437Z"
+exclude-newer = "2026-06-17T16:16:53.404973Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5633,7 +5633,7 @@ wheels = [
 
 [[package]]
 name = "temporalio"
-version = "1.29.0"
+version = "1.30.0"
 source = { virtual = "." }
 dependencies = [
     { name = "nexus-rpc" },


### PR DESCRIPTION
## Summary

- Bump the Python SDK version to 1.30.0
- Roll the current Unreleased changelog entries into a 1.30.0 section dated 2026-07-01
- Fix `prepare_release.py` so version replacement preserves the blank line after `temporalio.service.__version__`

## Tests

- `uv run pytest tests/test_prepare_release.py tests/test_service.py -q`
- `uv run python .github/scripts/release_verify.py validate-version --sha 46768b2b48c4b08e5e087b6c428354d23c2ff4c6`
- `uv run python .github/scripts/release_verify.py changelog-notes --version 1.30.0 --output /tmp/sdk-python-release-notes-1.30.0.md`
