### PR TITLE
fix: use functools.wraps in activity_tool to preserve __annotations__ and __module__

### DIFF
--- a/temporalio/contrib/google_adk_agents/workflow.py
+++ b/temporalio/contrib/google_adk_agents/workflow.py
@@ -1,5 +1,6 @@
 """Workflow utilities for Google ADK agents integration with Temporal."""
 
+import functools
 import inspect
 from typing import Any, Callable
 
@@ -18,6 +19,7 @@ def activity_tool(activity_def: Callable, **kwargs: Any) -> Callable:
     while marking it as a tool that executes via 'workflow.execute_activity'.
     """
 
+    @functools.wraps(activity_def)
     async def wrapper(*args: Any, **kw: Any):
         # Inspect signature to bind arguments
         sig = inspect.signature(activity_def)
@@ -48,9 +50,8 @@ def activity_tool(activity_def: Callable, **kwargs: Any) -> Callable:
             activity_def, args=activity_args, **options
         )
 
-    # Copy metadata
-    wrapper.__name__ = activity_def.__name__
-    wrapper.__doc__ = activity_def.__doc__
+    # functools.wraps copies name/doc/module/annotations/qualname/dict.
+    # Signature must be set explicitly since the wrapper uses *args/**kw.
     setattr(wrapper, "__signature__", inspect.signature(activity_def))
 
     return wrapper

--- a/tests/contrib/google_adk_agents/test_google_adk_agents.py
+++ b/tests/contrib/google_adk_agents/test_google_adk_agents.py
@@ -14,6 +14,7 @@
 
 """Integration tests for ADK Temporal support."""
 
+import inspect
 import json
 import logging
 import os
@@ -1099,3 +1100,41 @@ def test_explicitly_set_none_preserved() -> None:
 
     assert "cache_config" in serialized, "Explicitly-set None should be preserved"
     assert serialized["cache_config"] is None
+
+
+def test_activity_tool_preserves_metadata() -> None:
+    """activity_tool wrapper preserves the original function's metadata.
+
+    This ensures ADK's tool schema generation can inspect __annotations__
+    and __module__ on the wrapper, which are needed by
+    ``_handle_params_as_deferred_annotations`` to resolve type hints.
+    """
+
+    @activity.defn
+    async def my_activity(city: str, count: int = 1) -> str:
+        """Get info for a city."""
+        return f"{city}: {count}"
+
+    tool = temporalio.contrib.google_adk_agents.workflow.activity_tool(
+        my_activity, start_to_close_timeout=timedelta(seconds=30)
+    )
+
+    # __name__ and __doc__
+    assert tool.__name__ == "my_activity"
+    assert tool.__doc__ == "Get info for a city."
+
+    # __annotations__ — critical for ADK type introspection
+    assert "city" in tool.__annotations__
+    assert tool.__annotations__["city"] is str
+    assert tool.__annotations__["count"] is int
+    assert tool.__annotations__["return"] is str
+
+    # __module__ — needed by _handle_params_as_deferred_annotations
+    assert tool.__module__ == my_activity.__module__
+
+    # __signature__ — must match the original, not *args/**kw
+    sig = inspect.signature(tool)
+    params = list(sig.parameters.keys())
+    assert params == ["city", "count"]
+    assert sig.parameters["city"].annotation is str
+    assert sig.parameters["count"].default == 1


### PR DESCRIPTION
## Summary

Replace manual metadata copying in `activity_tool()` with `@functools.wraps(activity_def)` to fix missing `__annotations__` and `__module__` on the wrapper function.

## Problem

The `activity_tool()` wrapper copies `__name__`, `__doc__`, and `__signature__` but **misses `__annotations__` and `__module__`**. ADK's `build_function_declaration()` → `_handle_params_as_deferred_annotations()` reads the wrapper's `__annotations__` to resolve parameter types, but finds `{'args': Any, 'kw': Any}` instead of the original function's typed parameters, causing a `KeyError`.

## Fix

```diff
+import functools

 def activity_tool(activity_def, **kwargs):
+    @functools.wraps(activity_def)
     async def wrapper(*args, **kw):
         ...

-    wrapper.__name__ = activity_def.__name__
-    wrapper.__doc__ = activity_def.__doc__
-    setattr(wrapper, "__signature__", inspect.signature(activity_def))
+    wrapper.__signature__ = inspect.signature(activity_def)
     return wrapper
```

`functools.wraps` copies `__name__`, `__qualname__`, `__module__`, `__annotations__`, `__doc__`, `__dict__`, and sets `__wrapped__`. The explicit `__signature__` override remains because the wrapper uses `*args/**kw`.

## Testing

Verified locally: wrapping a typed activity with `activity_tool()` and using it as a `LlmAgent` tool now produces correct function declarations without `KeyError`.

Fixes #1635