### PR TITLE
Add patch activation callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ to include examples, links to docs, or any other relevant information.
 
 ### Added
 
+- Added the experimental `Worker` `patch_activation_callback` option, allowing workers
+  to decide whether a first non-replay `workflow.patched` call should activate a patch
+  during rolling deployments.
+
 ### Changed
 
 ### Deprecated

--- a/temporalio/worker/__init__.py
+++ b/temporalio/worker/__init__.py
@@ -58,6 +58,7 @@ from ._worker import (
     WorkerDeploymentConfig,
 )
 from ._workflow_instance import (
+    PatchActivationInput,
     UnsandboxedWorkflowRunner,
     WorkflowInstance,
     WorkflowInstanceDetails,
@@ -77,6 +78,7 @@ __all__ = [
     "PollerBehavior",
     "PollerBehaviorSimpleMaximum",
     "PollerBehaviorAutoscaling",
+    "PatchActivationInput",
     # Interceptor base classes
     "Interceptor",
     "ActivityInboundInterceptor",

--- a/temporalio/worker/_replayer.py
+++ b/temporalio/worker/_replayer.py
@@ -255,6 +255,7 @@ class Replayer:
                 workflow_failure_exception_types=self._config.get(
                     "workflow_failure_exception_types", []
                 ),
+                patch_activation_callback=None,
                 debug_mode=self._config.get("debug_mode", False),
                 metric_meter=runtime.metric_meter,
                 on_eviction_hook=on_eviction_hook,

--- a/temporalio/worker/_worker.py
+++ b/temporalio/worker/_worker.py
@@ -40,7 +40,11 @@ from ._workflow import (
     _DEFAULT_WORKFLOW_TASK_EXTERNAL_STORAGE_CONCURRENCY,
     _WorkflowWorker,
 )
-from ._workflow_instance import UnsandboxedWorkflowRunner, WorkflowRunner
+from ._workflow_instance import (
+    PatchActivationInput,
+    UnsandboxedWorkflowRunner,
+    WorkflowRunner,
+)
 from .workflow_sandbox import SandboxedWorkflowRunner
 
 logger = logging.getLogger(__name__)
@@ -135,6 +139,7 @@ class Worker:
         use_worker_versioning: bool = False,
         disable_safe_workflow_eviction: bool = False,
         deployment_config: WorkerDeploymentConfig | None = None,
+        patch_activation_callback: Callable[[PatchActivationInput], bool] | None = None,
         workflow_task_poller_behavior: PollerBehavior = PollerBehaviorSimpleMaximum(
             maximum=5
         ),
@@ -307,6 +312,12 @@ class Worker:
             deployment_config: Deployment config for the worker. Exclusive with ``build_id`` and
                 ``use_worker_versioning``.
                 WARNING: This is an experimental feature and may change in the future.
+            patch_activation_callback: Callback to decide whether the first non-replay
+                call to :py:func:`workflow.patched<temporalio.workflow.patched>` for a
+                patch ID should activate that patch. The callback receives a
+                :py:class:`PatchActivationInput` and must return ``True`` to activate the
+                patch or ``False`` to leave it inactive.
+                WARNING: This is an experimental feature and may change in the future.
             workflow_task_poller_behavior: Specify the behavior of workflow task polling.
                 Defaults to a 5-poller maximum.
             activity_task_poller_behavior: Specify the behavior of activity task polling.
@@ -368,6 +379,7 @@ class Worker:
             use_worker_versioning=use_worker_versioning,
             disable_safe_workflow_eviction=disable_safe_workflow_eviction,
             deployment_config=deployment_config,
+            patch_activation_callback=patch_activation_callback,
             workflow_task_poller_behavior=workflow_task_poller_behavior,
             activity_task_poller_behavior=activity_task_poller_behavior,
             nexus_task_poller_behavior=nexus_task_poller_behavior,
@@ -528,6 +540,7 @@ class Worker:
                 workflow_failure_exception_types=config[
                     "workflow_failure_exception_types"
                 ],  # type: ignore[reportTypedDictNotRequiredAccess]
+                patch_activation_callback=config.get("patch_activation_callback"),
                 debug_mode=config["debug_mode"],  # type: ignore[reportTypedDictNotRequiredAccess]
                 disable_eager_activity_execution=config[
                     "disable_eager_activity_execution"
@@ -982,6 +995,7 @@ class WorkerConfig(TypedDict, total=False):
     use_worker_versioning: bool
     disable_safe_workflow_eviction: bool
     deployment_config: WorkerDeploymentConfig | None
+    patch_activation_callback: Callable[[PatchActivationInput], bool] | None
     workflow_task_poller_behavior: PollerBehavior
     activity_task_poller_behavior: PollerBehavior
     nexus_task_poller_behavior: PollerBehavior

--- a/temporalio/worker/_workflow.py
+++ b/temporalio/worker/_workflow.py
@@ -42,6 +42,7 @@ from ._interceptor import (
     WorkflowInterceptorClassInput,
 )
 from ._workflow_instance import (
+    PatchActivationInput,
     WorkflowInstance,
     WorkflowInstanceDetails,
     WorkflowRunner,
@@ -78,6 +79,7 @@ class _WorkflowWorker:  # type:ignore[reportUnusedClass]
         data_converter: temporalio.converter.DataConverter,
         interceptors: Sequence[Interceptor],
         workflow_failure_exception_types: Sequence[type[BaseException]],
+        patch_activation_callback: Callable[[PatchActivationInput], bool] | None,
         debug_mode: bool,
         disable_eager_activity_execution: bool,
         metric_meter: temporalio.common.MetricMeter,
@@ -145,6 +147,7 @@ class _WorkflowWorker:  # type:ignore[reportUnusedClass]
         )
 
         self._workflow_failure_exception_types = workflow_failure_exception_types
+        self._patch_activation_callback = patch_activation_callback
         self._running_workflows: dict[str, _RunningWorkflow] = {}
         self._disable_eager_activity_execution = disable_eager_activity_execution
         self._on_eviction_hook = on_eviction_hook
@@ -798,6 +801,7 @@ class _WorkflowWorker:  # type:ignore[reportUnusedClass]
             extern_functions=self._extern_functions,
             disable_eager_activity_execution=self._disable_eager_activity_execution,
             worker_level_failure_exception_types=self._workflow_failure_exception_types,
+            patch_activation_callback=self._patch_activation_callback,
             last_completion_result=init.last_completion_result,
             last_failure=last_failure,
         )

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -132,6 +132,17 @@ class WorkflowRunner(ABC):
 
 
 @dataclass(frozen=True)
+class PatchActivationInput:
+    """Input for the worker patch activation callback."""
+
+    workflow_info: temporalio.workflow.Info
+    """Information about the workflow execution calling ``patched``."""
+
+    patch_id: str
+    """Patch ID passed to ``patched``."""
+
+
+@dataclass(frozen=True)
 class WorkflowInstanceDetails:
     """Immutable details for creating a workflow instance."""
 
@@ -144,6 +155,7 @@ class WorkflowInstanceDetails:
     extern_functions: Mapping[str, Callable]
     disable_eager_activity_execution: bool
     worker_level_failure_exception_types: Sequence[type[BaseException]]
+    patch_activation_callback: Callable[[PatchActivationInput], bool] | None
     last_completion_result: temporalio.api.common.v1.Payloads
     last_failure: Failure | None
 
@@ -264,6 +276,7 @@ class _WorkflowInstanceImpl(  # type: ignore[reportImplicitAbstractClass]
         self._worker_level_failure_exception_types = (
             det.worker_level_failure_exception_types
         )
+        self._patch_activation_callback = det.patch_activation_callback
         self._primary_task: asyncio.Task[None] | None = None
         self._time_ns = 0
         self._cancel_reason: str | None = None
@@ -1363,7 +1376,20 @@ class _WorkflowInstanceImpl(  # type: ignore[reportImplicitAbstractClass]
         if use_patch is not None:
             return use_patch
 
-        use_patch = not self._is_replaying or id in self._patches_notified
+        # Replay and history markers already determine the branch, and deprecation must
+        # keep existing patch semantics, so only a genuinely new patch consults the
+        # callback.
+        if deprecated or self._is_replaying or id in self._patches_notified:
+            use_patch = not self._is_replaying or id in self._patches_notified
+        elif self._patch_activation_callback is not None:
+            with self._as_read_only(in_query_or_validator=False):
+                use_patch = self._patch_activation_callback(
+                    PatchActivationInput(workflow_info=self._info, patch_id=id)
+                )
+            if type(use_patch) is not bool:
+                raise TypeError("Patch activation callback must return true or false")
+        else:
+            use_patch = True
         self._patches_memoized[id] = use_patch
         if use_patch:
             command = self._add_command()
@@ -1873,6 +1899,7 @@ class _WorkflowInstanceImpl(  # type: ignore[reportImplicitAbstractClass]
     def workflow_register_random_seed_callback(
         self, callback: Callable[[int], None]
     ) -> None:
+        self._assert_not_read_only("register random seed callback")
         self._seed_callbacks.append(callback)
 
     #### Calls from outbound impl ####

--- a/temporalio/worker/workflow_sandbox/_runner.py
+++ b/temporalio/worker/workflow_sandbox/_runner.py
@@ -89,6 +89,7 @@ class SandboxedWorkflowRunner(WorkflowRunner):
                 extern_functions={},
                 disable_eager_activity_execution=False,
                 worker_level_failure_exception_types=self._worker_level_failure_exception_types,
+                patch_activation_callback=None,
                 last_completion_result=Payloads(),
                 last_failure=Failure(),
             ),

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -3193,6 +3193,329 @@ async def test_workflow_patch_memoized(client: Client):
 
 
 @workflow.defn
+class PatchActivationWorkflow:
+    @workflow.run
+    async def run(self, patch_id: str, sleep_after_first: bool = False) -> list[bool]:
+        first = workflow.patched(patch_id)
+        if sleep_after_first:
+            await workflow.sleep(0.001)
+        return [first, workflow.patched(patch_id)]
+
+
+@workflow.defn
+class PatchActivationDeprecateWorkflow:
+    @workflow.run
+    async def run(self, patch_id: str) -> bool:
+        workflow.deprecate_patch(patch_id)
+        return workflow.patched(patch_id)
+
+
+@workflow.defn(name="PatchActivationRolloutWorkflow")
+class PatchActivationRolloutWorkflow:
+    def __init__(self) -> None:
+        self._ready = False
+        self._released = False
+
+    @workflow.run
+    async def run(self) -> str:
+        workflow.patched("rollout-patch")
+        self._ready = True
+        await workflow.wait_condition(lambda: self._released)
+        return "new" if workflow.patched("rollout-patch") else "old"
+
+    @workflow.query
+    def ready(self) -> bool:
+        return self._ready
+
+    @workflow.signal
+    def release(self) -> None:
+        self._released = True
+
+
+@workflow.defn(name="PatchActivationRolloutWorkflow")
+class PatchActivationOldRolloutWorkflow:
+    def __init__(self) -> None:
+        self._ready = False
+        self._released = False
+
+    @workflow.run
+    async def run(self) -> str:
+        self._ready = True
+        await workflow.wait_condition(lambda: self._released)
+        return "old"
+
+    @workflow.query
+    def ready(self) -> bool:
+        return self._ready
+
+    @workflow.signal
+    def release(self) -> None:
+        self._released = True
+
+
+async def patch_marker_count(handle: WorkflowHandle) -> int:
+    count = 0
+    async for event in handle.fetch_history_events():
+        if event.event_type is EventType.EVENT_TYPE_MARKER_RECORDED:
+            count += 1
+    return count
+
+
+async def has_completed_workflow_task(handle: WorkflowHandle) -> bool:
+    async for event in handle.fetch_history_events():
+        if event.event_type is EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED:
+            return True
+    return False
+
+
+def recording_patch_activation_callback(
+    calls: list[temporalio.worker.PatchActivationInput], decision: bool
+) -> typing.Callable[[temporalio.worker.PatchActivationInput], bool]:
+    def callback(input: temporalio.worker.PatchActivationInput) -> bool:
+        calls.append(input)
+        return decision
+
+    return callback
+
+
+async def test_workflow_patch_activation_callback(client: Client):
+    workflow_id = f"workflow-{uuid.uuid4()}"
+    calls: list[temporalio.worker.PatchActivationInput] = []
+    async with new_worker(
+        client,
+        PatchActivationWorkflow,
+        patch_activation_callback=recording_patch_activation_callback(calls, True),
+    ) as worker:
+        result = await client.execute_workflow(
+            PatchActivationWorkflow.run,
+            args=["my-patch", False],
+            id=workflow_id,
+            task_queue=worker.task_queue,
+        )
+
+    assert result == [True, True]
+    assert len(calls) == 1
+    assert calls[0].workflow_info.workflow_id == workflow_id
+    assert calls[0].patch_id == "my-patch"
+
+
+async def test_workflow_patch_activation_callback_can_decline(client: Client):
+    calls: list[temporalio.worker.PatchActivationInput] = []
+    async with new_worker(
+        client,
+        PatchActivationWorkflow,
+        patch_activation_callback=recording_patch_activation_callback(calls, False),
+    ) as worker:
+        handle = await client.start_workflow(
+            PatchActivationWorkflow.run,
+            args=["my-patch", False],
+            id=f"workflow-{uuid.uuid4()}",
+            task_queue=worker.task_queue,
+        )
+        assert await handle.result() == [False, False]
+
+    assert len(calls) == 1
+    assert await patch_marker_count(handle) == 0
+
+
+async def test_workflow_patch_activation_default_activates(client: Client):
+    async with new_worker(client, PatchActivationWorkflow) as worker:
+        handle = await client.start_workflow(
+            PatchActivationWorkflow.run,
+            args=["my-patch", False],
+            id=f"workflow-{uuid.uuid4()}",
+            task_queue=worker.task_queue,
+        )
+        assert await handle.result() == [True, True]
+
+    assert await patch_marker_count(handle) == 1
+
+
+async def test_workflow_patch_activation_callback_not_recalled_on_replay(
+    client: Client,
+):
+    calls: list[temporalio.worker.PatchActivationInput] = []
+    async with new_worker(
+        client,
+        PatchActivationWorkflow,
+        max_cached_workflows=0,
+        patch_activation_callback=recording_patch_activation_callback(calls, False),
+    ) as worker:
+        result = await client.execute_workflow(
+            PatchActivationWorkflow.run,
+            args=["my-patch", True],
+            id=f"workflow-{uuid.uuid4()}",
+            task_queue=worker.task_queue,
+        )
+        assert result == [False, False]
+
+    assert len(calls) == 1
+
+
+async def test_workflow_patch_activation_callback_bypassed_for_deprecate(
+    client: Client,
+):
+    def unexpected_callback(_: temporalio.worker.PatchActivationInput) -> bool:
+        raise AssertionError("Patch activation callback should not be called")
+
+    async with new_worker(
+        client,
+        PatchActivationDeprecateWorkflow,
+        patch_activation_callback=unexpected_callback,
+    ) as worker:
+        result = await client.execute_workflow(
+            PatchActivationDeprecateWorkflow.run,
+            "my-patch",
+            id=f"workflow-{uuid.uuid4()}",
+            task_queue=worker.task_queue,
+        )
+
+    assert result is True
+
+
+async def test_workflow_patch_activation_callback_must_return_bool(client: Client):
+    def invalid_callback(_: temporalio.worker.PatchActivationInput) -> bool:
+        return "not a bool"  # type: ignore[return-value]  # pyright: ignore[reportReturnType]
+
+    async with new_worker(
+        client,
+        PatchActivationWorkflow,
+        patch_activation_callback=invalid_callback,
+    ) as worker:
+        handle = await client.start_workflow(
+            PatchActivationWorkflow.run,
+            args=["my-patch", False],
+            id=f"workflow-{uuid.uuid4()}",
+            task_queue=worker.task_queue,
+        )
+        await assert_task_fail_eventually(
+            handle,
+            message_contains="Patch activation callback must return true or false",
+        )
+
+
+async def test_workflow_patch_activation_callback_is_read_only(client: Client):
+    def make_command(_: temporalio.worker.PatchActivationInput) -> bool:
+        workflow.upsert_memo({"foo": "bar"})
+        return True
+
+    def schedule_task(_: temporalio.worker.PatchActivationInput) -> bool:
+        asyncio.get_running_loop().call_soon(lambda: None)
+        return True
+
+    def wait_condition(_: temporalio.worker.PatchActivationInput) -> bool:
+        coroutine = workflow.wait_condition(lambda: True)
+        try:
+            coroutine.send(None)
+        finally:
+            coroutine.close()
+        return True
+
+    def use_random(_: temporalio.worker.PatchActivationInput) -> bool:
+        workflow.random().random()
+        return True
+
+    def register_random_seed_callback(
+        _: temporalio.worker.PatchActivationInput,
+    ) -> bool:
+        workflow.register_random_seed_callback(lambda _seed: None)
+        return True
+
+    def create_new_random(_: temporalio.worker.PatchActivationInput) -> bool:
+        workflow.new_random()
+        return True
+
+    callbacks = [
+        (make_command, "action attempted: add command"),
+        (schedule_task, "action attempted: schedule task"),
+        (wait_condition, "action attempted: wait condition"),
+        (use_random, "action attempted: random"),
+        (
+            register_random_seed_callback,
+            "action attempted: register random seed callback",
+        ),
+        (create_new_random, "action attempted: register random seed callback"),
+    ]
+    for callback, message in callbacks:
+        async with new_worker(
+            client,
+            PatchActivationWorkflow,
+            patch_activation_callback=callback,
+        ) as worker:
+            handle = await client.start_workflow(
+                PatchActivationWorkflow.run,
+                args=["my-patch", False],
+                id=f"workflow-{uuid.uuid4()}",
+                task_queue=worker.task_queue,
+            )
+            await assert_task_fail_eventually(handle, message_contains=message)
+
+
+async def test_workflow_declined_patch_rolls_out_to_old_worker(client: Client):
+    task_queue = f"tq-{uuid.uuid4()}"
+    calls: list[temporalio.worker.PatchActivationInput] = []
+    async with new_worker(
+        client,
+        PatchActivationRolloutWorkflow,
+        task_queue=task_queue,
+        max_cached_workflows=0,
+        patch_activation_callback=recording_patch_activation_callback(calls, False),
+    ):
+        handle = await client.start_workflow(
+            PatchActivationRolloutWorkflow.run,
+            id=f"workflow-{uuid.uuid4()}",
+            task_queue=task_queue,
+        )
+        await assert_eq_eventually(True, lambda: has_completed_workflow_task(handle))
+
+    assert len(calls) == 1
+    async with new_worker(
+        client,
+        PatchActivationOldRolloutWorkflow,
+        task_queue=task_queue,
+        max_cached_workflows=0,
+    ):
+        await handle.signal("release")
+        assert await handle.result() == "old"
+
+
+async def test_workflow_activated_patch_ignores_declining_worker(client: Client):
+    task_queue = f"tq-{uuid.uuid4()}"
+    activated_calls: list[temporalio.worker.PatchActivationInput] = []
+    declining_calls: list[temporalio.worker.PatchActivationInput] = []
+    async with new_worker(
+        client,
+        PatchActivationRolloutWorkflow,
+        task_queue=task_queue,
+        max_cached_workflows=0,
+        patch_activation_callback=recording_patch_activation_callback(
+            activated_calls, True
+        ),
+    ):
+        handle = await client.start_workflow(
+            PatchActivationRolloutWorkflow.run,
+            id=f"workflow-{uuid.uuid4()}",
+            task_queue=task_queue,
+        )
+        await assert_eq_eventually(True, lambda: has_completed_workflow_task(handle))
+
+    assert len(activated_calls) == 1
+    async with new_worker(
+        client,
+        PatchActivationRolloutWorkflow,
+        task_queue=task_queue,
+        max_cached_workflows=0,
+        patch_activation_callback=recording_patch_activation_callback(
+            declining_calls, False
+        ),
+    ):
+        await handle.signal(PatchActivationRolloutWorkflow.release)
+        assert await handle.result() == "new"
+
+    assert not declining_calls
+
+
+@workflow.defn
 class UUIDWorkflow:
     def __init__(self) -> None:
         self._result = "<unset>"
@@ -4175,6 +4498,8 @@ class QueriesDoingBadThingsWorkflow:
             workflow.set_query_handler("some-handler", lambda: "whatever")
         elif bad_thing == "patch":
             workflow.patched("some-patch")
+        elif bad_thing == "register_random_seed_callback":
+            workflow.register_random_seed_callback(lambda _seed: None)
         elif bad_thing == "signal_external_handle":
             await workflow.get_external_workflow_handle("some-id").signal("some-signal")
         return "should never get here"
@@ -4203,6 +4528,7 @@ async def test_workflow_queries_doing_bad_things(client: Client):
         await assert_bad_query("random")
         await assert_bad_query("set_query_handler")
         await assert_bad_query("patch")
+        await assert_bad_query("register_random_seed_callback")
         await assert_bad_query("signal_external_handle")
 
 


### PR DESCRIPTION
## What was changed

Added an experimental `Worker(..., patch_activation_callback=...)` option that lets a worker decide whether the first newly encountered, non-replay `workflow.patched` call activates a patch.

The callback receives frozen `PatchActivationInput` containing workflow information and the patch ID. Its strict boolean decision is memoized for the workflow run. Declined patches return `False` without recording a marker, while replay, existing history markers, and deprecated patches retain their existing behavior. Replayers do not invoke the callback.

This ports the behavior introduced by https://github.com/temporalio/sdk-ruby/pull/481.

## Why?

This allows workflow changes using `workflow.patched` to roll out gradually without every new-code worker immediately recording a marker that older workers cannot replay.

## Testing

- Focused patch activation and rolling-worker scenarios: 11
- Targeted mypy checks
- Ruff import and formatting checks
- Diff and sdk-core submodule cleanliness checks