### PR TITLE
Release the GIL during the activity heartbeat core call

### DIFF
--- a/temporalio/bridge/src/worker.rs
+++ b/temporalio/bridge/src/worker.rs
@@ -658,10 +658,14 @@ impl WorkerRef {
         enter_sync!(self.runtime);
         let heartbeat = ActivityHeartbeat::decode(proto.as_bytes())
             .map_err(|err| PyValueError::new_err(format!("Invalid proto: {err}")))?;
-        self.worker
-            .as_ref()
-            .unwrap()
-            .record_activity_heartbeat(heartbeat);
+        let worker = self.worker.as_ref().unwrap().clone();
+        // Detach from the GIL during the core call. Core may block on internal
+        // locks whose holders can call back into Python (e.g. a custom slot
+        // supplier's mark_slot_used runs while core's outstanding-activity
+        // lock is held); holding the GIL here would deadlock the worker.
+        proto
+            .py()
+            .detach(move || worker.record_activity_heartbeat(heartbeat));
         Ok(())
     }
 

--- a/tests/worker/test_worker.py
+++ b/tests/worker/test_worker.py
@@ -589,6 +589,95 @@ async def test_blocking_slot_supplier(client: Client):
         await asyncio.sleep(1)
 
 
+@activity.defn
+async def heartbeating_activity(beats: int) -> None:
+    for i in range(beats):
+        activity.heartbeat(i)
+        await asyncio.sleep(0)
+
+
+@workflow.defn
+class HeartbeatingFanOutWorkflow:
+    @workflow.run
+    async def run(self, total: int, beats: int, window: int) -> None:
+        in_flight = asyncio.Semaphore(window)
+
+        async def run_one() -> None:
+            async with in_flight:
+                await workflow.execute_activity(
+                    heartbeating_activity,
+                    beats,
+                    start_to_close_timeout=timedelta(minutes=1),
+                    heartbeat_timeout=timedelta(seconds=30),
+                )
+
+        await asyncio.gather(*(run_one() for _ in range(total)))
+
+
+async def test_custom_slot_supplier_with_heartbeating_activities(client: Client):
+    """Regression test for the GIL <-> core-mutex deadlock (#1642).
+
+    Any custom slot supplier plus heartbeating activities used to wedge the
+    worker permanently: the heartbeat FFI held the GIL while blocking on
+    core's outstanding-activity lock, while an activity task start invoked
+    mark_slot_used (which acquires the GIL) under that same lock. The
+    supplier below is deliberately trivial - the deadlock was in the calling
+    convention, not in what the callbacks do.
+
+    NOTE: on regression this test HANGS rather than fails - the deadlock
+    freezes the event loop, so no in-process timeout (including the
+    wait_for below) can fire, and only a CI-level job timeout kills it.
+    """
+
+    class CappedSlotSupplier(CustomSlotSupplier):
+        def __init__(self, max_slots: int) -> None:
+            self.max_slots = max_slots
+            self.used = 0
+
+        async def reserve_slot(self, ctx: SlotReserveContext) -> SlotPermit:
+            while True:
+                permit = self.try_reserve_slot(ctx)
+                if permit is not None:
+                    return permit
+                await asyncio.sleep(0.005)
+
+        def try_reserve_slot(self, ctx: SlotReserveContext) -> SlotPermit | None:
+            # Called with the GIL held, so no extra lock is needed
+            if self.used >= self.max_slots:
+                return None
+            self.used += 1
+            return SlotPermit()
+
+        def mark_slot_used(self, ctx: SlotMarkUsedContext) -> None:
+            return None
+
+        def release_slot(self, ctx: SlotReleaseContext) -> None:
+            self.used = max(0, self.used - 1)
+
+    fixed = FixedSizeSlotSupplier(100)
+    tuner = WorkerTuner.create_composite(
+        workflow_supplier=fixed,
+        # A small cap keeps activity starts (and thus mark_slot_used calls)
+        # churning against the heartbeat FFI
+        activity_supplier=CappedSlotSupplier(8),
+        local_activity_supplier=fixed,
+        nexus_supplier=fixed,
+    )
+    async with new_worker(
+        client,
+        HeartbeatingFanOutWorkflow,
+        activities=[heartbeating_activity],
+        tuner=tuner,
+    ) as w:
+        wf1 = await client.start_workflow(
+            HeartbeatingFanOutWorkflow.run,
+            args=[600, 50, 150],
+            id=f"heartbeating-slot-supplier-{uuid.uuid4()}",
+            task_queue=w.task_queue,
+        )
+        await asyncio.wait_for(wf1.result(), timeout=120)
+
+
 @workflow.defn(
     name="DeploymentVersioningWorkflow",
     versioning_behavior=VersioningBehavior.AUTO_UPGRADE,


### PR DESCRIPTION
## What was changed

`WorkerRef::record_activity_heartbeat` in the pyo3 bridge now detaches from the GIL (`Python::detach`, formerly `allow_threads`) for the call into core. The heartbeat proto is still decoded with the GIL held (it borrows the Python `bytes`), so only owned data crosses the detach boundary.

Also adds a regression test: a trivial custom slot supplier + a workflow fanning out heartbeating activities (`tests/worker/test_worker.py::test_custom_slot_supplier_with_heartbeating_activities`).

## Why?

Fixes the permanent worker deadlock described in #1642: any worker using a `CustomSlotSupplier` whose activities heartbeat can wedge forever.

- The heartbeat FFI held the GIL while core's `record_heartbeat` blocked on the `outstanding_activity_tasks` mutex.
- Meanwhile an activity task start invokes the supplier's `mark_slot_used` — whose bridge wrapper unconditionally acquires the GIL — while core holds that same mutex (guard alive during `insert(...)` argument evaluation).

Classic ABBA: thread A holds the mutex and wants the GIL; thread B holds the GIL and wants the mutex. Releasing the GIL during the core call means the cycle cannot form, and as a bonus a heartbeat contending on that mutex no longer freezes the entire Python process (event loop and all unrelated threads) for the duration.

The other half of the cycle (core invoking lang callbacks while holding internal locks, including via Rust temporary-lifetime guard extension in `insert(...)` argument position) is described in #1642 for the maintainers' consideration; this PR fixes the Python side, which alone breaks the cycle.

## Checklist

1. Closes #1642

2. How was this tested:

- New regression test `test_custom_slot_supplier_with_heartbeating_activities` (600 heartbeating activities through a capped custom slot supplier). Passes in ~13s with this change. Note: on regression it hangs rather than fails — the deadlock freezes the event loop, so no in-process timeout can fire (the deterministic non-hanging variant of this test would belong in sdk-core, where the lock ordering can be unit-tested directly).
- The reproducer from #1642 (8000 heartbeating activities, no-op custom slot supplier), unpatched `temporalio==1.30.0`:

  ```
  starting: 8000 activities, cap=12, 150 heartbeats each
  ...wedges before the first activity completes; faulthandler dump at 20s:
  Timeout (0:00:20)!
  Thread 0x00000001f74fdd80 (most recent call first):
    File ".../temporalio/bridge/worker.py", line 258 in record_activity_heartbeat   <-- holds GIL, wants core mutex
    File ".../temporalio/worker/_activity.py", line 290 in _heartbeat_async
    ...
  ```

  Same reproducer against this branch (editable install, patched bridge):

  ```
  [  31.1s] completed=7817
  [  31.6s] completed=7954
  workflow COMPLETED without a deadlock -- raise the load and retry
  ```

- `cargo fmt --check`, `cargo clippy -- -D warnings` (bridge), `ruff check --select I` / `ruff format --check` on the touched test file: clean.
- All four `*slot_supplier*` tests in `tests/worker/test_worker.py` pass locally.

3. Any docs updates needed?

None — behavior-preserving fix, no API change.
