### PR TITLE
Fix copy-paste error message in OpenTelemetryPlugin

### DIFF
--- a/temporalio/contrib/opentelemetry/_plugin.py
+++ b/temporalio/contrib/opentelemetry/_plugin.py
@@ -34,7 +34,9 @@ class OpenTelemetryPlugin(SimplePlugin):
 
         def workflow_runner(runner: WorkflowRunner | None) -> WorkflowRunner:
             if not runner:
-                raise ValueError("No WorkflowRunner provided to the OpenAI plugin.")
+                raise ValueError(
+                    "No WorkflowRunner provided to the OpenTelemetry plugin."
+                )
 
             # If in sandbox, add additional passthrough
             if isinstance(runner, SandboxedWorkflowRunner):


### PR DESCRIPTION
The `OpenTelemetryPlugin` no-runner guard raised `ValueError("No WorkflowRunner provided to the OpenAI plugin.")`, a copy-paste leftover from the OpenAI-agents plugin. This corrects it to name the OpenTelemetry plugin.