### PR TITLE
Fix type checking for google-genai 2.12.0

### DIFF
--- a/temporalio/contrib/google_genai/_compat.py
+++ b/temporalio/contrib/google_genai/_compat.py
@@ -12,15 +12,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     # google-genai 2.12.0 exports two ``Interaction`` names: the interaction
     # resource class and a ``TypeAliasType`` over the trigger-request
-    # variants. At runtime the resource class deliberately wins the
-    # star-import ordering in ``google.genai.interactions`` (see the comment
-    # there), but type checkers resolve the name to the alias — which cannot
-    # be used with ``isinstance`` and lacks the resource fields (``id``,
-    # ``status``, ...). Bind the static view to the class's defining module
-    # (the same location in 2.10.x); the runtime binding stays on the public
-    # path, so behavior is unchanged.
+    # variants. At runtime we get the resource class but type checkers
+    # resolve to the alias which causes failures (the alias has no ``id``,
+    # etc.). Force the type checker to see the right import here.
     from google.genai._gaos.types.interactions.interaction import Interaction
 else:
+    # < 2.12.0 has the expected behavior / only one exported ``Interaction``
     from google.genai.interactions import Interaction
 
 __all__ = ["Interaction"]

--- a/temporalio/contrib/google_genai/_compat.py
+++ b/temporalio/contrib/google_genai/_compat.py
@@ -14,10 +14,11 @@ if TYPE_CHECKING:
     # resource class and a ``TypeAliasType`` over the trigger-request
     # variants. At runtime we get the resource class but type checkers
     # resolve to the alias which causes failures (the alias has no ``id``,
-    # etc.). Force the type checker to see the right import here.
+    # etc.). Force the type checker to see the class' defining module (in
+    # the same location in 2.10 and 2.12).
     from google.genai._gaos.types.interactions.interaction import Interaction
 else:
-    # < 2.12.0 has the expected behavior / only one exported ``Interaction``
+    # At runtime, Interaction resolves properly for 2.10 and 2.12
     from google.genai.interactions import Interaction
 
 __all__ = ["Interaction"]

--- a/temporalio/contrib/google_genai/_compat.py
+++ b/temporalio/contrib/google_genai/_compat.py
@@ -1,0 +1,26 @@
+"""Version-compatibility shims for the ``google-genai`` SDK.
+
+Single home for workarounds that keep the plugin importable and
+type-checkable across the supported ``google-genai`` range; remove entries
+as upstream fixes land.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # google-genai 2.12.0 exports two ``Interaction`` names: the interaction
+    # resource class and a ``TypeAliasType`` over the trigger-request
+    # variants. At runtime the resource class deliberately wins the
+    # star-import ordering in ``google.genai.interactions`` (see the comment
+    # there), but type checkers resolve the name to the alias — which cannot
+    # be used with ``isinstance`` and lacks the resource fields (``id``,
+    # ``status``, ...). Bind the static view to the class's defining module
+    # (the same location in 2.10.x); the runtime binding stays on the public
+    # path, so behavior is unchanged.
+    from google.genai._gaos.types.interactions.interaction import Interaction
+else:
+    from google.genai.interactions import Interaction
+
+__all__ = ["Interaction"]

--- a/temporalio/contrib/google_genai/_gemini_activity.py
+++ b/temporalio/contrib/google_genai/_gemini_activity.py
@@ -17,11 +17,11 @@ import google.auth.credentials
 from google.genai import Client as GeminiClient
 from google.genai import errors as genai_errors
 from google.genai import types
-from google.genai.interactions import Interaction
 from google.genai.types import HttpOptions
 from google.genai.types import HttpResponse as SdkHttpResponse
 
 from temporalio import activity
+from temporalio.contrib.google_genai._compat import Interaction
 from temporalio.contrib.google_genai._models import (
     _GeminiApiRequest,
     _GeminiApiResponse,

--- a/temporalio/contrib/google_genai/_temporal_interactions.py
+++ b/temporalio/contrib/google_genai/_temporal_interactions.py
@@ -20,9 +20,10 @@ from types import TracebackType
 from typing import Any, cast
 
 import pydantic
-from google.genai.interactions import Interaction, InteractionSSEEvent
+from google.genai.interactions import InteractionSSEEvent
 
 from temporalio import workflow as temporal_workflow
+from temporalio.contrib.google_genai._compat import Interaction
 from temporalio.contrib.google_genai._models import (
     _GeminiInteractionIdRequest,
     _GeminiInteractionRequest,

--- a/tests/contrib/google_genai/test_gemini.py
+++ b/tests/contrib/google_genai/test_gemini.py
@@ -32,7 +32,6 @@ from google.genai import Client as GeminiClient
 from google.genai import types
 from google.genai.interactions import (
     Agent,  # pyright: ignore[reportPrivateImportUsage]
-    Interaction,
     InteractionSSEEvent,
 )
 from google.genai.types import HttpResponse as SdkHttpResponse
@@ -45,6 +44,7 @@ from temporalio.contrib.google_genai import (
     GoogleGenAIPlugin,
     activity_as_tool,
 )
+from temporalio.contrib.google_genai._compat import Interaction
 from temporalio.contrib.google_genai._models import (
     _GeminiApiRequest,
     _GeminiApiResponse,


### PR DESCRIPTION
## What

`google-genai` 2.12.0 (released 2026-07-16, within our `>=2.10.0,<3.0.0` range) broke type checking of `temporalio.contrib.google_genai`: `test-latest-deps` fails with 34 mypy errors (`isinstance` with a `TypeAliasType`, missing `id`/`status` attributes). Every branch's next `test-latest-deps` run fails the same way.

## Why

2.12.0's `google.genai.interactions` exports two `Interaction` names: the interaction **resource class** and a **`TypeAliasType`** over the trigger-request variants (`CreateAgentInteraction | CreateModelInteraction`). The module deliberately orders its star-imports so the resource class wins at runtime (per the comment in that module), but type checkers resolve the name to the alias, which fails (doesn't work with `isinstance`, no resource fields).

## How

A new `_compat.py` shim:

- **runtime**: unchanged; still binds `google.genai.interactions.Interaction` (verified the imported object is *identical* under 2.10.0 and 2.12.0, so there is no functionality change);
- **static** (`TYPE_CHECKING`): binds the class' defining module, which is the same location in 2.10.x and 2.12.0.

The three import sites (`_gemini_activity`, `_temporal_interactions`, `test_gemini`) go through the shim. Remove the shim once upstream exports the resource class unambiguously for type checkers.

## Verification

All tests and CI checks pass now with 2.10 and 2.12