### PR TITLE
Remove exclude-newer-package exemptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,4 +266,3 @@ exclude = ["temporalio/bridge/target/**/*"]
 # Prevent uv commands from building the package by default
 package = false
 exclude-newer = "2 weeks"
-exclude-newer-package = { google-adk = false, google-genai = false, openai-agents = false }

--- a/uv.lock
+++ b/uv.lock
@@ -12,11 +12,6 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P2W"
 
-[options.exclude-newer-package]
-google-adk = false
-google-genai = false
-openai-agents = false
-
 [[package]]
 name = "aioboto3"
 version = "15.5.0"


### PR DESCRIPTION
## What was changed

Removed the `exclude-newer-package` exemptions for `google-adk`, `google-genai`, and `openai-agents` from `pyproject.toml`, and re-ran `uv lock` (no version changes, only the exemption metadata block was removed).

## Why?

These exemptions existed because the pinned versions were newer than the 2-week `exclude-newer` cooldown when they were added. The currently locked versions all now predate the cutoff:

- `google-adk 2.2.0` — released 2026-06-04
- `google-genai 2.10.0` — released 2026-06-24
- `openai-agents 0.17.7` — released 2026-06-24

🤖 Generated with [Claude Code](https://claude.com/claude-code)