### PR TITLE
Fix stale workflow.tracer() references in OpenTelemetry contrib

### DIFF
--- a/temporalio/contrib/opentelemetry/README.md
+++ b/temporalio/contrib/opentelemetry/README.md
@@ -68,7 +68,7 @@ worker = Worker(
 - **Accurate Duration Spans**: Workflow spans have real durations reflecting actual execution time
 - **Direct OpenTelemetry Usage**: Use `opentelemetry.trace.get_tracer()` directly within workflows
 - **Better Span Hierarchy**: More accurate parent-child relationships within workflows
-- **Workflow Context Access**: Access spans within workflows using `temporalio.contrib.opentelemetry.workflow.tracer()`
+- **Workflow Context Access**: Access spans within workflows using `opentelemetry.trace.get_tracer()`
 
 #### ⚠️ Considerations:
 - **Experimental Status**: Subject to breaking changes in future versions

--- a/temporalio/contrib/opentelemetry/_plugin.py
+++ b/temporalio/contrib/opentelemetry/_plugin.py
@@ -18,7 +18,7 @@ class OpenTelemetryPlugin(SimplePlugin):
     It uses the new OpenTelemetryInterceptor implementation.
 
     Unlike the prior TracingInterceptor, this allows for accurate duration spans and parenting inside a workflow
-    with temporalio.contrib.opentelemetry.workflow.tracer()
+    using opentelemetry.trace.get_tracer() directly.
 
     Your tracer provider should be created with `create_tracer_provider` for it to be used within a Temporal worker.
     """

--- a/temporalio/contrib/opentelemetry/workflow.py
+++ b/temporalio/contrib/opentelemetry/workflow.py
@@ -30,7 +30,7 @@ def completed_span(
     span and this interceptor is configured on the worker and the span is on
     the context).
 
-    To create a long-running span or to create a span that actually spans other code use OpenTelemetryPlugin and tracer().
+    To create a long-running span or to create a span that actually spans other code use OpenTelemetryPlugin and opentelemetry.trace.get_tracer().
 
     Args:
         name: Name of the span.


### PR DESCRIPTION
The `OpenTelemetryPlugin` docstring, the `completed_span()` docstring, and the README all pointed readers at `temporalio.contrib.opentelemetry.workflow.tracer()`, which does not exist (the module only defines `completed_span()`). This points them at the real `opentelemetry.trace.get_tracer()` instead.