### PR TITLE
fix: close ephemeral Google ADK MCP toolsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ to include examples, links to docs, or any other relevant information.
 
 ### Fixed
 
+- Fixed Google ADK MCP toolset activities to close their factory-created toolsets after
+  listing or invoking tools, preventing leaked MCP sessions and stdio subprocesses.
+
 ### Security
 
 ## [1.30.0] - 2026-07-01

--- a/temporalio/contrib/google_adk_agents/_mcp.py
+++ b/temporalio/contrib/google_adk_agents/_mcp.py
@@ -109,41 +109,47 @@ class TemporalMcpToolSetProvider:
             args: _GetToolsArguments,
         ) -> list[_ToolResult]:
             toolset = self._toolset_factory(args.factory_argument)
-            tools = await toolset.get_tools()
-            return [
-                _ToolResult(
-                    tool.name,
-                    tool.description,
-                    tool.is_long_running,
-                    tool.custom_metadata,
-                    tool._get_declaration(),
-                )
-                for tool in tools
-            ]
+            try:
+                tools = await toolset.get_tools()
+                return [
+                    _ToolResult(
+                        tool.name,
+                        tool.description,
+                        tool.is_long_running,
+                        tool.custom_metadata,
+                        tool._get_declaration(),
+                    )
+                    for tool in tools
+                ]
+            finally:
+                await toolset.close()
 
         @activity.defn(name=self._name + "-call-tool")
         async def call_tool(
             args: _CallToolArguments,
         ) -> _CallToolResult:
             toolset = self._toolset_factory(args.factory_argument)
-            tools = await toolset.get_tools()
-            tool_match = [tool for tool in tools if tool.name == args.name]
-            if len(tool_match) == 0:
-                raise ApplicationError(
-                    f"Unable to find matching mcp tool by name: {args.name}"
-                )
-            if len(tool_match) > 1:
-                raise ApplicationError(
-                    f"Unable too many matching mcp tools by name: {args.name}"
-                )
-            tool = tool_match[0]
+            try:
+                tools = await toolset.get_tools()
+                tool_match = [tool for tool in tools if tool.name == args.name]
+                if len(tool_match) == 0:
+                    raise ApplicationError(
+                        f"Unable to find matching mcp tool by name: {args.name}"
+                    )
+                if len(tool_match) > 1:
+                    raise ApplicationError(
+                        f"Unable too many matching mcp tools by name: {args.name}"
+                    )
+                tool = tool_match[0]
 
-            # We cannot provide a full-fledged ToolContext so we need to provide only what is needed by the tool
-            result = await tool.run_async(
-                args=args.arguments,
-                tool_context=args.tool_context,  #  type:ignore
-            )
-            return _CallToolResult(result=result, tool_context=args.tool_context)
+                # We cannot provide a full-fledged ToolContext so we need to provide only what is needed by the tool
+                result = await tool.run_async(
+                    args=args.arguments,
+                    tool_context=args.tool_context,  #  type:ignore
+                )
+                return _CallToolResult(result=result, tool_context=args.tool_context)
+            finally:
+                await toolset.close()
 
         return get_tools, call_tool
 

--- a/tests/contrib/google_adk_agents/test_google_adk_agents.py
+++ b/tests/contrib/google_adk_agents/test_google_adk_agents.py
@@ -53,6 +53,11 @@ from temporalio.contrib.google_adk_agents import (
     TemporalMcpToolSetProvider,
     TemporalModel,
 )
+from temporalio.contrib.google_adk_agents._mcp import (
+    TemporalToolContext,
+    _CallToolArguments,
+    _GetToolsArguments,
+)
 from temporalio.contrib.opentelemetry import OpenTelemetryPlugin, create_tracer_provider
 from temporalio.worker import Worker
 from temporalio.workflow import ActivityConfig
@@ -396,6 +401,62 @@ def example_toolset(_: Any | None) -> McpToolset:
             ),
         ),
     )
+
+
+class _TrackingMcpTool:
+    name = "tracking-tool"
+    description = "A test MCP tool"
+    is_long_running = False
+    custom_metadata = None
+
+    def _get_declaration(self) -> None:
+        return None
+
+    async def run_async(
+        self, *, args: dict[str, Any], tool_context: TemporalToolContext
+    ) -> dict[str, Any]:
+        return args
+
+
+class _TrackingMcpToolset:
+    def __init__(self) -> None:
+        self.close_calls = 0
+        self.tool = _TrackingMcpTool()
+
+    async def get_tools(self) -> list[_TrackingMcpTool]:
+        return [self.tool]
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_mcp_toolset_provider_closes_factory_toolsets() -> None:
+    created_toolsets: list[_TrackingMcpToolset] = []
+
+    def factory(_: Any | None) -> _TrackingMcpToolset:
+        toolset = _TrackingMcpToolset()
+        created_toolsets.append(toolset)
+        return toolset
+
+    get_tools, call_tool = TemporalMcpToolSetProvider(
+        "tracking",
+        factory,  # type: ignore[arg-type]
+    )._get_activities()
+
+    tool_results = await get_tools(_GetToolsArguments(None))
+    call_result = await call_tool(
+        _CallToolArguments(
+            None,
+            "tracking-tool",
+            {"value": "ok"},
+            tool_context=None,  # type: ignore[arg-type]
+        )
+    )
+
+    assert [tool.name for tool in tool_results] == ["tracking-tool"]
+    assert call_result.result == {"value": "ok"}
+    assert [toolset.close_calls for toolset in created_toolsets] == [1, 1]
 
 
 def mcp_agent(model_name: str) -> Agent:


### PR DESCRIPTION
closes #1663

This PR closes each factory-created Google ADK `McpToolset` after the generated list-tools and call-tool activities complete. The existing per-activity factory semantics are preserved; the change ensures the MCP session manager releases stdio subprocesses and other transport resources even when tool discovery or invocation raises.

<details>

Validation:
- `pytest -q -n0 tests/contrib/google_adk_agents/test_google_adk_agents.py -k mcp_toolset_provider_closes_factory_toolsets`
- `ruff check temporalio/contrib/google_adk_agents/_mcp.py tests/contrib/google_adk_agents/test_google_adk_agents.py`
- `ruff format --check temporalio/contrib/google_adk_agents/_mcp.py tests/contrib/google_adk_agents/test_google_adk_agents.py`

</details>