### PR TITLE
Fix type checking for openai 2.45.0

### DIFF
--- a/tests/contrib/openai_agents/test_openai_streaming.py
+++ b/tests/contrib/openai_agents/test_openai_streaming.py
@@ -159,7 +159,9 @@ class StreamingTestModel(Model):
                 input_tokens=10,
                 output_tokens=5,
                 total_tokens=15,
-                input_tokens_details=InputTokensDetails(cached_tokens=0),
+                input_tokens_details=InputTokensDetails.model_validate(
+                    {"cached_tokens": 0, "cache_write_tokens": 0}
+                ),
                 output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
             ),
         )


### PR DESCRIPTION
openai 2.45.0 added a required cache_write_tokens field to InputTokensDetails; construct it via model_validate so the test type-checks with both older and newer openai.