### PR TITLE
Fix JSON conversion for dict[None, T] keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ to include examples, links to docs, or any other relevant information.
 
 ### Fixed
 
+- Fixed JSON conversion of `dict[None, T]` type hints to restore `None` keys.
+
 ### Security
 
 ## [1.30.0] - 2026-07-01

--- a/temporalio/converter/_payload_converter.py
+++ b/temporalio/converter/_payload_converter.py
@@ -916,8 +916,10 @@ def value_to_type(
             origin, "__optional_keys__", None
         ):
             per_key_types = get_type_hints(origin)
-        key_type = (
-            type_args[0]
+        key_type: Any = (
+            type(None)
+            if len(type_args) > 0 and type_args[0] is None
+            else type_args[0]
             if len(type_args) > 0
             and type_args[0] is not Any
             and not isinstance(type_args[0], TypeVar)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -552,10 +552,7 @@ def test_json_type_hints():
     ok(dict[float, str], {1.0: "1"})
     ok(dict[bool, str], {True: "1"})
 
-    # On a 3.10+ dict type, None isn't returned from a key. This is potentially a bug
-    ok(dict[None, str], {"null": "1"})
-
-    # Dict has a different value for None keys
+    ok(dict[None, str], {None: "1"})
     ok(Dict[None, str], {None: "1"})  # type:ignore[reportDeprecated]
 
     # Alias


### PR DESCRIPTION
## Summary

Normalize the literal `None` key argument produced by built-in
`dict[None, T]` type hints so JSON object keys serialized as `"null"` are
restored to Python `None`.

Fixes #1237.

## Root cause

Built-in generics and `typing.Dict` expose this annotation differently:

- `dict[None, str]` yields literal `None` as its key argument
- `typing.Dict[None, str]` yields `NoneType`

The mapping converter treated literal `None` as an absent key type, so it left
the JSON key as `"null"`.

The normalization is intentionally mapping-specific. It does not alter unrelated
annotations such as `Literal[None]`.

## Changes

- normalize literal `None` to `NoneType` while selecting a mapping key converter
- update the existing known-bug assertion to expect `{None: "1"}`
- add an Unreleased changelog entry

## Validation

- focused `test_json_type_hints`
- complete `tests/test_converter.py`: 28 passed
- repository-wide `poe lint`
- `git diff --check`