### PR TITLE
AI-374: Warn against passing secrets through MCP factory_argument

### DIFF
--- a/temporalio/contrib/google_adk_agents/README.md
+++ b/temporalio/contrib/google_adk_agents/README.md
@@ -166,6 +166,10 @@ worker = Worker(
 )
 ```
 
+`TemporalMcpToolSet` also accepts an optional `factory_argument`. It is sent to the toolset activities and passed to the registered `toolset_factory` when the `McpToolset` is created.
+
+⚠️ **Do not pass secrets, credentials, or API keys through `factory_argument`.** It is serialized as an activity argument, so it is recorded in workflow history, which is durable, replayed on every workflow replay, and visible in the Web UI. Resolve credentials worker-side inside the toolset factory instead (environment variable, secret manager, etc.), passing only non-secret identifiers through `factory_argument`.
+
 ### Local ADK Runs
 
 The same agent definitions can also be exercised outside Temporal with

--- a/temporalio/contrib/google_adk_agents/README.md
+++ b/temporalio/contrib/google_adk_agents/README.md
@@ -168,7 +168,7 @@ worker = Worker(
 
 `TemporalMcpToolSet` also accepts an optional `factory_argument`. It is sent to the toolset activities and passed to the registered `toolset_factory` when the `McpToolset` is created.
 
-⚠️ **Do not pass secrets, credentials, or API keys through `factory_argument`.** It is serialized as an activity argument, so it is recorded in workflow history, which is durable, replayed on every workflow replay, and visible in the Web UI. Resolve credentials worker-side inside the toolset factory instead (environment variable, secret manager, etc.), passing only non-secret identifiers through `factory_argument`.
+**Do not pass secrets, credentials, or API keys through `factory_argument`.** It is an activity argument, so it is recorded in workflow history and, without a payload codec, visible in the web UI. Resolve credentials worker-side inside the toolset factory instead.
 
 ### Local ADK Runs
 

--- a/temporalio/contrib/google_adk_agents/_mcp.py
+++ b/temporalio/contrib/google_adk_agents/_mcp.py
@@ -221,10 +221,19 @@ class TemporalMcpToolSet(BaseToolset):
     ):
         """Initializes the Temporal MCP toolset.
 
+        .. warning::
+            Do not pass secrets, credentials, or API keys through ``factory_argument``. It
+            is serialized as an activity argument, so it is recorded in workflow history,
+            which is durable, replayed on every workflow replay, and visible in the Web UI.
+            Resolve credentials worker-side inside the toolset factory instead (environment
+            variable, secret manager, etc.), passing only non-secret identifiers through
+            ``factory_argument``.
+
         Args:
             name: Name of the toolset (used for activity naming).
             config: Optional activity configuration.
-            factory_argument: Optional argument passed to toolset factory.
+            factory_argument: Optional argument passed to toolset factory. Must not
+                contain secrets; see the warning above.
             not_in_workflow_toolset: Optional factory that returns the
                 underlying ``McpToolset`` to use when this wrapper executes
                 outside ``workflow.in_workflow()``, such as local ADK runs.

--- a/temporalio/contrib/google_adk_agents/_mcp.py
+++ b/temporalio/contrib/google_adk_agents/_mcp.py
@@ -97,7 +97,9 @@ class TemporalMcpToolSetProvider:
 
         Args:
             name: Name prefix for the generated activities.
-            toolset_factory: Factory function that creates McpToolset instances.
+            toolset_factory: Factory function that creates McpToolset instances. It
+                receives the ``factory_argument`` from the workflow, or ``None`` if the
+                workflow did not provide one.
         """
         super().__init__()
         self._name = name
@@ -223,17 +225,16 @@ class TemporalMcpToolSet(BaseToolset):
 
         .. warning::
             Do not pass secrets, credentials, or API keys through ``factory_argument``. It
-            is serialized as an activity argument, so it is recorded in workflow history,
-            which is durable, replayed on every workflow replay, and visible in the Web UI.
-            Resolve credentials worker-side inside the toolset factory instead (environment
-            variable, secret manager, etc.), passing only non-secret identifiers through
-            ``factory_argument``.
+            is an activity argument, so it is recorded in workflow history and, without a
+            payload codec, visible in the web UI. Resolve credentials worker-side inside the
+            toolset factory instead.
 
         Args:
             name: Name of the toolset (used for activity naming).
             config: Optional activity configuration.
-            factory_argument: Optional argument passed to toolset factory. Must not
-                contain secrets; see the warning above.
+            factory_argument: Optional argument passed to the ``toolset_factory``
+                registered on ``TemporalMcpToolSetProvider``. ``not_in_workflow_toolset``
+                always receives ``None``. Must not contain secrets.
             not_in_workflow_toolset: Optional factory that returns the
                 underlying ``McpToolset`` to use when this wrapper executes
                 outside ``workflow.in_workflow()``, such as local ADK runs.

--- a/temporalio/contrib/google_adk_agents/_mcp.py
+++ b/temporalio/contrib/google_adk_agents/_mcp.py
@@ -97,9 +97,7 @@ class TemporalMcpToolSetProvider:
 
         Args:
             name: Name prefix for the generated activities.
-            toolset_factory: Factory function that creates McpToolset instances. It
-                receives the ``factory_argument`` from the workflow, or ``None`` if the
-                workflow did not provide one.
+            toolset_factory: Factory function that creates McpToolset instances.
         """
         super().__init__()
         self._name = name
@@ -232,9 +230,8 @@ class TemporalMcpToolSet(BaseToolset):
         Args:
             name: Name of the toolset (used for activity naming).
             config: Optional activity configuration.
-            factory_argument: Optional argument passed to the ``toolset_factory``
-                registered on ``TemporalMcpToolSetProvider``. ``not_in_workflow_toolset``
-                always receives ``None``. Must not contain secrets.
+            factory_argument: Optional argument passed to ``toolset_factory``.
+                Must not contain secrets.
             not_in_workflow_toolset: Optional factory that returns the
                 underlying ``McpToolset`` to use when this wrapper executes
                 outside ``workflow.in_workflow()``, such as local ADK runs.

--- a/temporalio/contrib/openai_agents/README.md
+++ b/temporalio/contrib/openai_agents/README.md
@@ -447,6 +447,12 @@ For implementation details and examples, see the [samples repository](https://gi
 When using stateful servers, the dedicated worker maintaining the connection may fail due to network issues or server problems. When this happens, Temporal raises an `ApplicationError` and cannot automatically recover because it cannot restore the lost server state.
 To recover from such failures, you need to implement your own application-level retry logic.
 
+### Factory Arguments
+
+Both `stateless_mcp_server()` and `stateful_mcp_server()` accept an optional `factory_argument`. It is sent to the MCP activities and passed to the registered server factory when the MCP server is created.
+
+⚠️ **Do not pass secrets, credentials, or API keys through `factory_argument`.** It is serialized as an activity argument, so it is recorded in workflow history, which is durable, replayed on every workflow replay, and visible in the Web UI. Resolve credentials worker-side inside the server factory instead (environment variable, secret manager, etc.), passing only non-secret identifiers through `factory_argument`.
+
 ### Hosted MCP Tool
 
 For network-accessible MCP servers, you can also use `HostedMCPTool` from the OpenAI Agents SDK, which uses an MCP client hosted by OpenAI.

--- a/temporalio/contrib/openai_agents/README.md
+++ b/temporalio/contrib/openai_agents/README.md
@@ -449,9 +449,11 @@ To recover from such failures, you need to implement your own application-level 
 
 ### Factory Arguments
 
-Both `stateless_mcp_server()` and `stateful_mcp_server()` accept an optional `factory_argument`. It is sent to the MCP activities and passed to the registered server factory when the MCP server is created.
+Both `stateless_mcp_server()` and `stateful_mcp_server()` accept an optional `factory_argument`, which is passed to the registered server factory when the MCP server is created.
 
-⚠️ **Do not pass secrets, credentials, or API keys through `factory_argument`.** It is serialized as an activity argument, so it is recorded in workflow history, which is durable, replayed on every workflow replay, and visible in the Web UI. Resolve credentials worker-side inside the server factory instead (environment variable, secret manager, etc.), passing only non-secret identifiers through `factory_argument`.
+A stateless factory that declares no parameters — like the `lambda: MCPServerStdio(...)` example above — ignores the value, but it is still recorded in history.
+
+**Do not pass secrets, credentials, or API keys through `factory_argument`.** It is an activity argument, so it is recorded in workflow history and, without a payload codec, visible in the web UI. Resolve credentials worker-side inside the server factory instead.
 
 ### Hosted MCP Tool
 

--- a/temporalio/contrib/openai_agents/_mcp.py
+++ b/temporalio/contrib/openai_agents/_mcp.py
@@ -152,7 +152,9 @@ class StatelessMCPServerProvider:
         Args:
             name: The name of the MCP server.
             server_factory: A function which will produce MCPServer instances. It should return a new server each time
-                so that state is not shared between workflow runs.
+                so that state is not shared between workflow runs. It may accept a single positional parameter, which
+                receives the ``factory_argument`` from the workflow; if it declares no parameters, that argument is
+                discarded.
         """
         self._server_factory = server_factory
 
@@ -437,7 +439,8 @@ class StatefulMCPServerProvider:
         Args:
             name: The name of the MCP server.
             server_factory: A function which will produce MCPServer instances. It should return a new server each time
-                so that state is not shared between workflow runs
+                so that state is not shared between workflow runs. It receives the ``factory_argument`` from the
+                workflow, or ``None`` if the workflow did not provide one.
         """
         self._server_factory = server_factory
         self._name = name + "-stateful"

--- a/temporalio/contrib/openai_agents/_mcp.py
+++ b/temporalio/contrib/openai_agents/_mcp.py
@@ -153,8 +153,7 @@ class StatelessMCPServerProvider:
             name: The name of the MCP server.
             server_factory: A function which will produce MCPServer instances. It should return a new server each time
                 so that state is not shared between workflow runs. It may accept a single positional parameter, which
-                receives the ``factory_argument`` from the workflow; if it declares no parameters, that argument is
-                discarded.
+                receives a ``factory_argument`` from the workflow.
         """
         self._server_factory = server_factory
 
@@ -439,8 +438,8 @@ class StatefulMCPServerProvider:
         Args:
             name: The name of the MCP server.
             server_factory: A function which will produce MCPServer instances. It should return a new server each time
-                so that state is not shared between workflow runs. It receives the ``factory_argument`` from the
-                workflow, or ``None`` if the workflow did not provide one.
+                so that state is not shared between workflow runs. It receives an optional ``factory_argument`` from the
+                workflow.
         """
         self._server_factory = server_factory
         self._name = name + "-stateful"

--- a/temporalio/contrib/openai_agents/workflow.py
+++ b/temporalio/contrib/openai_agents/workflow.py
@@ -292,12 +292,10 @@ def stateless_mcp_server(
     superior durability guarantees.
 
     .. warning::
-        Do not pass secrets, credentials, or API keys through ``factory_argument``. It is
-        serialized as an activity argument, so it is recorded in workflow history, which is
-        durable, replayed on every workflow replay, and visible in the Web UI. Resolve
-        credentials worker-side inside the server factory instead (environment variable,
-        secret manager, etc.), passing only non-secret identifiers through
-        ``factory_argument``.
+        Do not pass secrets, credentials, or API keys through ``factory_argument``. It is an
+        activity argument, so it is recorded in workflow history and, without a payload codec,
+        visible in the web UI. Resolve credentials worker-side inside the server factory
+        instead.
 
     Args:
         name: A string name for the server. Should match that provided in the plugin.
@@ -305,7 +303,7 @@ def stateless_mcp_server(
                Defaults to 1-minute start-to-close timeout.
         cache_tools_list: If true, the list of tools will be cached for the duration of the server
         factory_argument: Optional argument to be provided to the factory when producing an MCPServer.
-               Must not contain secrets; see the warning above.
+               Must not contain secrets.
     """
     from temporalio.contrib.openai_agents._mcp import (
         _StatelessMCPServerReference,
@@ -336,12 +334,10 @@ def stateful_mcp_server(
     unable to seamlessly recreate any lost state in that case.
 
     .. warning::
-        Do not pass secrets, credentials, or API keys through ``factory_argument``. It is
-        serialized as an activity argument, so it is recorded in workflow history, which is
-        durable, replayed on every workflow replay, and visible in the Web UI. Resolve
-        credentials worker-side inside the server factory instead (environment variable,
-        secret manager, etc.), passing only non-secret identifiers through
-        ``factory_argument``.
+        Do not pass secrets, credentials, or API keys through ``factory_argument``. It is an
+        activity argument, so it is recorded in workflow history and, without a payload codec,
+        visible in the web UI. Resolve credentials worker-side inside the server factory
+        instead.
 
     Args:
         name: A string name for the server. Should match that provided in the plugin.
@@ -350,7 +346,7 @@ def stateful_mcp_server(
         server_session_config: Optional activity configuration for the connection activity.
                        Defaults to 1-hour start-to-close timeout.
         factory_argument: Optional argument to be provided to the factory when producing an MCPServer.
-               Must not contain secrets; see the warning above.
+               Must not contain secrets.
     """
     from temporalio.contrib.openai_agents._mcp import (
         _StatefulMCPServerReference,

--- a/temporalio/contrib/openai_agents/workflow.py
+++ b/temporalio/contrib/openai_agents/workflow.py
@@ -291,12 +291,21 @@ def stateless_mcp_server(
     and you don't need to maintain state between operations. It should be preferred to stateful when possible due to its
     superior durability guarantees.
 
+    .. warning::
+        Do not pass secrets, credentials, or API keys through ``factory_argument``. It is
+        serialized as an activity argument, so it is recorded in workflow history, which is
+        durable, replayed on every workflow replay, and visible in the Web UI. Resolve
+        credentials worker-side inside the server factory instead (environment variable,
+        secret manager, etc.), passing only non-secret identifiers through
+        ``factory_argument``.
+
     Args:
         name: A string name for the server. Should match that provided in the plugin.
         config: Optional activity configuration for MCP operation activities.
                Defaults to 1-minute start-to-close timeout.
         cache_tools_list: If true, the list of tools will be cached for the duration of the server
-        factory_argument: Optional argument to be provided to the factory when producing an MCPServer
+        factory_argument: Optional argument to be provided to the factory when producing an MCPServer.
+               Must not contain secrets; see the warning above.
     """
     from temporalio.contrib.openai_agents._mcp import (
         _StatelessMCPServerReference,
@@ -326,13 +335,22 @@ def stateful_mcp_server(
     The caller will have to handle cases where the dedicated worker fails, as Temporal is
     unable to seamlessly recreate any lost state in that case.
 
+    .. warning::
+        Do not pass secrets, credentials, or API keys through ``factory_argument``. It is
+        serialized as an activity argument, so it is recorded in workflow history, which is
+        durable, replayed on every workflow replay, and visible in the Web UI. Resolve
+        credentials worker-side inside the server factory instead (environment variable,
+        secret manager, etc.), passing only non-secret identifiers through
+        ``factory_argument``.
+
     Args:
         name: A string name for the server. Should match that provided in the plugin.
         config: Optional activity configuration for MCP operation activities.
                Defaults to 1-minute start-to-close and 30-second schedule-to-start timeouts.
         server_session_config: Optional activity configuration for the connection activity.
                        Defaults to 1-hour start-to-close timeout.
-        factory_argument: Optional argument to be provided to the factory when producing an MCPServer
+        factory_argument: Optional argument to be provided to the factory when producing an MCPServer.
+               Must not contain secrets; see the warning above.
     """
     from temporalio.contrib.openai_agents._mcp import (
         _StatefulMCPServerReference,


### PR DESCRIPTION
Adds a warning to the MCP `factory_argument` docstrings and READMEs in the `openai_agents` and `google_adk_agents` contrib plugins: the value is serialized as an activity argument and therefore recorded in workflow history, so it must not carry secrets, credentials, or API keys. Points users at resolving credentials worker-side inside the server/toolset factory instead, passing only non-secret identifiers through `factory_argument`.

Users have been passing auth material this way, and nothing in the API surface signals that `factory_argument` crosses the workflow boundary.