### PR TITLE
fix(sandbox): suppress policy warnings during initial workflow load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ to include examples, links to docs, or any other relevant information.
 
 - Marked system Nexus envelope payloads so nested payloads can be detected and
   visited after the envelope is already stored as a payload.
+- Suppressed intentional passthrough notifications for the initial workflow
+  module import while retaining configured notifications for that module's
+  import-time dependencies.
 
 ### Security
 

--- a/temporalio/worker/workflow_sandbox/_importer.py
+++ b/temporalio/worker/workflow_sandbox/_importer.py
@@ -321,8 +321,7 @@ class Importer:
         # The workflow module itself must be loaded into every sandbox instance.
         # That import is intentional, but its import-time dependencies still need
         # to follow the configured notification policy.
-        if name == self._initial_workflow_module_import:
-            return None
+        is_initial_workflow_module = name == self._initial_workflow_module_import
 
         # If imports not passed through and all modules are not passed through
         # and name not in passthrough modules, check parents
@@ -330,13 +329,19 @@ class Importer:
             not temporalio.workflow.unsafe.is_imports_passed_through()
             and not self.module_configured_passthrough(name)
         ):
-            if self._is_import_notification_policy_applied(
-                temporalio.workflow.SandboxImportNotificationPolicy.RAISE_ON_UNINTENTIONAL_PASSTHROUGH
+            if (
+                not is_initial_workflow_module
+                and self._is_import_notification_policy_applied(
+                    temporalio.workflow.SandboxImportNotificationPolicy.RAISE_ON_UNINTENTIONAL_PASSTHROUGH
+                )
             ):
                 raise UnintentionalPassthroughError(name)
 
-            if self._is_import_notification_policy_applied(
-                temporalio.workflow.SandboxImportNotificationPolicy.WARN_ON_UNINTENTIONAL_PASSTHROUGH
+            if (
+                not is_initial_workflow_module
+                and self._is_import_notification_policy_applied(
+                    temporalio.workflow.SandboxImportNotificationPolicy.WARN_ON_UNINTENTIONAL_PASSTHROUGH
+                )
             ):
                 warnings.warn(
                     f"Module {name} was not intentionally passed through to the sandbox."

--- a/temporalio/worker/workflow_sandbox/_importer.py
+++ b/temporalio/worker/workflow_sandbox/_importer.py
@@ -329,23 +329,18 @@ class Importer:
             not temporalio.workflow.unsafe.is_imports_passed_through()
             and not self.module_configured_passthrough(name)
         ):
-            if (
-                not is_initial_workflow_module
-                and self._is_import_notification_policy_applied(
+            if not is_initial_workflow_module:
+                if self._is_import_notification_policy_applied(
                     temporalio.workflow.SandboxImportNotificationPolicy.RAISE_ON_UNINTENTIONAL_PASSTHROUGH
-                )
-            ):
-                raise UnintentionalPassthroughError(name)
+                ):
+                    raise UnintentionalPassthroughError(name)
 
-            if (
-                not is_initial_workflow_module
-                and self._is_import_notification_policy_applied(
+                if self._is_import_notification_policy_applied(
                     temporalio.workflow.SandboxImportNotificationPolicy.WARN_ON_UNINTENTIONAL_PASSTHROUGH
-                )
-            ):
-                warnings.warn(
-                    f"Module {name} was not intentionally passed through to the sandbox."
-                )
+                ):
+                    warnings.warn(
+                        f"Module {name} was not intentionally passed through to the sandbox."
+                    )
 
             return None
         # Do the pass through

--- a/temporalio/worker/workflow_sandbox/_importer.py
+++ b/temporalio/worker/workflow_sandbox/_importer.py
@@ -66,6 +66,7 @@ class Importer:
             "__main__": types.ModuleType("__main__"),
         }
         self.modules_checked_for_restrictions: set[str] = set()
+        self._initial_workflow_module_import: str | None = None
         self.import_func = self._import if not LOG_TRACE else self._traced_import
         # Pre-collect restricted builtins
         self.restricted_builtins: list[tuple[str, _ThreadLocalCallable, Callable]] = []
@@ -158,6 +159,16 @@ class Importer:
                         yield None
         finally:
             Importer._thread_local_current.importer = orig_importer
+
+    @contextmanager
+    def initial_workflow_module_import(self, module_name: str) -> Iterator[None]:
+        """Suppress notifications only for the initial workflow module import."""
+        previous_module = self._initial_workflow_module_import
+        self._initial_workflow_module_import = module_name
+        try:
+            yield None
+        finally:
+            self._initial_workflow_module_import = previous_module
 
     @contextmanager
     def _unapplied(self) -> Iterator[None]:
@@ -307,6 +318,12 @@ class Importer:
         return policy in self.restrictions.import_notification_policy
 
     def _maybe_passthrough_module(self, name: str) -> types.ModuleType | None:
+        # The workflow module itself must be loaded into every sandbox instance.
+        # That import is intentional, but its import-time dependencies still need
+        # to follow the configured notification policy.
+        if name == self._initial_workflow_module_import:
+            return None
+
         # If imports not passed through and all modules are not passed through
         # and name not in passthrough modules, check parents
         if (

--- a/temporalio/worker/workflow_sandbox/_runner.py
+++ b/temporalio/worker/workflow_sandbox/_runner.py
@@ -135,14 +135,10 @@ class _Instance(WorkflowInstance):
         if module_name == "__main__":
             module_name = "__temporal_main__"
         try:
-            # Import user code
-            # Initial workflow loading necessarily imports the workflow module
-            # into the sandbox. It and its import-time dependencies are not
-            # accidental passthroughs, so defer notification policy until the
-            # workflow has finished loading.
-            with temporalio.workflow.unsafe.sandbox_import_notification_policy(
-                temporalio.workflow.SandboxImportNotificationPolicy.SILENT
-            ):
+            # Import user code. The workflow module is intentionally loaded
+            # into every sandbox instance, while its import-time dependencies
+            # must retain the configured warning/error policy.
+            with self.importer.initial_workflow_module_import(module_name):
                 self._run_code(
                     "with __temporal_importer.applied():\n"
                     # Import the workflow code

--- a/temporalio/worker/workflow_sandbox/_runner.py
+++ b/temporalio/worker/workflow_sandbox/_runner.py
@@ -136,13 +136,20 @@ class _Instance(WorkflowInstance):
             module_name = "__temporal_main__"
         try:
             # Import user code
-            self._run_code(
-                "with __temporal_importer.applied():\n"
-                # Import the workflow code
-                f"  from {module_name} import {self.instance_details.defn.cls.__name__} as __temporal_workflow_class\n"
-                f"  from {self.runner_class.__module__} import {self.runner_class.__name__} as __temporal_runner_class\n",
-                __temporal_importer=self.importer,
-            )
+            # Initial workflow loading necessarily imports the workflow module
+            # into the sandbox. It and its import-time dependencies are not
+            # accidental passthroughs, so defer notification policy until the
+            # workflow has finished loading.
+            with temporalio.workflow.unsafe.sandbox_import_notification_policy(
+                temporalio.workflow.SandboxImportNotificationPolicy.SILENT
+            ):
+                self._run_code(
+                    "with __temporal_importer.applied():\n"
+                    # Import the workflow code
+                    f"  from {module_name} import {self.instance_details.defn.cls.__name__} as __temporal_workflow_class\n"
+                    f"  from {self.runner_class.__module__} import {self.runner_class.__name__} as __temporal_runner_class\n",
+                    __temporal_importer=self.importer,
+                )
 
             # Set context as in runtime
             self.importer.restriction_context.is_runtime = True

--- a/tests/worker/workflow_sandbox/test_runner.py
+++ b/tests/worker/workflow_sandbox/test_runner.py
@@ -533,9 +533,9 @@ async def test_workflow_sandbox_initial_workflow_import_does_not_warn() -> None:
 
     with warnings.catch_warnings(record=True) as recorder:
         warnings.simplefilter("always")
-        SandboxedWorkflowRunner(restrictions).prepare_workflow(
-            workflow._Definition.from_class(LazyImportWorkflow)
-        )
+        definition = workflow._Definition.from_class(LazyImportWorkflow)
+        assert definition is not None
+        SandboxedWorkflowRunner(restrictions).prepare_workflow(definition)
 
     assert (
         "Module tests.worker.workflow_sandbox.test_runner was not intentionally "

--- a/tests/worker/workflow_sandbox/test_runner.py
+++ b/tests/worker/workflow_sandbox/test_runner.py
@@ -525,6 +525,25 @@ class LazyImportWorkflow:
             ) from err
 
 
+async def test_workflow_sandbox_initial_workflow_import_does_not_warn() -> None:
+    restrictions = dataclasses.replace(
+        SandboxRestrictions.default,
+        import_notification_policy=SandboxImportNotificationPolicy.WARN_ON_UNINTENTIONAL_PASSTHROUGH,
+    )
+
+    with warnings.catch_warnings(record=True) as recorder:
+        warnings.simplefilter("always")
+        SandboxedWorkflowRunner(restrictions).prepare_workflow(
+            workflow._Definition.from_class(LazyImportWorkflow)
+        )
+
+    assert (
+        "Module tests.worker.workflow_sandbox.test_runner was not intentionally "
+        "passed through to the sandbox."
+        not in {str(warning.message) for warning in recorder}
+    )
+
+
 async def test_workflow_sandbox_import_default_warnings(client: Client):
     restrictions = dataclasses.replace(
         SandboxRestrictions.default,

--- a/tests/worker/workflow_sandbox/test_runner.py
+++ b/tests/worker/workflow_sandbox/test_runner.py
@@ -544,6 +544,40 @@ async def test_workflow_sandbox_initial_workflow_import_does_not_warn() -> None:
     )
 
 
+async def test_workflow_sandbox_initial_workflow_import_warns_for_dependencies() -> (
+    None
+):
+    from tests.worker.workflow_sandbox.testmodules.initial_import_warning_dependency import (
+        InitialImportWarningDependencyWorkflow,
+    )
+
+    restrictions = dataclasses.replace(
+        SandboxRestrictions.default,
+        import_notification_policy=SandboxImportNotificationPolicy.WARN_ON_UNINTENTIONAL_PASSTHROUGH,
+    )
+
+    with warnings.catch_warnings(record=True) as recorder:
+        warnings.simplefilter("always")
+        definition = workflow._Definition.from_class(
+            InitialImportWarningDependencyWorkflow
+        )
+        assert definition is not None
+        SandboxedWorkflowRunner(restrictions).prepare_workflow(definition)
+
+    assert (
+        "Module tests.worker.workflow_sandbox.testmodules.lazy_module was not "
+        "intentionally passed through to the sandbox."
+        in {str(warning.message) for warning in recorder}
+    )
+
+    raising_restrictions = dataclasses.replace(
+        restrictions,
+        import_notification_policy=SandboxImportNotificationPolicy.RAISE_ON_UNINTENTIONAL_PASSTHROUGH,
+    )
+    with pytest.raises(UnintentionalPassthroughError, match="lazy_module"):
+        SandboxedWorkflowRunner(raising_restrictions).prepare_workflow(definition)
+
+
 async def test_workflow_sandbox_import_default_warnings(client: Client):
     restrictions = dataclasses.replace(
         SandboxRestrictions.default,

--- a/tests/worker/workflow_sandbox/testmodules/initial_import_warning_dependency.py
+++ b/tests/worker/workflow_sandbox/testmodules/initial_import_warning_dependency.py
@@ -1,4 +1,4 @@
-import tests.worker.workflow_sandbox.testmodules.lazy_module  # noqa: F401
+import tests.worker.workflow_sandbox.testmodules.lazy_module  # type:ignore[reportUnusedImport] # noqa: F401
 from temporalio import workflow
 
 

--- a/tests/worker/workflow_sandbox/testmodules/initial_import_warning_dependency.py
+++ b/tests/worker/workflow_sandbox/testmodules/initial_import_warning_dependency.py
@@ -1,0 +1,10 @@
+from temporalio import workflow
+
+import tests.worker.workflow_sandbox.testmodules.lazy_module  # noqa: F401
+
+
+@workflow.defn
+class InitialImportWarningDependencyWorkflow:
+    @workflow.run
+    async def run(self) -> None:
+        pass

--- a/tests/worker/workflow_sandbox/testmodules/initial_import_warning_dependency.py
+++ b/tests/worker/workflow_sandbox/testmodules/initial_import_warning_dependency.py
@@ -1,6 +1,5 @@
-from temporalio import workflow
-
 import tests.worker.workflow_sandbox.testmodules.lazy_module  # noqa: F401
+from temporalio import workflow
 
 
 @workflow.defn


### PR DESCRIPTION
## Summary
- suppress import-notification policy only for the sandbox’s initial workflow-module import
- retain configured warning and raise behavior for that module’s import-time dependencies
- add regressions covering both sides of that split and a high-level changelog entry

## Validation
- focused initial-module/dependency plus warning/error sandbox tests (4 passed)
- Ruff check and format check
- Pyright (0 errors)

Fixes #1254.