### PR TITLE
Mark breaking change headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ to include examples, links to docs, or any other relevant information.
 ### Added            — new features
 ### Changed          — changes in existing functionality
 ### Deprecated       — soon-to-be-removed features
-### Breaking Changes — removed or backwards-incompatible features
+### :boom: Breaking Changes — removed or backwards-incompatible features
 ### Fixed            — notable bug fixes
 ### Security         — notable security fixes
 -->
@@ -24,7 +24,7 @@ to include examples, links to docs, or any other relevant information.
 
 ### Deprecated
 
-### Breaking Changes
+### :boom: Breaking Changes
 
 ### Fixed
 
@@ -64,7 +64,7 @@ to include examples, links to docs, or any other relevant information.
   overrides for this flag from `tests/worker/test_workflow.py`, and replace this rollout
   note with a `Fixed` entry announcing the behavior change.
 
-### Breaking Changes
+### :boom: Breaking Changes
 
 - Custom workflow runners that construct `WorkflowInstanceDetails` must now pass
   `payload_converter_factory` instead of `payload_converter_class`. The factory
@@ -104,7 +104,7 @@ to include examples, links to docs, or any other relevant information.
   with the selected optional dependencies.
 - Standalone Nexus operation links are now forwarded on start workflow and signal requests.
 
-### Breaking Changes
+### :boom: Breaking Changes
 
 - AWS Lambda worker `configure` parameter has been changed to be invoked
   per-invocation of the worker instead of only at startup. It is advised that
@@ -127,7 +127,7 @@ to include examples, links to docs, or any other relevant information.
   Pass `grpc_compression=GrpcCompression.NONE` to `Client.connect` or
   `CloudOperationsClient.connect` to disable it.
 
-### Breaking Changes
+### :boom: Breaking Changes
 
 - `StartWorkflowUpdateWithStartInput` now owns the authoritative
   `rpc_metadata` and `rpc_timeout` fields for

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -17,7 +17,7 @@ CHANGELOG_HEADERS = (
     "Added",
     "Changed",
     "Deprecated",
-    "Breaking Changes",
+    ":boom: Breaking Changes",
     "Fixed",
     "Security",
 )

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -20,6 +20,8 @@ def test_finalize_changelog_release_seeds_unreleased_and_versions_notes() -> Non
 
 - Changed a thing.
 
+### :boom: Breaking Changes
+
 ### Fixed
 
 ## [1.29.0] - 2026-06-17
@@ -46,7 +48,7 @@ def test_finalize_changelog_release_seeds_unreleased_and_versions_notes() -> Non
 
 ### Deprecated
 
-### Breaking Changes
+### :boom: Breaking Changes
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- add the :boom: marker to Breaking Changes headings
- generate the marked heading in release preparation

## Validation
- poe test -s tests/test_prepare_release.py