### PR TITLE
Fix flake in test_started_workflow_has_link_to_standalone_nexus_operation

### DIFF
--- a/tests/nexus/test_standalone_operations.py
+++ b/tests/nexus/test_standalone_operations.py
@@ -308,8 +308,10 @@ async def test_started_workflow_has_link_to_standalone_nexus_operation(
         workflow_history = await _assert_workflow_started_with_nexus_operation_link(
             client, workflow_id, handle
         )
-        await _assert_nexus_operation_has_link_to_started_workflow(
-            client, workflow_history, handle
+        await assert_eventually(
+            lambda: _assert_nexus_operation_has_link_to_started_workflow(
+                client, workflow_history, handle
+            )
         )
 
         workflow_handle = client.get_workflow_handle(workflow_id)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Add eventual assertion to link test to account for eventual consistency in visibility

## Why?
<!-- Tell your future self why have you made these changes -->

Flake fix
