### PR TITLE
test: unskip unfinished update handler cases on time-skipping server

### DIFF
--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -6725,7 +6725,6 @@ class UnfinishedHandlersOnWorkflowTerminationWorkflow:
 )
 async def test_unfinished_handler_on_workflow_termination(
     client: Client,
-    env: WorkflowEnvironment,
     handler_type: Literal["-signal-", "-update-"],
     handler_registration: Literal["-late-registered-", "-not-late-registered-"],
     handler_dynamism: Literal["-dynamic-", "-not-dynamic-"],
@@ -6736,10 +6735,6 @@ async def test_unfinished_handler_on_workflow_termination(
         "-cancellation-", "-failure-", "-continue-as-new-"
     ],
 ):
-    if env.supports_time_skipping:
-        pytest.skip(
-            "Issues with update: https://github.com/temporalio/sdk-python/issues/826"
-        )
     skip_unfinished_handler_tests_in_older_python()
     await _UnfinishedHandlersOnWorkflowTerminationTest(
         client,
@@ -6832,13 +6827,24 @@ class _UnfinishedHandlersOnWorkflowTerminationTest:
                     if self.handler_waiting == "-wait-all-handlers-finish-":
                         await update_task
                     else:
-                        with pytest.raises(WorkflowUpdateFailedError) as err_info:
+                        with pytest.raises(
+                            (WorkflowUpdateFailedError, RPCError)
+                        ) as err_info:
                             await update_task
                         update_err = err_info.value
-                        assert isinstance(update_err.cause, ApplicationError)
-                        assert (
-                            update_err.cause.type == "AcceptedUpdateCompletedWorkflow"
-                        )
+                        if isinstance(update_err, WorkflowUpdateFailedError):
+                            assert isinstance(update_err.cause, ApplicationError)
+                            assert (
+                                update_err.cause.type
+                                == "AcceptedUpdateCompletedWorkflow"
+                            )
+                        else:
+                            assert isinstance(update_err, RPCError)
+                            assert update_err.status == RPCStatusCode.NOT_FOUND
+                            assert (
+                                str(update_err)
+                                == "workflow execution already completed"
+                            )
 
                 with pytest.raises(WorkflowFailureError) as err:
                     await handle.result()


### PR DESCRIPTION
## Summary
- unskip the unfinished-handler matrix for the time-skipping environment
- accept the documented `NOT_FOUND` update-poll outcome when a continue-as-new interrupts an unfinished update handler
- preserve the existing `WorkflowUpdateFailedError` assertion for servers that report the aborted update as an outcome

The workflow runtime warning already documents that interrupted update handlers can cause clients to receive `workflow execution already completed`; the time-skipping server exposes that path directly.

## Validation
- `pytest tests/worker/test_workflow.py::test_unfinished_handler_on_workflow_termination -q --workflow-environment time-skipping` (48 passed)
- `pytest tests/worker/test_workflow.py::test_unfinished_handler_on_workflow_termination -q` (48 passed)
- `ruff format --check tests/worker/test_workflow.py`
- `python -m compileall -q tests/worker/test_workflow.py`

Closes #826.