### PR TITLE
Add pytest marker to skip nexus extstore tests

### DIFF
--- a/tests/nexus/test_dynamic_creation_of_user_handler_classes.py
+++ b/tests/nexus/test_dynamic_creation_of_user_handler_classes.py
@@ -10,6 +10,8 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 from tests.helpers.nexus import make_nexus_endpoint_name
 
+# Cloud CI's namespace credentials cannot manage Nexus endpoints.
+# See https://github.com/temporalio/sdk-python/issues/1704.
 pytestmark = pytest.mark.requires_local_server
 
 

--- a/tests/nexus/test_nexus_client_updates.py
+++ b/tests/nexus/test_nexus_client_updates.py
@@ -12,6 +12,8 @@ from temporalio.client import Client
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
+# Cloud CI's namespace credentials cannot manage Nexus endpoints.
+# See https://github.com/temporalio/sdk-python/issues/1704.
 pytestmark = pytest.mark.requires_local_server
 
 

--- a/tests/nexus/test_nexus_worker_shutdown.py
+++ b/tests/nexus/test_nexus_worker_shutdown.py
@@ -23,6 +23,8 @@ from tests.helpers.nexus import (
     make_nexus_endpoint_name,
 )
 
+# Cloud CI's namespace credentials cannot manage Nexus endpoints.
+# See https://github.com/temporalio/sdk-python/issues/1704.
 pytestmark = pytest.mark.requires_local_server
 
 

--- a/tests/nexus/test_signal_link_propagation_e2e.py
+++ b/tests/nexus/test_signal_link_propagation_e2e.py
@@ -56,6 +56,8 @@ from tests.helpers.nexus import (
     workflow_event_link_event_type,
 )
 
+# Cloud CI's namespace credentials cannot manage Nexus endpoints.
+# See https://github.com/temporalio/sdk-python/issues/1704.
 pytestmark = pytest.mark.requires_local_server
 
 EventType = temporalio.api.enums.v1.EventType

--- a/tests/nexus/test_standalone_operations.py
+++ b/tests/nexus/test_standalone_operations.py
@@ -71,6 +71,8 @@ from tests.helpers.nexus import (
 # ---------------------------------------------------------------------------
 
 
+# Cloud CI's namespace credentials cannot manage Nexus endpoints.
+# See https://github.com/temporalio/sdk-python/issues/1704.
 pytestmark = pytest.mark.requires_local_server
 
 

--- a/tests/nexus/test_temporal_extstore.py
+++ b/tests/nexus/test_temporal_extstore.py
@@ -41,6 +41,8 @@ from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 from tests.helpers.nexus import make_nexus_endpoint_name
 from tests.test_extstore import InMemoryTestDriver
 
+# Cloud CI's namespace credentials cannot manage Nexus endpoints.
+# See https://github.com/temporalio/sdk-python/issues/1704.
 pytestmark = pytest.mark.requires_local_server
 
 PAYLOAD_SIZE = 4096

--- a/tests/nexus/test_temporal_extstore.py
+++ b/tests/nexus/test_temporal_extstore.py
@@ -41,6 +41,8 @@ from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 from tests.helpers.nexus import make_nexus_endpoint_name
 from tests.test_extstore import InMemoryTestDriver
 
+pytestmark = pytest.mark.requires_local_server
+
 PAYLOAD_SIZE = 4096
 PAYLOAD_SIZE_THRESHOLD = 1024
 _STORE_FAILURE_MESSAGE = "external storage store failed"

--- a/tests/nexus/test_temporal_operation.py
+++ b/tests/nexus/test_temporal_operation.py
@@ -20,6 +20,8 @@ from temporalio.worker import Worker
 from tests.helpers import EventType, assert_event_subsequence, assert_eventually
 from tests.helpers.nexus import make_nexus_endpoint_name
 
+# Cloud CI's namespace credentials cannot manage Nexus endpoints.
+# See https://github.com/temporalio/sdk-python/issues/1704.
 pytestmark = pytest.mark.requires_local_server
 
 

--- a/tests/nexus/test_use_existing_conflict_policy.py
+++ b/tests/nexus/test_use_existing_conflict_policy.py
@@ -14,6 +14,8 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 from tests.helpers.nexus import make_nexus_endpoint_name
 
+# Cloud CI's namespace credentials cannot manage Nexus endpoints.
+# See https://github.com/temporalio/sdk-python/issues/1704.
 pytestmark = pytest.mark.requires_local_server
 
 

--- a/tests/nexus/test_workflow_caller.py
+++ b/tests/nexus/test_workflow_caller.py
@@ -90,6 +90,8 @@ class OpDefinitionType(IntEnum):
     LONGHAND = 1
 
 
+# Cloud CI's namespace credentials cannot manage Nexus endpoints.
+# See https://github.com/temporalio/sdk-python/issues/1704.
 pytestmark = pytest.mark.requires_local_server
 
 

--- a/tests/nexus/test_workflow_caller_cancellation_types.py
+++ b/tests/nexus/test_workflow_caller_cancellation_types.py
@@ -25,6 +25,8 @@ from temporalio.worker import Worker
 from tests.helpers import LogCapturer, assert_event_subsequence, assert_eventually
 from tests.helpers.nexus import make_nexus_endpoint_name
 
+# Cloud CI's namespace credentials cannot manage Nexus endpoints.
+# See https://github.com/temporalio/sdk-python/issues/1704.
 pytestmark = pytest.mark.requires_local_server
 
 

--- a/tests/nexus/test_workflow_caller_cancellation_types_when_cancel_handler_fails.py
+++ b/tests/nexus/test_workflow_caller_cancellation_types_when_cancel_handler_fails.py
@@ -30,6 +30,8 @@ from tests.nexus.test_workflow_caller_cancellation_types import (
     has_event,
 )
 
+# Cloud CI's namespace credentials cannot manage Nexus endpoints.
+# See https://github.com/temporalio/sdk-python/issues/1704.
 pytestmark = pytest.mark.requires_local_server
 
 

--- a/tests/nexus/test_workflow_caller_error_chains.py
+++ b/tests/nexus/test_workflow_caller_error_chains.py
@@ -25,6 +25,8 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 from tests.helpers.nexus import make_nexus_endpoint_name
 
+# Cloud CI's namespace credentials cannot manage Nexus endpoints.
+# See https://github.com/temporalio/sdk-python/issues/1704.
 pytestmark = pytest.mark.requires_local_server
 
 

--- a/tests/nexus/test_workflow_caller_errors.py
+++ b/tests/nexus/test_workflow_caller_errors.py
@@ -42,6 +42,8 @@ from temporalio.worker import Worker
 from tests.helpers import LogCapturer, assert_eq_eventually
 from tests.helpers.nexus import make_nexus_endpoint_name
 
+# Cloud CI's namespace credentials cannot manage Nexus endpoints.
+# See https://github.com/temporalio/sdk-python/issues/1704.
 pytestmark = pytest.mark.requires_local_server
 
 operation_invocation_counts = Counter[str]()

--- a/tests/nexus/test_workflow_run_operation.py
+++ b/tests/nexus/test_workflow_run_operation.py
@@ -23,6 +23,8 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 from tests.helpers.nexus import make_nexus_endpoint_name
 
+# Cloud CI's namespace credentials cannot manage Nexus endpoints.
+# See https://github.com/temporalio/sdk-python/issues/1704.
 pytestmark = pytest.mark.requires_local_server
 
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Add the local server requirement for nexus extstore tests.

## Why?
<!-- Tell your future self why have you made these changes -->

Cloud CI runs are failing


