### PR TITLE
fix: preserve restricted proxies after in-place operations

### DIFF
--- a/temporalio/worker/workflow_sandbox/_restrictions.py
+++ b/temporalio/worker/workflow_sandbox/_restrictions.py
@@ -860,6 +860,8 @@ class _RestrictionState:
 
 
 class _RestrictedProxyLookup:
+    bind_func: Callable[[_RestrictedProxy, Any], Callable[..., Any]] | None
+
     def __init__(
         self,
         access_func: Callable | None = None,

--- a/temporalio/worker/workflow_sandbox/_restrictions.py
+++ b/temporalio/worker/workflow_sandbox/_restrictions.py
@@ -951,12 +951,12 @@ class _RestrictedProxyIOp(_RestrictedProxyLookup):
 
         def bind_f(instance: _RestrictedProxy, obj: Any) -> Callable:
             def i_op(self: Any, other: Any) -> _RestrictedProxy:
-                f(self, other)  # type: ignore
+                access_func(self, other)  # type: ignore
                 return instance
 
             return i_op.__get__(obj, type(obj))  # type: ignore
 
-        self.bind_f = bind_f
+        self.bind_func = bind_f
 
 
 _OpF = TypeVar("_OpF", bound=Callable[..., Any])

--- a/tests/worker/workflow_sandbox/test_restrictions.py
+++ b/tests/worker/workflow_sandbox/test_restrictions.py
@@ -75,6 +75,21 @@ def test_restricted_proxy_dunder_methods():
     assert f"{restricted_path_obj}" == expected_path
 
 
+def test_restricted_proxy_in_place_operations_preserve_proxy():
+    restricted_list = _RestrictedProxy(
+        "list",
+        list,
+        RestrictionContext(),
+        SandboxMatcher(),
+    )
+    values = restricted_list([1])
+
+    values += [2]
+
+    assert type(values) is _RestrictedProxy
+    assert RestrictionContext.unwrap_if_proxied(values) == [1, 2]
+
+
 def test_workflow_sandbox_restricted_proxy():
     obj_class = _RestrictedProxy(
         "RestrictableObject",


### PR DESCRIPTION
## What changed

Fixes #772. In-place operations on a sandbox-restricted mutable object now keep the restriction proxy instead of replacing it with the raw object.

## Why

`_RestrictedProxyIOp` built a wrapper that returned the proxy, but stored it under `bind_f` instead of the lookup descriptor's `bind_func`. The normal binding path therefore returned the underlying object after `+=`, bypassing the proxy for later accesses.

## Validation

- Added a regression covering `list += [...]` through `_RestrictedProxy`.
- `pytest tests/worker/workflow_sandbox/test_restrictions.py -q` (4 passed)
- `ruff check` and `ruff format --check` on changed files
- `pyright tests/worker/workflow_sandbox/test_restrictions.py`