### PR TITLE
Bump OpenAI Agents failure-propagation test timeout

### DIFF
--- a/tests/contrib/openai_agents/test_openai.py
+++ b/tests/contrib/openai_agents/test_openai.py
@@ -461,7 +461,7 @@ async def test_tool_failure_workflow(client: Client):
                 "What is the weather in Tokio?",
                 id=f"tools-failure-workflow-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=2),
+                execution_timeout=timedelta(seconds=30),
             )
             with pytest.raises(WorkflowFailureError) as e:
                 await workflow_handle.result()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Bumped the timeout from 2s to 30s

## Why?
Flaky test, bumping test timeout to make more stable.

