### PR TITLE
Improve worker deployment visibility diagnostics

### DIFF
--- a/tests/worker/test_worker.py
+++ b/tests/worker/test_worker.py
@@ -1271,16 +1271,19 @@ async def wait_until_worker_deployment_visible(
                     deployment_name=version.deployment_name,
                 )
             )
-        except RPCError:
-            # Expected
-            assert False
+        except RPCError as err:
+            raise AssertionError(
+                "Worker deployment "
+                f"{version.to_canonical_string()} is not visible "
+                f"({err.status.name}): {err.message}"
+            ) from err
         assert any(
             vs.version == version.to_canonical_string()
             for vs in res.worker_deployment_info.version_summaries
         )
         return res
 
-    return await assert_eventually(mk_call)
+    return await assert_eventually(mk_call, timeout=timedelta(seconds=30))
 
 
 async def set_current_deployment_version(


### PR DESCRIPTION
## What was changed

- Wait up to 30 seconds for a Worker Deployment to become visible.
- Preserve the deployment version plus RPC status and message when visibility does not occur.

## Why?

Cloud CI intermittently reports that newly started Worker Deployments have no pollers. The previous 10-second generic assertion hid the RPC details needed to distinguish propagation delay from an actual worker/poller failure.

## Validation

- `poe test -s tests/worker/test_worker.py -k worker_deployment`
- `poe lint`