### PR TITLE
Improve worker deployment visibility diagnostics

### DIFF
--- a/tests/worker/test_worker.py
+++ b/tests/worker/test_worker.py
@@ -1271,16 +1271,19 @@ async def wait_until_worker_deployment_visible(
                     deployment_name=version.deployment_name,
                 )
             )
-        except RPCError:
-            # Expected
-            assert False
+        except RPCError as err:
+            raise AssertionError(
+                "Worker deployment "
+                f"{version.to_canonical_string()} is not visible "
+                f"({err.status.name}): {err.message}"
+            ) from err
         assert any(
             vs.version == version.to_canonical_string()
             for vs in res.worker_deployment_info.version_summaries
         )
         return res
 
-    return await assert_eventually(mk_call)
+    return await assert_eventually(mk_call, timeout=timedelta(seconds=30))
 
 
 async def set_current_deployment_version(


### PR DESCRIPTION
## What was changed

- Wait up to 30 seconds for a Worker Deployment to become visible.
- Preserve the deployment version plus RPC status and message when visibility does not occur.

## Why?

Cloud CI intermittently reports that newly started Worker Deployments have no pollers. The previous 10-second generic assertion hid the RPC details needed to distinguish propagation delay from an actual worker/poller failure.

## Validation

- Poe => uv run pytest -n auto --dist=worksteal -s tests/worker/test_worker.py -k worker_deployment
============================= test session starts ==============================
platform darwin -- Python 3.14.0, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/tconley/sdk-python
configfile: pyproject.toml
plugins: rerunfailures-16.4, cov-7.1.0, pretty-1.3.0, xdist-3.8.0, timeout-2.4.0, flakefinder-1.1.0, anyio-4.14.2, asyncio-0.21.2, langsmith-0.8.18
timeout: 60.0s
timeout method: signal
timeout func_only: True
asyncio: mode=Mode.AUTO
created: 14/14 workers
14 workers [5 items]

.....
=============================== warnings summary ===============================
.venv/lib/python3.14/site-packages/_pytest/config/__init__.py:2234: 15 warnings
  /Users/tconley/sdk-python/.venv/lib/python3.14/site-packages/_pytest/config/__init__.py:2234: PytestConfigWarning: Failed to import filter module 'temporalio': error::temporalio.workflow.UnfinishedUpdateHandlersWarning
    warnings.warn(

.venv/lib/python3.14/site-packages/_pytest/config/__init__.py:2234: 15 warnings
  /Users/tconley/sdk-python/.venv/lib/python3.14/site-packages/_pytest/config/__init__.py:2234: PytestConfigWarning: Failed to import filter module 'temporalio': error::temporalio.workflow.UnfinishedSignalHandlersWarning
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
Results (6.55s):
         5 passed
        30 warnings
- Poe => uv run ruff check --select I
All checks passed!
Poe => uv run ruff format --check
657 files already formatted
Poe => uv run pyright
0 errors, 0 warnings, 0 informations 
WARNING: there is a new pyright version available (v1.1.403 -> v1.1.411).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`

Poe => uv run mypy --namespace-packages --check-untyped-defs .
Success: no issues found in 342 source files
Poe => uv run basedpyright
0 errors, 0 warnings, 0 notes
Poe => uv run pydocstyle --ignore-decorators=overload