### PR TITLE
test: tolerate trace start-run ordering

### DIFF
--- a/tests/contrib/langsmith/conftest.py
+++ b/tests/contrib/langsmith/conftest.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests.helpers.trace import TraceNode
+
 
 @pytest.fixture(autouse=True)
 def _clear_langsmith_env_cache() -> Any:  # pyright: ignore[reportUnusedFunction]
@@ -92,13 +94,8 @@ class InMemoryRunCollector:
         self._by_id.clear()
 
 
-def dump_traces(collector: InMemoryRunCollector) -> list[list[str]]:
-    """Reconstruct parent-child hierarchy grouped by root trace.
-
-    Returns a list of traces, where each trace is a list of indented
-    strings (same format as dump_runs). Each trace starts from a
-    different root run.
-    """
+def build_trace_trees(collector: InMemoryRunCollector) -> list[TraceNode]:
+    """Build trace trees from the collector's run parent relationships."""
     runs = collector.runs
     children: dict[str | None, list[_RunRecord]] = {}
     for r in runs:
@@ -113,30 +110,18 @@ def dump_traces(collector: InMemoryRunCollector) -> list[list[str]]:
                 f"which is not in the collected runs — dangling parent reference"
             )
 
-    traces: list[list[str]] = []
-    for root in children.get(None, []):
-        trace: list[str] = []
+    def build_tree(run: _RunRecord) -> TraceNode:
+        return TraceNode(
+            run.name,
+            [build_tree(child) for child in children.get(run.id, [])],
+        )
 
-        def _walk(parent_id: str | None, depth: int) -> None:
-            for child in children.get(parent_id, []):
-                trace.append("  " * depth + child.name)
-                _walk(child.id, depth + 1)
-
-        trace.append(root.name)
-        _walk(root.id, 1)
-        traces.append(trace)
-
-    return traces
+    return [build_tree(root) for root in children.get(None, [])]
 
 
-def dump_runs(collector: InMemoryRunCollector) -> list[str]:
-    """Flat list of all runs across all traces."""
-    return [run for trace in dump_traces(collector) for run in trace]
-
-
-def find_traces(traces: list[list[str]], root_name: str) -> list[list[str]]:
-    """Filter traces by exact root name match."""
-    return [t for t in traces if t[0] == root_name]
+def find_trace_trees(traces: list[TraceNode], root_name: str) -> list[TraceNode]:
+    """Filter trace trees by exact root run name."""
+    return [trace for trace in traces if trace.name == root_name]
 
 
 def make_mock_ls_client(collector: InMemoryRunCollector) -> MagicMock:

--- a/tests/contrib/langsmith/test_integration.py
+++ b/tests/contrib/langsmith/test_integration.py
@@ -26,13 +26,13 @@ from temporalio.service import RPCError
 from temporalio.testing import WorkflowEnvironment
 from tests.contrib.langsmith.conftest import (
     InMemoryRunCollector,
-    dump_runs,
-    dump_traces,
-    find_traces,
+    build_trace_trees,
+    find_trace_trees,
     make_mock_ls_client,
 )
 from tests.helpers import new_worker
 from tests.helpers.nexus import make_nexus_endpoint_name
+from tests.helpers.trace import assert_trace_hierarchy
 
 # ---------------------------------------------------------------------------
 # Shared @traceable functions and activities
@@ -359,7 +359,6 @@ class TestBasicTracing:
             )
             assert await result.result() == "activity-done"
 
-        hierarchy = dump_runs(collector)
         expected = [
             "StartWorkflow:SimpleWorkflow",
             "RunWorkflow:SimpleWorkflow",
@@ -367,9 +366,7 @@ class TestBasicTracing:
             "  RunActivity:simple_activity",
             "    simple_activity",
         ]
-        assert hierarchy == expected, (
-            f"Hierarchy mismatch.\nExpected:\n{expected}\nActual:\n{hierarchy}"
-        )
+        assert_trace_hierarchy(build_trace_trees(collector), expected)
 
         # Verify run_type: RunActivity is "tool", others are "chain"
         for run in collector.runs:
@@ -421,7 +418,6 @@ class TestReplay:
 
         # Workflow→activity→@traceable flow should produce exactly these runs
         # with no duplicates from replay:
-        hierarchy = dump_runs(collector)
         expected = [
             "StartWorkflow:TraceableActivityWorkflow",
             "RunWorkflow:TraceableActivityWorkflow",
@@ -430,10 +426,7 @@ class TestReplay:
             "    traceable_activity",
             "      inner_llm_call",
         ]
-        assert hierarchy == expected, (
-            f"Hierarchy mismatch (possible replay duplicates).\n"
-            f"Expected:\n{expected}\nActual:\n{hierarchy}"
-        )
+        assert_trace_hierarchy(build_trace_trees(collector), expected)
 
 
 # ---------------------------------------------------------------------------
@@ -467,7 +460,6 @@ class TestErrorTracing:
             with pytest.raises(WorkflowFailureError):
                 await handle.result()
 
-        hierarchy = dump_runs(collector)
         expected = [
             "StartWorkflow:ActivityFailureWorkflow",
             "RunWorkflow:ActivityFailureWorkflow",
@@ -475,9 +467,7 @@ class TestErrorTracing:
             "  RunActivity:failing_activity",
             "    failing_activity",
         ]
-        assert hierarchy == expected, (
-            f"Hierarchy mismatch.\nExpected:\n{expected}\nActual:\n{hierarchy}"
-        )
+        assert_trace_hierarchy(build_trace_trees(collector), expected)
         # Verify the RunActivity run has an error
         activity_runs = [
             r for r in collector.runs if r.name == "RunActivity:failing_activity"
@@ -509,14 +499,11 @@ class TestErrorTracing:
             with pytest.raises(WorkflowFailureError):
                 await handle.result()
 
-        hierarchy = dump_runs(collector)
         expected = [
             "StartWorkflow:FailingWorkflow",
             "RunWorkflow:FailingWorkflow",
         ]
-        assert hierarchy == expected, (
-            f"Hierarchy mismatch.\nExpected:\n{expected}\nActual:\n{hierarchy}"
-        )
+        assert_trace_hierarchy(build_trace_trees(collector), expected)
         # Verify the RunWorkflow run has an error
         wf_runs = [r for r in collector.runs if r.name == "RunWorkflow:FailingWorkflow"]
         assert len(wf_runs) == 1
@@ -547,7 +534,6 @@ class TestErrorTracing:
             with pytest.raises(WorkflowFailureError):
                 await handle.result()
 
-        hierarchy = dump_runs(collector)
         expected = [
             "StartWorkflow:BenignErrorWorkflow",
             "RunWorkflow:BenignErrorWorkflow",
@@ -555,9 +541,7 @@ class TestErrorTracing:
             "  RunActivity:benign_failing_activity",
             "    benign_failing_activity",
         ]
-        assert hierarchy == expected, (
-            f"Hierarchy mismatch.\nExpected:\n{expected}\nActual:\n{hierarchy}"
-        )
+        assert_trace_hierarchy(build_trace_trees(collector), expected)
         # The RunActivity run for benign error should NOT have error set
         activity_runs = [
             r for r in collector.runs if r.name == "RunActivity:benign_failing_activity"
@@ -651,12 +635,12 @@ class TestComprehensiveTracing:
 
         assert result == "comprehensive-done"
 
-        traces = dump_traces(collector)
+        trace_trees = build_trace_trees(collector)
 
         # user_pipeline trace: StartWorkflow + full workflow execution tree
-        workflow_traces = find_traces(traces, "user_pipeline")
-        assert len(workflow_traces) == 1
-        assert workflow_traces[0] == [
+        workflow_trace_trees = find_trace_trees(trace_trees, "user_pipeline")
+        assert len(workflow_trace_trees) == 1
+        expected_workflow = [
             "user_pipeline",
             "  StartWorkflow:ComprehensiveWorkflow",
             "  RunWorkflow:ComprehensiveWorkflow",
@@ -718,53 +702,73 @@ class TestComprehensiveTracing:
             "        outer_chain",
             "          inner_llm_call",
         ]
+        assert_trace_hierarchy(workflow_trace_trees, expected_workflow)
 
         # poll_query trace (separate root, variable number of iterations)
-        poll_traces = find_traces(traces, "poll_query")
-        assert len(poll_traces) == 1
-        poll = poll_traces[0]
-        assert poll[0] == "poll_query"
-        poll_children = poll[1:]
-        for i in range(0, len(poll_children), 2):
-            assert poll_children[i] == "  QueryWorkflow:is_waiting_for_signal"
-            assert poll_children[i + 1] == "    HandleQuery:is_waiting_for_signal"
+        poll_trace_trees = find_trace_trees(trace_trees, "poll_query")
+        assert len(poll_trace_trees) == 1
+        poll = poll_trace_trees[0]
+        assert poll.name == "poll_query"
+        poll_children = poll.children
+        for poll_child in poll_children:
+            assert poll_child.name == "QueryWorkflow:is_waiting_for_signal"
+            assert [child.name for child in poll_child.children] == [
+                "HandleQuery:is_waiting_for_signal"
+            ]
+            assert not poll_child.children[0].children
 
         # Raw-client query — no parent context, appears as root
-        raw_query_traces = [t for t in traces if t[0].startswith("HandleQuery:")]
-        assert len(raw_query_traces) == 1
+        raw_query_trace_trees = [
+            trace for trace in trace_trees if trace.name.startswith("HandleQuery:")
+        ]
+        assert len(raw_query_trace_trees) == 1
 
         # Phase 2: each operation is its own root trace
-        query_traces = find_traces(traces, "QueryWorkflow:my_query")
-        assert len(query_traces) == 1
-        assert query_traces[0] == [
-            "QueryWorkflow:my_query",
-            "  HandleQuery:my_query",
-        ]
+        query_trace_trees = find_trace_trees(trace_trees, "QueryWorkflow:my_query")
+        assert len(query_trace_trees) == 1
+        assert_trace_hierarchy(
+            query_trace_trees,
+            [
+                "QueryWorkflow:my_query",
+                "  HandleQuery:my_query",
+            ],
+        )
 
-        signal_traces = find_traces(traces, "SignalWorkflow:my_signal")
-        assert len(signal_traces) == 1
-        assert signal_traces[0] == [
-            "SignalWorkflow:my_signal",
-            "  HandleSignal:my_signal",
-        ]
+        signal_trace_trees = find_trace_trees(trace_trees, "SignalWorkflow:my_signal")
+        assert len(signal_trace_trees) == 1
+        assert_trace_hierarchy(
+            signal_trace_trees,
+            [
+                "SignalWorkflow:my_signal",
+                "  HandleSignal:my_signal",
+            ],
+        )
 
-        update_traces = find_traces(traces, "StartWorkflowUpdate:my_update")
-        assert len(update_traces) == 1
-        assert update_traces[0] == [
-            "StartWorkflowUpdate:my_update",
-            "  ValidateUpdate:my_update",
-            "  HandleUpdate:my_update",
-        ]
+        update_trace_trees = find_trace_trees(
+            trace_trees, "StartWorkflowUpdate:my_update"
+        )
+        assert len(update_trace_trees) == 1
+        assert_trace_hierarchy(
+            update_trace_trees,
+            [
+                "StartWorkflowUpdate:my_update",
+                "  ValidateUpdate:my_update",
+                "  HandleUpdate:my_update",
+            ],
+        )
 
         # Update without a validator — no ValidateUpdate trace
-        unvalidated_traces = find_traces(
-            traces, "StartWorkflowUpdate:my_unvalidated_update"
+        unvalidated_trace_trees = find_trace_trees(
+            trace_trees, "StartWorkflowUpdate:my_unvalidated_update"
         )
-        assert len(unvalidated_traces) == 1
-        assert unvalidated_traces[0] == [
-            "StartWorkflowUpdate:my_unvalidated_update",
-            "  HandleUpdate:my_unvalidated_update",
-        ]
+        assert len(unvalidated_trace_trees) == 1
+        assert_trace_hierarchy(
+            unvalidated_trace_trees,
+            [
+                "StartWorkflowUpdate:my_unvalidated_update",
+                "  HandleUpdate:my_unvalidated_update",
+            ],
+        )
 
     @pytest.mark.requires_local_server
     async def test_comprehensive_without_temporal_runs(
@@ -843,11 +847,11 @@ class TestComprehensiveTracing:
 
         assert result == "comprehensive-done"
 
-        traces = dump_traces(collector)
+        trace_trees = build_trace_trees(collector)
 
         # Main workflow trace (only @traceable runs, nested under user_pipeline)
-        workflow_traces = find_traces(traces, "user_pipeline")
-        assert len(workflow_traces) == 1
+        workflow_trace_trees = find_trace_trees(trace_trees, "user_pipeline")
+        assert len(workflow_trace_trees) == 1
         expected_workflow = [
             "user_pipeline",
             "  nested_traceable_activity",
@@ -877,15 +881,12 @@ class TestComprehensiveTracing:
             "    outer_chain",
             "      inner_llm_call",
         ]
-        assert workflow_traces[0] == expected_workflow, (
-            f"Workflow trace mismatch.\n"
-            f"Expected:\n{expected_workflow}\nActual:\n{workflow_traces[0]}"
-        )
+        assert_trace_hierarchy(workflow_trace_trees, expected_workflow)
 
         # Poll query — separate root, just the @traceable wrapper, no Temporal children
-        poll_traces = find_traces(traces, "poll_query")
-        assert len(poll_traces) == 1
-        assert poll_traces[0] == ["poll_query"]
+        poll_trace_trees = find_trace_trees(trace_trees, "poll_query")
+        assert len(poll_trace_trees) == 1
+        assert_trace_hierarchy(poll_trace_trees, ["poll_query"])
 
 
 # ---------------------------------------------------------------------------
@@ -978,7 +979,6 @@ class TestBackgroundIOIntegration:
             == "response to: async|sync-response to: sync|sync-response to: mixed"
         )
 
-        hierarchy = dump_runs(collector)
         expected = [
             "outer_chain",
             "  inner_llm_call",
@@ -990,9 +990,7 @@ class TestBackgroundIOIntegration:
             "  outer_chain",
             "    inner_llm_call",
         ]
-        assert hierarchy == expected, (
-            f"Hierarchy mismatch.\nExpected:\n{expected}\nActual:\n{hierarchy}"
-        )
+        assert_trace_hierarchy(build_trace_trees(collector), expected)
 
         # Verify no duplicate run IDs (replay safety with max_cached_workflows=0)
         run_ids = [r.id for r in collector.runs]
@@ -1065,7 +1063,6 @@ class TestBackgroundIOIntegration:
             == "response to: async|sync-response to: sync|sync-response to: mixed"
         )
 
-        hierarchy = dump_runs(collector)
         # With add_temporal_runs=True, Temporal operations get their own runs.
         # @traceable calls nest under the RunWorkflow run.
         expected = [
@@ -1083,9 +1080,7 @@ class TestBackgroundIOIntegration:
             "      outer_chain",
             "        inner_llm_call",
         ]
-        assert hierarchy == expected, (
-            f"Hierarchy mismatch.\nExpected:\n{expected}\nActual:\n{hierarchy}"
-        )
+        assert_trace_hierarchy(build_trace_trees(collector), expected)
 
         # Verify no duplicate run IDs (replay safety with max_cached_workflows=0)
         run_ids = [r.id for r in collector.runs]
@@ -1186,16 +1181,13 @@ class TestNexusInboundTracing:
 
         assert result == "response to: nexus-input"
 
-        hierarchy = dump_runs(collector)
         # @traceable runs from inside the nexus handler should be collected
         # via the interceptor's tracing_context setup.
         expected = [
             "nexus_direct_traceable",
             "  inner_llm_call",
         ]
-        assert hierarchy == expected, (
-            f"Hierarchy mismatch.\nExpected:\n{expected}\nActual:\n{hierarchy}"
-        )
+        assert_trace_hierarchy(build_trace_trees(collector), expected)
 
 
 # ---------------------------------------------------------------------------
@@ -1281,8 +1273,10 @@ class TestBuiltinQueryFiltering:
             assert await handle.result() == "done"
 
         # Built-in queries should be absent; only user query and signal remain.
-        traces = dump_traces(collector)
-        assert traces == [
-            ["HandleQuery:my_query"],
-            ["HandleSignal:complete"],
-        ], f"Unexpected traces: {traces}"
+        assert_trace_hierarchy(
+            build_trace_trees(collector),
+            [
+                "HandleQuery:my_query",
+                "HandleSignal:complete",
+            ],
+        )

--- a/tests/contrib/langsmith/test_plugin.py
+++ b/tests/contrib/langsmith/test_plugin.py
@@ -12,7 +12,10 @@ from langsmith import traceable, tracing_context
 from temporalio.client import Client, WorkflowHandle
 from temporalio.contrib.langsmith import LangSmithInterceptor, LangSmithPlugin
 from temporalio.testing import WorkflowEnvironment
-from tests.contrib.langsmith.conftest import dump_traces, find_traces
+from tests.contrib.langsmith.conftest import (
+    build_trace_trees,
+    find_trace_trees,
+)
 from tests.contrib.langsmith.test_integration import (
     ComprehensiveWorkflow,
     NexusService,
@@ -24,6 +27,7 @@ from tests.contrib.langsmith.test_integration import (
 )
 from tests.helpers import new_worker
 from tests.helpers.nexus import make_nexus_endpoint_name
+from tests.helpers.trace import assert_trace_hierarchy
 
 
 class TestPluginConstruction:
@@ -111,12 +115,12 @@ class TestPluginIntegration:
 
         assert result == "comprehensive-done"
 
-        traces = dump_traces(collector)
+        trace_trees = build_trace_trees(collector)
 
         # user_pipeline trace: StartWorkflow + full workflow execution tree
-        workflow_traces = find_traces(traces, "user_pipeline")
-        assert len(workflow_traces) == 1
-        assert workflow_traces[0] == [
+        workflow_trace_trees = find_trace_trees(trace_trees, "user_pipeline")
+        assert len(workflow_trace_trees) == 1
+        expected_workflow = [
             "user_pipeline",
             "  StartWorkflow:ComprehensiveWorkflow",
             "  RunWorkflow:ComprehensiveWorkflow",
@@ -178,46 +182,64 @@ class TestPluginIntegration:
             "        outer_chain",
             "          inner_llm_call",
         ]
+        assert_trace_hierarchy(workflow_trace_trees, expected_workflow)
 
         # poll_query trace (separate root, variable number of iterations)
-        poll_traces = find_traces(traces, "poll_query")
-        assert len(poll_traces) == 1
-        poll = poll_traces[0]
-        assert poll[0] == "poll_query"
-        poll_children = poll[1:]
-        for i in range(0, len(poll_children), 2):
-            assert poll_children[i] == "  QueryWorkflow:is_waiting_for_signal"
-            assert poll_children[i + 1] == "    HandleQuery:is_waiting_for_signal"
+        poll_trace_trees = find_trace_trees(trace_trees, "poll_query")
+        assert len(poll_trace_trees) == 1
+        poll = poll_trace_trees[0]
+        assert poll.name == "poll_query"
+        poll_children = poll.children
+        for poll_child in poll_children:
+            assert poll_child.name == "QueryWorkflow:is_waiting_for_signal"
+            assert [child.name for child in poll_child.children] == [
+                "HandleQuery:is_waiting_for_signal"
+            ]
+            assert not poll_child.children[0].children
 
         # Each remaining operation is its own root trace
-        query_traces = find_traces(traces, "QueryWorkflow:my_query")
-        assert len(query_traces) == 1
-        assert query_traces[0] == [
-            "QueryWorkflow:my_query",
-            "  HandleQuery:my_query",
-        ]
+        query_trace_trees = find_trace_trees(trace_trees, "QueryWorkflow:my_query")
+        assert len(query_trace_trees) == 1
+        assert_trace_hierarchy(
+            query_trace_trees,
+            [
+                "QueryWorkflow:my_query",
+                "  HandleQuery:my_query",
+            ],
+        )
 
-        signal_traces = find_traces(traces, "SignalWorkflow:my_signal")
-        assert len(signal_traces) == 1
-        assert signal_traces[0] == [
-            "SignalWorkflow:my_signal",
-            "  HandleSignal:my_signal",
-        ]
+        signal_trace_trees = find_trace_trees(trace_trees, "SignalWorkflow:my_signal")
+        assert len(signal_trace_trees) == 1
+        assert_trace_hierarchy(
+            signal_trace_trees,
+            [
+                "SignalWorkflow:my_signal",
+                "  HandleSignal:my_signal",
+            ],
+        )
 
-        update_traces = find_traces(traces, "StartWorkflowUpdate:my_update")
-        assert len(update_traces) == 1
-        assert update_traces[0] == [
-            "StartWorkflowUpdate:my_update",
-            "  ValidateUpdate:my_update",
-            "  HandleUpdate:my_update",
-        ]
+        update_trace_trees = find_trace_trees(
+            trace_trees, "StartWorkflowUpdate:my_update"
+        )
+        assert len(update_trace_trees) == 1
+        assert_trace_hierarchy(
+            update_trace_trees,
+            [
+                "StartWorkflowUpdate:my_update",
+                "  ValidateUpdate:my_update",
+                "  HandleUpdate:my_update",
+            ],
+        )
 
         # Update without a validator — no ValidateUpdate trace
-        unvalidated_traces = find_traces(
-            traces, "StartWorkflowUpdate:my_unvalidated_update"
+        unvalidated_trace_trees = find_trace_trees(
+            trace_trees, "StartWorkflowUpdate:my_unvalidated_update"
         )
-        assert len(unvalidated_traces) == 1
-        assert unvalidated_traces[0] == [
-            "StartWorkflowUpdate:my_unvalidated_update",
-            "  HandleUpdate:my_unvalidated_update",
-        ]
+        assert len(unvalidated_trace_trees) == 1
+        assert_trace_hierarchy(
+            unvalidated_trace_trees,
+            [
+                "StartWorkflowUpdate:my_unvalidated_update",
+                "  HandleUpdate:my_unvalidated_update",
+            ],
+        )

--- a/tests/helpers/trace.py
+++ b/tests/helpers/trace.py
@@ -1,0 +1,111 @@
+"""Helpers for asserting indented trace hierarchies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Sequence
+
+
+@dataclass
+class TraceNode:
+    name: str
+    children: list[TraceNode] = field(default_factory=list)
+
+
+def format_trace_hierarchy(roots: Sequence[TraceNode]) -> list[str]:
+    """Render a trace forest as indented lines."""
+    lines: list[str] = []
+
+    def render(node: TraceNode, depth: int) -> None:
+        lines.append("  " * depth + node.name)
+        for child in node.children:
+            render(child, depth + 1)
+
+    for root in roots:
+        render(root, 0)
+    return lines
+
+
+def assert_trace_hierarchy(
+    actual: Sequence[TraceNode], expected: Sequence[str]
+) -> None:
+    """Assert a trace hierarchy, allowing matching Start/Run siblings to swap.
+
+    Activity execution can begin before the asynchronously published Start span
+    reaches an in-memory exporter. The two spans retain the same parent, so this
+    accepts only that sibling transposition and preserves all other ordering.
+    """
+    actual_tree = TraceNode("<root>", list(actual))
+    expected_tree = _parse_trace(expected)
+    assert _nodes_match(actual_tree, expected_tree), (
+        "Trace hierarchy differed.\n"
+        f"Actual:\n{chr(10).join(format_trace_hierarchy(actual))}\n"
+        f"Expected:\n{chr(10).join(expected)}"
+    )
+
+
+def _parse_trace(trace: Sequence[str]) -> TraceNode:
+    root = TraceNode("<root>")
+    stack: list[tuple[int, TraceNode]] = [(-1, root)]
+    for line in trace:
+        name = line.lstrip()
+        indent = len(line) - len(name)
+        assert name and indent % 2 == 0, f"Invalid trace line: {line!r}"
+        depth = indent // 2
+        while stack[-1][0] >= depth:
+            stack.pop()
+        assert depth == stack[-1][0] + 1, f"Invalid trace nesting: {line!r}"
+        node = TraceNode(name)
+        stack[-1][1].children.append(node)
+        stack.append((depth, node))
+    return root
+
+
+def _nodes_match(actual: TraceNode, expected: TraceNode) -> bool:
+    if actual.name != expected.name or len(actual.children) != len(expected.children):
+        return False
+
+    index = 0
+    while index < len(actual.children):
+        actual_child = actual.children[index]
+        expected_child = expected.children[index]
+        if _nodes_match(actual_child, expected_child):
+            index += 1
+            continue
+
+        if index + 1 == len(actual.children):
+            return False
+        actual_pair = actual.children[index : index + 2]
+        expected_pair = expected.children[index : index + 2]
+        if not _is_start_run_pair(*actual_pair) or not _is_start_run_pair(
+            *expected_pair
+        ):
+            return False
+        expected_by_name = {node.name: node for node in expected_pair}
+        if any(node.name not in expected_by_name for node in actual_pair):
+            return False
+        if not all(
+            _nodes_match(node, expected_by_name[node.name]) for node in actual_pair
+        ):
+            return False
+        index += 2
+
+    return True
+
+
+def _is_start_run_pair(first: TraceNode, second: TraceNode) -> bool:
+    first_start = _start_run_suffix(first.name)
+    second_start = _start_run_suffix(second.name)
+    first_run = _run_suffix(first.name)
+    second_run = _run_suffix(second.name)
+    return (first_start is not None and first_start == second_run) or (
+        second_start is not None and second_start == first_run
+    )
+
+
+def _start_run_suffix(name: str) -> str | None:
+    return name.removeprefix("Start") if name.startswith("Start") else None
+
+
+def _run_suffix(name: str) -> str | None:
+    return name.removeprefix("Run") if name.startswith("Run") else None

--- a/tests/helpers/trace.py
+++ b/tests/helpers/trace.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Sequence
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- build LangSmith trace trees directly from collected parent relationships
- compare every LangSmith hierarchy assertion against structured trace nodes
- permit only matching Start/Run siblings to arrive in either order

## Why
Workflow-side Start runs are posted asynchronously, while activity-side Run runs can be published immediately. A local activity can therefore report RunActivity before its same-parent StartActivity even though the trace hierarchy is correct. Building trees directly preserves parent relationships and prevents tests from flattening and reparsing actual traces.

## Validation
- `poe build-develop`
- `poe test -s tests/contrib/langsmith/test_integration.py tests/contrib/langsmith/test_plugin.py::TestPluginIntegration::test_comprehensive_plugin_trace_hierarchy`
- `uv run ruff format --check tests/helpers/trace.py tests/contrib/langsmith/conftest.py tests/contrib/langsmith/test_integration.py tests/contrib/langsmith/test_plugin.py`
- `uv run ruff check tests/helpers/trace.py tests/contrib/langsmith/conftest.py tests/contrib/langsmith/test_integration.py tests/contrib/langsmith/test_plugin.py`