### PR TITLE
Forward MCP server config through GeminiTestServer.plugin()

### DIFF
--- a/temporalio/contrib/google_genai/testing.py
+++ b/temporalio/contrib/google_genai/testing.py
@@ -30,12 +30,16 @@ from __future__ import annotations
 
 import json
 from collections.abc import Sequence
-from typing import Any
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
 
 from google.genai import Client as GeminiClient
 from google.genai.types import HttpResponse as SdkHttpResponse
 
 from temporalio.contrib.google_genai._google_genai_plugin import GoogleGenAIPlugin
+
+if TYPE_CHECKING:
+    from temporalio.contrib.google_genai._mcp import McpSessionFactory
 
 __all__ = [
     "GeminiTestServer",
@@ -100,7 +104,8 @@ class GeminiTestServer:
 
     Only model calls (``client.models``) are scripted.  File, interaction, and
     agent operations are not; mock those on a ``genai.Client`` directly if a
-    test needs them.
+    test needs them.  MCP servers can be registered with
+    ``plugin(mcp_servers=...)`` and run for real.
     """
 
     def __init__(self, responses: Sequence[str]) -> None:
@@ -119,12 +124,29 @@ class GeminiTestServer:
             )
         return self._responses[idx]
 
-    def plugin(self) -> GoogleGenAIPlugin:
+    def plugin(
+        self,
+        *,
+        mcp_servers: dict[str, McpSessionFactory] | None = None,
+        mcp_connection_idle_timeout: timedelta | None = None,
+    ) -> GoogleGenAIPlugin:
         """Return a :class:`GoogleGenAIPlugin` whose model calls serve the script.
 
         The real plugin activities run; only the underlying HTTP layer is
         replaced, so request formatting and the AFC loop are exercised exactly
         as in production.
+
+        Args:
+            mcp_servers: MCP servers to expose to workflows, as on
+                :class:`temporalio.contrib.google_genai.GoogleGenAIPlugin`.
+                These are *not* scripted — ``list_tools`` / ``call_tool`` run
+                for real against the given sessions — so a test can drive an
+                MCP tool call with a scripted
+                :func:`function_call_response` and assert on what the server
+                actually returned.
+            mcp_connection_idle_timeout: How long an idle worker-side MCP
+                connection stays open, as on
+                :class:`temporalio.contrib.google_genai.GoogleGenAIPlugin`.
         """
         client = GeminiClient(api_key="fake-test-key")
 
@@ -148,4 +170,8 @@ class GeminiTestServer:
 
         client._api_client.async_request = fake_async_request  # type: ignore[assignment]
         client._api_client.async_request_streamed = fake_async_request_streamed  # type: ignore[assignment]
-        return GoogleGenAIPlugin(client)
+        return GoogleGenAIPlugin(
+            client,
+            mcp_servers=mcp_servers,
+            mcp_connection_idle_timeout=mcp_connection_idle_timeout,
+        )

--- a/tests/contrib/google_genai/test_gemini_mcp.py
+++ b/tests/contrib/google_genai/test_gemini_mcp.py
@@ -15,6 +15,7 @@ Plus the server-side pass-through paths that need no shim code:
 
 from __future__ import annotations
 
+import json
 import sys
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
@@ -36,6 +37,11 @@ from temporalio.contrib.google_genai import (
     TemporalMcpClientSession,
 )
 from temporalio.contrib.google_genai._temporal_interactions import _deserialize
+from temporalio.contrib.google_genai.testing import (
+    GeminiTestServer,
+    function_call_response,
+    text_response,
+)
 from temporalio.worker import Replayer
 from temporalio.workflow import ActivityConfig
 from tests.contrib.google_genai.test_gemini import (
@@ -323,6 +329,51 @@ async def test_mcp_side_effects(client: Client):
         "gemini_api_client_async_request": 2,
         f"{server}-call-tool": 1,
     }
+
+
+async def test_mcp_via_gemini_test_server(client: Client):
+    """GeminiTestServer.plugin(mcp_servers=...) scripts the model, runs MCP for real.
+
+    This is the public testing path — the tests above reach into
+    ``GeminiApiCaller`` to also count API calls, but a user testing an
+    MCP-grounded workflow should need nothing but ``GeminiTestServer``.
+    """
+    server = "echo_public"
+    test_server = GeminiTestServer(
+        [
+            function_call_response("echo", {"message": "durable execution"}),
+            text_response("The echo tool returned: durable execution"),
+        ]
+    )
+
+    config = client.config()
+    config["plugins"] = [test_server.plugin(mcp_servers={server: _echo_session})]
+    new_client = Client(**config)
+
+    async with new_worker(new_client, McpToolWorkflow) as worker:
+        handle = await new_client.start_workflow(
+            McpToolWorkflow.run,
+            args=[server, "echo the phrase: durable execution"],
+            id=f"gemini-mcp-public-{uuid4()}",
+            task_queue=worker.task_queue,
+            execution_timeout=timedelta(seconds=30),
+        )
+        result = await handle.result()
+        names = await _activity_names(handle)
+
+    assert result == "The echo tool returned: durable execution"
+    # The MCP activities really ran; only the model HTTP layer was scripted.
+    assert names == [
+        f"{server}-list-tools",
+        "gemini_api_client_async_request",
+        f"{server}-call-tool",
+        "gemini_api_client_async_request",
+    ]
+    # The echoed message reached the model as a function response.
+    assert any(
+        "durable execution" in json.dumps(request)
+        for request in test_server.requests[1:]
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What was changed

`GeminiTestServer.plugin()` now accepts `mcp_servers` and `mcp_connection_idle_timeout` and forwards them to `GoogleGenAIPlugin`.

## Why?

`GoogleGenAIPlugin.__init__` already takes both arguments, but `GeminiTestServer.plugin()` constructed the plugin without them. That left no public way to test an MCP-grounded workflow offline: a test had to build `GoogleGenAIPlugin` itself and monkeypatch `genai.Client._api_client.async_request` to script the model, duplicating what `GeminiTestServer` exists to do.

This came up writing the `google_genai` sample suite in samples-python ([#319](https://github.com/temporalio/samples-python/pull/319)), whose `mcp` test carries exactly that private-API helper — it can be deleted once this ships.

The MCP servers are not scripted. `list_tools` / `call_tool` run for real against the supplied sessions while only the model HTTP layer is faked, so a scripted `function_call_response` drives a genuine tool call.

`McpSessionFactory` is imported under `TYPE_CHECKING`, keeping `mcp` an optional dependency for anyone importing `testing`.

## Checklist

1. How was this tested:

   Added `test_mcp_via_gemini_test_server` to `tests/contrib/google_genai/test_gemini_mcp.py`, which runs an MCP-grounded workflow through the public helper and asserts the real `{server}-list-tools` / `{server}-call-tool` activities were scheduled and that the echoed text reached the model as a function response. Confirmed the test depends on the change: with `testing.py` reverted it fails with `TypeError: GeminiTestServer.plugin() got an unexpected keyword argument 'mcp_servers'`.

   - `pytest tests/contrib/google_genai -q` → 63 passed
   - `ruff check --select I`, `ruff format --check`, `pydocstyle --ignore-decorators=overload` → clean
   - `pyright` + `mypy --namespace-packages --check-untyped-defs` on both changed files → clean

2. Any docs updates needed?

   No public-API docs beyond the docstrings updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
