### PR TITLE
Fix OpenInference trace patch lifecycle

### DIFF
--- a/temporalio/contrib/openai_agents/_temporal_openai_agents.py
+++ b/temporalio/contrib/openai_agents/_temporal_openai_agents.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 import json
+import threading
 import typing
 from collections.abc import AsyncIterator, Callable, Iterator, Sequence
 from contextlib import asynccontextmanager, contextmanager
@@ -52,6 +53,55 @@ if typing.TYPE_CHECKING:
         StatefulMCPServerProvider,
         StatelessMCPServerProvider,
     )
+
+
+_otel_trace_start_patch_lock = threading.RLock()
+_otel_trace_start_patch_ref_count = 0
+_otel_trace_start_original: Callable[..., typing.Any] | None = None
+
+
+def _install_otel_trace_start_patch() -> None:
+    """Make an OpenInference root span current while tracing is configured."""
+    global _otel_trace_start_original
+    global _otel_trace_start_patch_ref_count
+
+    from openinference.instrumentation.openai_agents._processor import (
+        OpenInferenceTracingProcessor,
+    )
+    from opentelemetry.context import attach
+    from opentelemetry.trace import set_span_in_context
+
+    with _otel_trace_start_patch_lock:
+        if _otel_trace_start_patch_ref_count == 0:
+            _otel_trace_start_original = OpenInferenceTracingProcessor.on_trace_start
+
+            def on_trace_start(self: typing.Any, trace: Trace) -> None:  # type: ignore[reportUnusedFunction]
+                _otel_trace_start_original(self, trace)  # type: ignore[operator]
+                attach(set_span_in_context(self._root_spans[trace.trace_id]))
+
+            setattr(OpenInferenceTracingProcessor, "on_trace_start", on_trace_start)
+        _otel_trace_start_patch_ref_count += 1
+
+
+def _uninstall_otel_trace_start_patch() -> None:
+    """Restore OpenInference after the final tracing context exits."""
+    global _otel_trace_start_original
+    global _otel_trace_start_patch_ref_count
+
+    from openinference.instrumentation.openai_agents._processor import (
+        OpenInferenceTracingProcessor,
+    )
+
+    with _otel_trace_start_patch_lock:
+        _otel_trace_start_patch_ref_count -= 1
+        if _otel_trace_start_patch_ref_count == 0:
+            if _otel_trace_start_original is not None:
+                setattr(
+                    OpenInferenceTracingProcessor,
+                    "on_trace_start",
+                    _otel_trace_start_original,
+                )
+            _otel_trace_start_original = None
 
 
 @contextmanager
@@ -377,28 +427,15 @@ class OpenAIAgentsPlugin(SimplePlugin):
         """
         # Set up OTEL instrumentation if exporters are provided
         otel_instrumentor = None
+        otel_trace_start_patch_installed = False
         if self._use_otel_instrumentation and not self._instrumented:
             from openinference.instrumentation.openai_agents import (
                 OpenAIAgentsInstrumentor,
             )
-            from openinference.instrumentation.openai_agents._processor import (
-                OpenInferenceTracingProcessor,
-            )
             from opentelemetry import trace
-            from opentelemetry.context import attach
-            from opentelemetry.trace import set_span_in_context
 
-            # Unfortunate monkey patching is needed to ensure the trace is set in context so we can propagate it.
-            original_on_trace_start = OpenInferenceTracingProcessor.on_trace_start
-
-            def on_trace_start(self, trace: Trace) -> None:  # type: ignore[reportMissingParameterType]
-                original_on_trace_start(self, trace)
-                otel_span = self._root_spans[trace.trace_id]
-                attach(set_span_in_context(otel_span))
-
-            OpenInferenceTracingProcessor.on_trace_start = on_trace_start  # type:ignore[method-assign]
-
-            # Set up instrumentor
+            _install_otel_trace_start_patch()
+            otel_trace_start_patch_installed = True
             otel_instrumentor = OpenAIAgentsInstrumentor()
             otel_instrumentor.instrument(tracer_provider=trace.get_tracer_provider())
             self._instrumented = True
@@ -408,3 +445,5 @@ class OpenAIAgentsPlugin(SimplePlugin):
             # Clean up OTEL instrumentation
             if otel_instrumentor is not None:
                 otel_instrumentor.uninstrument()
+            if otel_trace_start_patch_installed:
+                _uninstall_otel_trace_start_patch()

--- a/temporalio/contrib/openai_agents/_temporal_openai_agents.py
+++ b/temporalio/contrib/openai_agents/_temporal_openai_agents.py
@@ -448,7 +448,7 @@ class OpenAIAgentsPlugin(SimplePlugin):
         Yields:
             Context with tracing instrumentation enabled.
         """
-        # Set up OTEL instrumentation if exporters are provided
+        # Set up OTEL instrumentation if enabled
         otel_instrumentation_installed = False
         if self._use_otel_instrumentation:
             from opentelemetry import trace

--- a/temporalio/contrib/openai_agents/_temporal_openai_agents.py
+++ b/temporalio/contrib/openai_agents/_temporal_openai_agents.py
@@ -76,10 +76,11 @@ def _install_otel_instrumentation(tracer_provider: typing.Any) -> None:
 
     with _otel_trace_start_patch_lock:
         if _otel_trace_start_patch_ref_count == 0:
-            _otel_trace_start_original = OpenInferenceTracingProcessor.on_trace_start
+            original_on_trace_start = OpenInferenceTracingProcessor.on_trace_start
+            _otel_trace_start_original = original_on_trace_start
 
             def on_trace_start(self: typing.Any, trace: Trace) -> None:  # type: ignore[reportUnusedFunction]
-                _otel_trace_start_original(self, trace)  # type: ignore[operator]
+                original_on_trace_start(self, trace)
                 attach(set_span_in_context(self._root_spans[trace.trace_id]))
 
             setattr(OpenInferenceTracingProcessor, "on_trace_start", on_trace_start)

--- a/temporalio/contrib/openai_agents/_temporal_openai_agents.py
+++ b/temporalio/contrib/openai_agents/_temporal_openai_agents.py
@@ -58,13 +58,16 @@ if typing.TYPE_CHECKING:
 _otel_trace_start_patch_lock = threading.RLock()
 _otel_trace_start_patch_ref_count = 0
 _otel_trace_start_original: Callable[..., typing.Any] | None = None
+_otel_trace_start_instrumentor: typing.Any | None = None
 
 
-def _install_otel_trace_start_patch() -> None:
-    """Make an OpenInference root span current while tracing is configured."""
+def _install_otel_instrumentation(tracer_provider: typing.Any) -> None:
+    """Configure OpenInference while at least one tracing context is active."""
+    global _otel_trace_start_instrumentor
     global _otel_trace_start_original
     global _otel_trace_start_patch_ref_count
 
+    from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
     from openinference.instrumentation.openai_agents._processor import (
         OpenInferenceTracingProcessor,
     )
@@ -80,11 +83,26 @@ def _install_otel_trace_start_patch() -> None:
                 attach(set_span_in_context(self._root_spans[trace.trace_id]))
 
             setattr(OpenInferenceTracingProcessor, "on_trace_start", on_trace_start)
+            try:
+                _otel_trace_start_instrumentor = OpenAIAgentsInstrumentor()
+                _otel_trace_start_instrumentor.instrument(
+                    tracer_provider=tracer_provider
+                )
+            except BaseException:
+                setattr(
+                    OpenInferenceTracingProcessor,
+                    "on_trace_start",
+                    _otel_trace_start_original,
+                )
+                _otel_trace_start_original = None
+                _otel_trace_start_instrumentor = None
+                raise
         _otel_trace_start_patch_ref_count += 1
 
 
-def _uninstall_otel_trace_start_patch() -> None:
-    """Restore OpenInference after the final tracing context exits."""
+def _uninstall_otel_instrumentation() -> None:
+    """Tear down OpenInference after the final tracing context exits."""
+    global _otel_trace_start_instrumentor
     global _otel_trace_start_original
     global _otel_trace_start_patch_ref_count
 
@@ -93,15 +111,22 @@ def _uninstall_otel_trace_start_patch() -> None:
     )
 
     with _otel_trace_start_patch_lock:
+        if _otel_trace_start_patch_ref_count == 0:
+            raise RuntimeError("OpenInference instrumentation was not acquired")
         _otel_trace_start_patch_ref_count -= 1
         if _otel_trace_start_patch_ref_count == 0:
-            if _otel_trace_start_original is not None:
-                setattr(
-                    OpenInferenceTracingProcessor,
-                    "on_trace_start",
-                    _otel_trace_start_original,
-                )
-            _otel_trace_start_original = None
+            try:
+                if _otel_trace_start_instrumentor is not None:
+                    _otel_trace_start_instrumentor.uninstrument()
+            finally:
+                if _otel_trace_start_original is not None:
+                    setattr(
+                        OpenInferenceTracingProcessor,
+                        "on_trace_start",
+                        _otel_trace_start_original,
+                    )
+                _otel_trace_start_original = None
+                _otel_trace_start_instrumentor = None
 
 
 @contextmanager
@@ -314,8 +339,6 @@ class OpenAIAgentsPlugin(SimplePlugin):
                     "When configuring a custom provider, the model activity must have start_to_close_timeout or schedule_to_close_timeout"
                 )
 
-        # Store OTEL configuration for later setup
-        self._instrumented = False
         self._use_otel_instrumentation = use_otel_instrumentation
 
         # Delay activity construction until they are actually needed
@@ -426,24 +449,15 @@ class OpenAIAgentsPlugin(SimplePlugin):
             Context with tracing instrumentation enabled.
         """
         # Set up OTEL instrumentation if exporters are provided
-        otel_instrumentor = None
-        otel_trace_start_patch_installed = False
-        if self._use_otel_instrumentation and not self._instrumented:
-            from openinference.instrumentation.openai_agents import (
-                OpenAIAgentsInstrumentor,
-            )
+        otel_instrumentation_installed = False
+        if self._use_otel_instrumentation:
             from opentelemetry import trace
 
-            _install_otel_trace_start_patch()
-            otel_trace_start_patch_installed = True
-            otel_instrumentor = OpenAIAgentsInstrumentor()
-            otel_instrumentor.instrument(tracer_provider=trace.get_tracer_provider())
-            self._instrumented = True
+            _install_otel_instrumentation(trace.get_tracer_provider())
+            otel_instrumentation_installed = True
         try:
             yield
         finally:
             # Clean up OTEL instrumentation
-            if otel_instrumentor is not None:
-                otel_instrumentor.uninstrument()
-            if otel_trace_start_patch_installed:
-                _uninstall_otel_trace_start_patch()
+            if otel_instrumentation_installed:
+                _uninstall_otel_instrumentation()

--- a/tests/contrib/openai_agents/test_openai_tracing.py
+++ b/tests/contrib/openai_agents/test_openai_tracing.py
@@ -51,26 +51,31 @@ class MemoryTracingProcessor(TracingProcessor):
         pass
 
 
-def test_otel_trace_start_patch_does_not_nest() -> None:
+def test_otel_instrumentation_lifecycle_does_not_nest() -> None:
     from openinference.instrumentation.openai_agents._processor import (
         OpenInferenceTracingProcessor,
     )
+    from opentelemetry import trace
 
     original = OpenInferenceTracingProcessor.on_trace_start
-    _temporal_openai_agents._install_otel_trace_start_patch()
+    _temporal_openai_agents._install_otel_instrumentation(
+        trace.get_tracer_provider()
+    )
     try:
         installed_patch = OpenInferenceTracingProcessor.on_trace_start
         assert installed_patch is not original
 
-        _temporal_openai_agents._install_otel_trace_start_patch()
+        _temporal_openai_agents._install_otel_instrumentation(
+            trace.get_tracer_provider()
+        )
         try:
             assert OpenInferenceTracingProcessor.on_trace_start is installed_patch
         finally:
-            _temporal_openai_agents._uninstall_otel_trace_start_patch()
+            _temporal_openai_agents._uninstall_otel_instrumentation()
 
         assert OpenInferenceTracingProcessor.on_trace_start is installed_patch
     finally:
-        _temporal_openai_agents._uninstall_otel_trace_start_patch()
+        _temporal_openai_agents._uninstall_otel_instrumentation()
 
     assert OpenInferenceTracingProcessor.on_trace_start is original
 

--- a/tests/contrib/openai_agents/test_openai_tracing.py
+++ b/tests/contrib/openai_agents/test_openai_tracing.py
@@ -11,6 +11,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 
 from temporalio import activity, workflow
 from temporalio.client import Client
+from temporalio.contrib.openai_agents import _temporal_openai_agents
 from temporalio.contrib.openai_agents.testing import (
     AgentEnvironment,
 )
@@ -48,6 +49,30 @@ class MemoryTracingProcessor(TracingProcessor):
 
     def force_flush(self) -> None:
         pass
+
+
+def test_otel_trace_start_patch_does_not_nest() -> None:
+    from openinference.instrumentation.openai_agents._processor import (
+        OpenInferenceTracingProcessor,
+    )
+
+    original = OpenInferenceTracingProcessor.on_trace_start
+    _temporal_openai_agents._install_otel_trace_start_patch()
+    try:
+        installed_patch = OpenInferenceTracingProcessor.on_trace_start
+        assert installed_patch is not original
+
+        _temporal_openai_agents._install_otel_trace_start_patch()
+        try:
+            assert OpenInferenceTracingProcessor.on_trace_start is installed_patch
+        finally:
+            _temporal_openai_agents._uninstall_otel_trace_start_patch()
+
+        assert OpenInferenceTracingProcessor.on_trace_start is installed_patch
+    finally:
+        _temporal_openai_agents._uninstall_otel_trace_start_patch()
+
+    assert OpenInferenceTracingProcessor.on_trace_start is original
 
 
 async def test_tracing(client: Client):

--- a/tests/contrib/openai_agents/test_openai_tracing.py
+++ b/tests/contrib/openai_agents/test_openai_tracing.py
@@ -58,9 +58,7 @@ def test_otel_instrumentation_lifecycle_does_not_nest() -> None:
     from opentelemetry import trace
 
     original = OpenInferenceTracingProcessor.on_trace_start
-    _temporal_openai_agents._install_otel_instrumentation(
-        trace.get_tracer_provider()
-    )
+    _temporal_openai_agents._install_otel_instrumentation(trace.get_tracer_provider())
     try:
         installed_patch = OpenInferenceTracingProcessor.on_trace_start
         assert installed_patch is not original


### PR DESCRIPTION
## Summary
- scope the OpenInference trace-start patch to active OpenAI Agents tracing contexts
- prevent nested wrappers when multiple contexts are active
- restore the original method after the final context exits
- add a regression test for the patch lifecycle

## Why
The patch previously remained installed after instrumentation was removed. Each new OTel-enabled AgentEnvironment wrapped the previous patch, causing suite-order-dependent context work during workflow replay.

## Validation
- uv sync --all-extras
- poe build-develop
- poe test -s -k 'otel_trace_start_patch_does_not_nest or test_sdk_trace_to_otel_span_parenting'
- poe lint (Ruff and Pyright passed; the Mypy step did not return a final status before the command session ended)