### PR TITLE
Test LangSmith built-in query filtering

### DIFF
--- a/tests/contrib/langsmith/test_integration.py
+++ b/tests/contrib/langsmith/test_integration.py
@@ -1271,8 +1271,6 @@ class TestBuiltinQueryFiltering:
 
             # Built-in queries — should NOT be traced
             await handle.query("__temporal_workflow_metadata")
-            await handle.query("__stack_trace")
-            await handle.query("__enhanced_stack_trace")
 
             # User query — should be traced
             await handle.query(QueryFilteringWorkflow.my_query)

--- a/tests/contrib/langsmith/test_interceptor.py
+++ b/tests/contrib/langsmith/test_interceptor.py
@@ -16,9 +16,11 @@ from temporalio.contrib.langsmith._interceptor import (
     HEADER_KEY,
     _extract_context,
     _inject_context,
+    _LangSmithWorkflowInboundInterceptor,
     _maybe_run,
     _ReplaySafeRunTree,
 )
+from temporalio.worker import HandleQueryInput
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -86,6 +88,48 @@ def _get_runtree_metadata(MockRunTree: MagicMock) -> dict[str, Any]:
         return extra["metadata"]
     # Alternatively, metadata might be passed directly
     return kwargs.get("metadata", {})
+
+
+# ===================================================================
+# TestBuiltinQueryFiltering
+# ===================================================================
+
+
+class _RecordingWorkflowInboundInterceptor:
+    def __init__(self) -> None:
+        self.queries: list[HandleQueryInput] = []
+
+    async def handle_query(self, input: HandleQueryInput) -> str:
+        self.queries.append(input)
+        return "forwarded"
+
+
+class TestBuiltinQueryFiltering:
+    async def test_builtin_queries_bypass_tracing(self) -> None:
+        next_interceptor = _RecordingWorkflowInboundInterceptor()
+        interceptor = _LangSmithWorkflowInboundInterceptor(
+            next_interceptor  # type: ignore[arg-type]
+        )
+
+        with patch.object(interceptor, "_workflow_maybe_run") as maybe_run:
+            for query in (
+                "__temporal_workflow_metadata",
+                "__stack_trace",
+                "__enhanced_stack_trace",
+            ):
+                assert (
+                    await interceptor.handle_query(
+                        HandleQueryInput(id="id", query=query, args=[], headers={})
+                    )
+                    == "forwarded"
+                )
+
+        assert [input.query for input in next_interceptor.queries] == [
+            "__temporal_workflow_metadata",
+            "__stack_trace",
+            "__enhanced_stack_trace",
+        ]
+        maybe_run.assert_not_called()
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
- move stack-trace built-in query filtering coverage from the workflow integration test to an interceptor unit test
- retain an end-to-end check for the lightweight Temporal-prefixed query
- stack-trace built-ins can be expensive enough on CI runners to exceed the workflow task deadlock timeout, so their trace-filtering behavior is tested directly at the interceptor boundary

## Validation
- focused LangSmith test selection: 2 passed
- targeted Ruff import/format checks, Pyright, and git diff --check