### PR TITLE
Fix race in nexus double start test

### DIFF
--- a/tests/nexus/test_temporal_operation.py
+++ b/tests/nexus/test_temporal_operation.py
@@ -336,19 +336,21 @@ class TestServiceHandler:
         self,
         _ctx: nexus.TemporalStartOperationContext,
         client: nexus.TemporalNexusClient,
-        input: Input,
+        _input: Input,
     ) -> nexus.TemporalOperationResult[None]:
+        # Keep the first activity running so its callback cannot race the
+        # handler error raised by the second start.
         await client.start_activity(
-            echo_activity,
-            input,
+            wait_for_cancel_activity,
             id=f"double-start-activity-{uuid.uuid4()}",
-            start_to_close_timeout=timedelta(seconds=5),
+            start_to_close_timeout=timedelta(seconds=30),
+            heartbeat_timeout=timedelta(seconds=1),
         )
         await client.start_activity(
-            echo_activity,
-            input,
+            wait_for_cancel_activity,
             id=f"double-start-activity-{uuid.uuid4()}",
-            start_to_close_timeout=timedelta(seconds=5),
+            start_to_close_timeout=timedelta(seconds=30),
+            heartbeat_timeout=timedelta(seconds=1),
         )
         return nexus.TemporalOperationResult.sync(None)
 
@@ -1264,7 +1266,7 @@ async def test_temporal_operation_double_start_activity_raises_handler_err(
         env.client,
         task_queue=task_queue,
         nexus_service_handlers=[TestServiceHandler()],
-        activities=[echo_activity],
+        activities=[wait_for_cancel_activity],
     ):
         nexus_client = client.create_nexus_client(TestService, endpoint_name)
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Use a blocking activity in the Nexus double start activity test.

## Why?
<!-- Tell your future self why have you made these changes -->

There's a race where the first activity could finish before the double start happens. If that happens the nexus operation would be successful and the test would be in a bad state.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
