### PR TITLE
Test Strands with unique task queues

### DIFF
--- a/tests/contrib/strands/test_hooks.py
+++ b/tests/contrib/strands/test_hooks.py
@@ -67,7 +67,7 @@ class HooksWorkflow:
 
 async def test_hooks(client: Client):
     _AUDIT_LOG.clear()
-    task_queue = "test_hooks"
+    task_queue = f"test_hooks-{uuid4()}"
     plugin = StrandsPlugin(
         models={
             "mock": lambda: MockModel(

--- a/tests/contrib/strands/test_interrupt.py
+++ b/tests/contrib/strands/test_interrupt.py
@@ -65,7 +65,7 @@ class InterruptWorkflow:
 
 
 async def test_interrupt(client: Client):
-    task_queue = "test_interrupt"
+    task_queue = f"test_interrupt-{uuid4()}"
     plugin = StrandsPlugin(
         models={
             "mock": lambda: MockModel(

--- a/tests/contrib/strands/test_interrupt_exception.py
+++ b/tests/contrib/strands/test_interrupt_exception.py
@@ -99,7 +99,7 @@ class ActivityToolInterruptWorkflow:
 
 
 async def test_in_workflow_tool_interrupt(client: Client):
-    task_queue = "test_in_workflow_tool_interrupt"
+    task_queue = f"test_in_workflow_tool_interrupt-{uuid4()}"
     plugin = StrandsPlugin(
         models={
             "mock": lambda: MockModel(
@@ -140,7 +140,7 @@ async def test_in_workflow_tool_interrupt(client: Client):
 async def test_activity_tool_interrupt(client: Client):
     global _activity_delete_calls
     _activity_delete_calls = 0
-    task_queue = "test_activity_tool_interrupt"
+    task_queue = f"test_activity_tool_interrupt-{uuid4()}"
     plugin = StrandsPlugin(
         models={
             "mock": lambda: MockModel(

--- a/tests/contrib/strands/test_invocation_state.py
+++ b/tests/contrib/strands/test_invocation_state.py
@@ -58,11 +58,12 @@ class _InvocationStateWorkflow:
 
 async def test_invocation_state_round_trip(client: Client):
     _RECEIVED.clear()
+    task_queue = f"test_invocation_state-{uuid4()}"
     plugin = StrandsPlugin(models={"recording": lambda: _RecordingModel()})
 
     async with Worker(
         client,
-        task_queue="test_invocation_state",
+        task_queue=task_queue,
         workflows=[_InvocationStateWorkflow],
         plugins=[plugin],
         max_cached_workflows=0,
@@ -71,7 +72,7 @@ async def test_invocation_state_round_trip(client: Client):
             _InvocationStateWorkflow.run,
             "hi",
             id=f"test_invocation_state_{uuid4()}",
-            task_queue="test_invocation_state",
+            task_queue=task_queue,
         )
 
     # The serializable key crosses the activity boundary; the non-serializable

--- a/tests/contrib/strands/test_mcp.py
+++ b/tests/contrib/strands/test_mcp.py
@@ -52,7 +52,7 @@ class MCPWorkflow:
 
 
 async def test_mcp(client: Client):
-    task_queue = "test_mcp"
+    task_queue = f"test_mcp-{uuid4()}"
     plugin = StrandsPlugin(
         models={
             "mock": lambda: MockModel(
@@ -125,7 +125,7 @@ class MCPReuseWorkflow:
 
 async def test_mcp_reuses_connection(client: Client):
     """Successive MCP tool calls reuse one cached worker-side connection."""
-    task_queue = "test_mcp_reuses_connection"
+    task_queue = f"test_mcp_reuses_connection-{uuid4()}"
     # Count how often the worker opens a connection. One lazily-opened
     # connection serves the list-tools discovery and both tool calls (1);
     # reconnecting per call would make it more.
@@ -206,7 +206,7 @@ class MCPIdleWorkflow:
 
 async def test_mcp_connection_idle_timeout(client: Client):
     """A short idle timeout evicts the cached connection while the worker runs."""
-    task_queue = "test_mcp_connection_idle_timeout"
+    task_queue = f"test_mcp_connection_idle_timeout-{uuid4()}"
     factory_calls = [0]
 
     def counting_factory() -> MCPClient:
@@ -282,7 +282,7 @@ class MCPNoCacheWorkflow:
 
 async def test_mcp_lists_tools_each_turn_when_uncached(client: Client):
     """With cache_tools=False the tool list is re-fetched on every model call."""
-    task_queue = "test_mcp_lists_tools_each_turn_when_uncached"
+    task_queue = f"test_mcp_lists_tools_each_turn_when_uncached-{uuid4()}"
     plugin = StrandsPlugin(
         models={
             "mock": lambda: MockModel(

--- a/tests/contrib/strands/test_model.py
+++ b/tests/contrib/strands/test_model.py
@@ -24,7 +24,7 @@ class ModelWorkflow:
 
 
 async def test_model(client: Client):
-    task_queue = "test_model"
+    task_queue = f"test_model-{uuid4()}"
     plugin = StrandsPlugin(models={"mock": lambda: MockModel(["Done!"])})
 
     async with Worker(

--- a/tests/contrib/strands/test_model_streaming.py
+++ b/tests/contrib/strands/test_model_streaming.py
@@ -30,7 +30,7 @@ class StreamingModelWorkflow:
 
 
 async def test_model_streaming(client: Client):
-    task_queue = "test_model_streaming"
+    task_queue = f"test_model_streaming-{uuid4()}"
     plugin = StrandsPlugin(models={"mock": lambda: MockModel(["Done!"])})
     workflow_id = f"test_model_streaming_{uuid4()}"
 

--- a/tests/contrib/strands/test_structured_output.py
+++ b/tests/contrib/strands/test_structured_output.py
@@ -33,7 +33,7 @@ class StructuredOutputWorkflow:
 
 
 async def test_structured_output(client: Client):
-    task_queue = "test_structured_output"
+    task_queue = f"test_structured_output-{uuid4()}"
     plugin = StrandsPlugin(
         models={
             "mock": lambda: MockModel(

--- a/tests/contrib/strands/test_tool.py
+++ b/tests/contrib/strands/test_tool.py
@@ -59,7 +59,7 @@ class ToolWorkflow:
 
 
 async def test_tool(client: Client, tmp_path: Path):
-    task_queue = "test_tool"
+    task_queue = f"test_tool-{uuid4()}"
     fixture = tmp_path / "greeting.txt"
     fixture.write_text("hello\n")
 


### PR DESCRIPTION
## Summary
- give every Strands test invocation a unique task queue
- prevent workers from concurrent CI runs in the shared Cloud namespace from processing each other's workflows

## Validation
- poe test -s tests/contrib/strands: 13 passed
- poe lint
- git diff --check