### PR TITLE
contrib/google_adk_agents: rename activity_tool to activity_as_tool

### DIFF
--- a/temporalio/contrib/google_adk_agents/README.md
+++ b/temporalio/contrib/google_adk_agents/README.md
@@ -183,7 +183,7 @@ from datetime import timedelta
 from temporalio import activity
 from temporalio.contrib.google_adk_agents.workflow import (
     ToolContextSnapshot,
-    activity_tool,
+    activity_as_tool,
 )
 
 
@@ -193,7 +193,9 @@ async def get_weather(query: str, tool_context: ToolContextSnapshot) -> dict:
     ...
 
 
-weather_tool = activity_tool(get_weather, start_to_close_timeout=timedelta(seconds=30))
+weather_tool = activity_as_tool(
+    get_weather, start_to_close_timeout=timedelta(seconds=30)
+)
 ```
 
 Exactly like a native ADK function tool's `tool_context` parameter, it is
@@ -222,7 +224,7 @@ example an ADK callback or a plain tool function).
 The same agent definitions can also be exercised outside Temporal with
 `adk run` or `adk web`.
 
-- `TemporalModel` and `activity_tool(...)` work in local ADK runs without
+- `TemporalModel` and `activity_as_tool(...)` work in local ADK runs without
   additional configuration.
 - If the agent uses `TemporalMcpToolSet`, define a shared toolset factory,
   register it with `TemporalMcpToolSetProvider(...)` for workflow runs, and

--- a/temporalio/contrib/google_adk_agents/workflow.py
+++ b/temporalio/contrib/google_adk_agents/workflow.py
@@ -28,7 +28,7 @@ class ToolContextSnapshot:
 
     Declare a parameter named ``tool_context`` annotated with this type (or
     ``ToolContextSnapshot | None``) on an activity wrapped by
-    :func:`activity_tool`:
+    :func:`activity_as_tool`:
 
     .. code-block:: python
 
@@ -187,7 +187,7 @@ def _snapshot_tool_context(tool_context: Any) -> ToolContextSnapshot:
     )
 
 
-def activity_tool(activity_def: Callable, **kwargs: Any) -> Callable:
+def activity_as_tool(activity_def: Callable, **kwargs: Any) -> Callable:
     """Decorator/Wrapper to wrap a Temporal Activity as an ADK Tool.
 
     .. warning::

--- a/tests/contrib/google_adk_agents/test_adk_tool_context.py
+++ b/tests/contrib/google_adk_agents/test_adk_tool_context.py
@@ -1,7 +1,7 @@
 """Tests for ToolContextSnapshot injection into activity-backed tools.
 
 Covers https://github.com/temporalio/sdk-python/issues/1470: activities
-wrapped with activity_tool can read the serializable subset of the ADK
+wrapped with activity_as_tool can read the serializable subset of the ADK
 ToolContext (session state and function-call id) without the live,
 non-serializable ToolContext ever crossing the activity boundary, and
 without the parameter leaking into the LLM-facing tool schema.
@@ -30,7 +30,7 @@ from temporalio.client import Client
 from temporalio.contrib.google_adk_agents import GoogleAdkPlugin, TemporalModel
 from temporalio.contrib.google_adk_agents.workflow import (
     ToolContextSnapshot,
-    activity_tool,
+    activity_as_tool,
 )
 from temporalio.worker import Worker
 
@@ -67,7 +67,9 @@ def weather_agent(model_name: str) -> Agent:
         name="state_agent",
         model=TemporalModel(model_name),
         tools=[
-            activity_tool(lookup_weather, start_to_close_timeout=timedelta(seconds=30))
+            activity_as_tool(
+                lookup_weather, start_to_close_timeout=timedelta(seconds=30)
+            )
         ],
     )
 
@@ -144,7 +146,7 @@ class StateToolWorkflow:
 
 
 @pytest.mark.asyncio
-async def test_activity_tool_receives_tool_context_snapshot(client: Client):
+async def test_activity_as_tool_receives_tool_context_snapshot(client: Client):
     new_config = client.config()
     new_config["plugins"] = [GoogleAdkPlugin()]
     client = Client(**new_config)
@@ -172,7 +174,7 @@ async def test_activity_tool_receives_tool_context_snapshot(client: Client):
 
 
 @pytest.mark.asyncio
-async def test_activity_tool_snapshot_outside_workflow():
+async def test_activity_as_tool_snapshot_outside_workflow():
     """Local ADK runs (no Temporal) receive the same snapshot."""
     LLMRegistry.register(StateToolModel)
     result = await run_state_agent("state_tool_model")
@@ -192,7 +194,9 @@ def _declared_properties(tool: FunctionTool) -> dict[str, Any]:
 def test_tool_schema_excludes_tool_context():
     """The tool_context parameter never appears in the LLM-facing schema."""
     tool = FunctionTool(
-        func=activity_tool(lookup_weather, start_to_close_timeout=timedelta(seconds=30))
+        func=activity_as_tool(
+            lookup_weather, start_to_close_timeout=timedelta(seconds=30)
+        )
     )
     properties = _declared_properties(tool)
     assert "city" in properties
@@ -205,7 +209,7 @@ def test_tool_schema_excludes_tool_context_legacy_declaration():
     override_feature_enabled(FeatureName.JSON_SCHEMA_FOR_FUNC_DECL, False)
     try:
         tool = FunctionTool(
-            func=activity_tool(
+            func=activity_as_tool(
                 lookup_weather, start_to_close_timeout=timedelta(seconds=30)
             )
         )
@@ -229,7 +233,9 @@ def test_tool_schema_context_only_parameter():
         return str(tool_context.state)
 
     tool = FunctionTool(
-        func=activity_tool(ctx_only_tool, start_to_close_timeout=timedelta(seconds=30))
+        func=activity_as_tool(
+            ctx_only_tool, start_to_close_timeout=timedelta(seconds=30)
+        )
     )
     declaration = tool._get_declaration()
     if declaration is not None:
@@ -243,7 +249,7 @@ def test_tool_schema_context_only_parameter():
         assert not legacy_properties
 
 
-def test_activity_tool_accepts_optional_snapshot_annotation():
+def test_activity_as_tool_accepts_optional_snapshot_annotation():
     """ToolContextSnapshot | None is accepted and still excluded from the schema."""
 
     @activity.defn
@@ -254,13 +260,15 @@ def test_activity_tool_accepts_optional_snapshot_annotation():
         return query
 
     tool = FunctionTool(
-        func=activity_tool(optional_tool, start_to_close_timeout=timedelta(seconds=30))
+        func=activity_as_tool(
+            optional_tool, start_to_close_timeout=timedelta(seconds=30)
+        )
     )
     properties = _declared_properties(tool)
     assert set(properties) == {"query"}
 
 
-def test_activity_tool_rejects_adk_tool_context_annotation():
+def test_activity_as_tool_rejects_adk_tool_context_annotation():
     """Annotating with the live ADK ToolContext gives an actionable error."""
 
     @activity.defn
@@ -268,10 +276,10 @@ def test_activity_tool_rejects_adk_tool_context_annotation():
         return query
 
     with pytest.raises(ValueError, match="ToolContextSnapshot"):
-        activity_tool(bad_tool, start_to_close_timeout=timedelta(seconds=30))
+        activity_as_tool(bad_tool, start_to_close_timeout=timedelta(seconds=30))
 
 
-def test_activity_tool_rejects_optional_adk_tool_context_annotation():
+def test_activity_as_tool_rejects_optional_adk_tool_context_annotation():
     """Optional[ToolContext] is rejected with the ADK-specific message."""
 
     @activity.defn
@@ -282,10 +290,12 @@ def test_activity_tool_rejects_optional_adk_tool_context_annotation():
         return query
 
     with pytest.raises(ValueError, match="not serializable"):
-        activity_tool(optional_bad_tool, start_to_close_timeout=timedelta(seconds=30))
+        activity_as_tool(
+            optional_bad_tool, start_to_close_timeout=timedelta(seconds=30)
+        )
 
 
-def test_activity_tool_rejects_adk_context_under_any_name():
+def test_activity_as_tool_rejects_adk_context_under_any_name():
     """ADK injects into any param annotated with a context type, so all are rejected."""
 
     @activity.defn
@@ -293,10 +303,10 @@ def test_activity_tool_rejects_adk_context_under_any_name():
         return query
 
     with pytest.raises(ValueError, match="not serializable"):
-        activity_tool(sneaky_tool, start_to_close_timeout=timedelta(seconds=30))
+        activity_as_tool(sneaky_tool, start_to_close_timeout=timedelta(seconds=30))
 
 
-def test_activity_tool_rejects_snapshot_under_other_name():
+def test_activity_as_tool_rejects_snapshot_under_other_name():
     """ToolContextSnapshot on a differently-named param would leak into the schema."""
 
     @activity.defn
@@ -304,10 +314,10 @@ def test_activity_tool_rejects_snapshot_under_other_name():
         return query
 
     with pytest.raises(ValueError, match="named 'tool_context'"):
-        activity_tool(misnamed_tool, start_to_close_timeout=timedelta(seconds=30))
+        activity_as_tool(misnamed_tool, start_to_close_timeout=timedelta(seconds=30))
 
 
-def test_activity_tool_rejects_unannotated_tool_context():
+def test_activity_as_tool_rejects_unannotated_tool_context():
     """The reserved name without an annotation gives an actionable error."""
 
     @activity.defn
@@ -315,10 +325,10 @@ def test_activity_tool_rejects_unannotated_tool_context():
         return query
 
     with pytest.raises(ValueError, match="unannotated 'tool_context'"):
-        activity_tool(untyped_tool, start_to_close_timeout=timedelta(seconds=30))
+        activity_as_tool(untyped_tool, start_to_close_timeout=timedelta(seconds=30))
 
 
-def test_activity_tool_rejects_other_tool_context_annotation():
+def test_activity_as_tool_rejects_other_tool_context_annotation():
     """The reserved name with an unrelated annotation gives an actionable error."""
 
     @activity.defn
@@ -326,10 +336,10 @@ def test_activity_tool_rejects_other_tool_context_annotation():
         return query
 
     with pytest.raises(ValueError, match="reserved by ADK"):
-        activity_tool(confused_tool, start_to_close_timeout=timedelta(seconds=30))
+        activity_as_tool(confused_tool, start_to_close_timeout=timedelta(seconds=30))
 
 
-def test_activity_tool_without_tool_context_unchanged():
+def test_activity_as_tool_without_tool_context_unchanged():
     """Activities without a tool_context parameter keep their exact schema."""
 
     @activity.defn
@@ -337,6 +347,6 @@ def test_activity_tool_without_tool_context_unchanged():
         return query
 
     tool = FunctionTool(
-        func=activity_tool(plain_tool, start_to_close_timeout=timedelta(seconds=30))
+        func=activity_as_tool(plain_tool, start_to_close_timeout=timedelta(seconds=30))
     )
     assert set(_declared_properties(tool)) == {"query"}

--- a/tests/contrib/google_adk_agents/test_google_adk_agents.py
+++ b/tests/contrib/google_adk_agents/test_google_adk_agents.py
@@ -69,7 +69,7 @@ async def get_weather(city: str) -> str:  #  type: ignore[reportUnusedParameter]
 
 def weather_agent(model_name: str) -> Agent:
     # Wraps 'get_weather' activity as a Tool
-    weather_tool = temporalio.contrib.google_adk_agents.workflow.activity_tool(
+    weather_tool = temporalio.contrib.google_adk_agents.workflow.activity_as_tool(
         get_weather, start_to_close_timeout=timedelta(seconds=60)
     )
 
@@ -700,7 +700,7 @@ def test_summary_and_summary_fn_raises():
 
 @pytest.mark.asyncio
 async def test_agent_outside_workflow():
-    """Test that an agent using TemporalModel and activity_tool works outside a Temporal workflow."""
+    """Test that an agent using TemporalModel and activity_as_tool works outside a Temporal workflow."""
     LLMRegistry.register(WeatherModel)
 
     agent = weather_agent("weather_model")
@@ -827,13 +827,13 @@ class ComplexActivityInputAgent:
             name="complex_input_agent",
             model=TemporalModel(model_name),
             tools=[
-                temporalio.contrib.google_adk_agents.workflow.activity_tool(
+                temporalio.contrib.google_adk_agents.workflow.activity_as_tool(
                     book_trip, start_to_close_timeout=timedelta(seconds=60)
                 ),
-                temporalio.contrib.google_adk_agents.workflow.activity_tool(
+                temporalio.contrib.google_adk_agents.workflow.activity_as_tool(
                     summarize_payload, start_to_close_timeout=timedelta(seconds=60)
                 ),
-                temporalio.contrib.google_adk_agents.workflow.activity_tool(
+                temporalio.contrib.google_adk_agents.workflow.activity_as_tool(
                     method_holder.annotate_trip,
                     start_to_close_timeout=timedelta(seconds=60),
                 ),
@@ -934,7 +934,7 @@ class ComplexActivityInputModel(TestModel):
 
 
 @pytest.mark.asyncio
-async def test_activity_tool_supports_complex_inputs_via_adk(client: Client):
+async def test_activity_as_tool_supports_complex_inputs_via_adk(client: Client):
     new_config = client.config()
     new_config["plugins"] = [GoogleAdkPlugin()]
     client = Client(**new_config)
@@ -1122,8 +1122,8 @@ def test_explicitly_set_none_preserved() -> None:
     assert serialized["cache_config"] is None
 
 
-def test_activity_tool_preserves_metadata() -> None:
-    """activity_tool wrapper preserves the original function's metadata.
+def test_activity_as_tool_preserves_metadata() -> None:
+    """activity_as_tool wrapper preserves the original function's metadata.
 
     This ensures ADK's tool schema generation can inspect __annotations__
     and __module__ on the wrapper, which are needed by
@@ -1135,7 +1135,7 @@ def test_activity_tool_preserves_metadata() -> None:
         """Get info for a city."""
         return f"{city}: {count}"
 
-    tool = temporalio.contrib.google_adk_agents.workflow.activity_tool(
+    tool = temporalio.contrib.google_adk_agents.workflow.activity_as_tool(
         my_activity, start_to_close_timeout=timedelta(seconds=30)
     )
 


### PR DESCRIPTION
**Breaking:** `google_adk_agents.workflow.activity_tool` → `activity_as_tool`. Follows up on @brianstrauch's [comment on #1683](https://github.com/temporalio/sdk-python/pull/1683#discussion_r3707160771).

### Why

ADK was the only plugin here not already using `activity_as_tool`: `openai_agents`, `strands` (plus `activity_as_hook`), and `google_genai` all do, and `google_genai`'s is the closest twin (also returns a bare `Callable` the framework introspects for its schema).

It's cross-language, too: sdk-go's plugin for the *same* framework uses [`ActivityAsTool`](https://github.com/temporalio/sdk-go/blob/main/contrib/googleadk/tool.go#L120), with `ActivityToolOptions` for the options struct and a private `activityTool` type (verb for the conversion, noun for the result). We used the noun for the verb. TS uses `activityAsTool`. Otherwise a Go reader and a Python reader of the same ADK guide see different names for one primitive.

### No alias

ADK is Pre-release at every level (prerelease banner on the docs page, `## Pre-release` in the 1.24.0 notes, experimental docstring, absent from `__all__`), and the [policy](https://docs.temporal.io/evaluate/development-production-features/release-stages) for that stage is "API is subject to change." Matches #1139 and #947, neither of which shipped an alias.

We'll have to update [adk.dev](https://adk.dev/integrations/temporal/), which Google controls, but it's OSS so we'll just open a PR and hope they merge it quickly. Lmk if you think that's a bad approach.

### Deliberately out of scope

`**kwargs: Any` here is still out of step with the siblings (explicit options, or an `ActivityConfig`; Go uses an options struct), and the "Decorator/Wrapper" docstring is wrong — parameterized decorator use fails. Both are design questions, not renames; follow-up keeps this diff purely mechanical.

### Follow-ups once merged

`temporalio/documentation` (`google-adk.mdx`, 4 mentions) · `samples-python` (`google_adk_agents/`, 3 files) · `google/adk-docs` (`docs/integrations/temporal.md` L85/97/246/272 - external PRs accepted, CLA already satisfied.

### Test plan

`pytest tests/contrib/google_adk_agents/` → 39 passed. `ruff check --select I`, `ruff format --check`, `pyright`, `pydocstyle` clean.