### PR TITLE
Add mcp dependency to google-adk extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ to include examples, links to docs, or any other relevant information.
 
 ### Fixed
 
+- The `google-adk` extra now depends on `mcp`, so fresh installs of
+  `temporalio[google-adk]` can import `temporalio.contrib.google_adk_agents`
+  without separately installing `mcp`. Previously the import failed with an
+  `ImportError` because `google.adk.tools.mcp_tool` only exports `McpToolset`
+  when `mcp` is installed.
+
 ### Security
 
 ## [1.31.0] - 2026-07-29

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ grpc = ["grpcio>=1.48.2,<2"]
 opentelemetry = ["opentelemetry-api>=1.11.1,<2", "opentelemetry-sdk>=1.11.1,<2"]
 pydantic = ["pydantic>=2.0.0,<3"]
 openai-agents = ["openai-agents>=0.17.5", "mcp>=1.9.4, <2"]
-google-adk = ["google-adk>=2.2.0,<3"]
+google-adk = ["google-adk>=2.2.0,<3", "mcp>=1.24,<2"]
 langgraph = ["langgraph>=1.1.0"]
 langsmith = ["langsmith>=0.7.34,<0.9"]
 lambda-worker-otel = [

--- a/uv.lock
+++ b/uv.lock
@@ -4625,6 +4625,7 @@ aioboto3 = [
 ]
 google-adk = [
     { name = "google-adk" },
+    { name = "mcp" },
 ]
 google-genai = [
     { name = "google-genai" },
@@ -4712,6 +4713,7 @@ requires-dist = [
     { name = "grpcio", marker = "extra == 'grpc'", specifier = ">=1.48.2,<2" },
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.1.0" },
     { name = "langsmith", marker = "extra == 'langsmith'", specifier = ">=0.7.34,<0.9" },
+    { name = "mcp", marker = "extra == 'google-adk'", specifier = ">=1.24,<2" },
     { name = "mcp", marker = "extra == 'openai-agents'", specifier = ">=1.9.4,<2" },
     { name = "nexus-rpc", specifier = "==1.4.0" },
     { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.17.5" },


### PR DESCRIPTION
## What was changed

Added `mcp>=1.24,<2` to the `google-adk` extra (plus `uv.lock` and a CHANGELOG entry under Fixed).

## Why

A fresh `pip install temporalio[google-adk]` could not import the contrib package:

```
File ".../google_adk_agents/_mcp.py", line 13, in <module>
    from google.adk.tools.mcp_tool import McpToolset
ImportError: cannot import name 'McpToolset' from 'google.adk.tools.mcp_tool'
```

`google-adk` only exports `McpToolset` when the optional `mcp` package is importable and keeps `mcp` behind its own extra, which ours didn't pull in. The constraint matches google-adk's own `mcp` extra across our supported range (2.2.0–current), following the precedent of our `openai-agents` extra.

## How was this tested

Fresh-venv before/after with only the `google-adk` extra: reproduces the `ImportError` on main's metadata, imports cleanly with this change. `uv lock --check`, `poe lint`, and `pytest tests/contrib/google_adk_agents` (39 passed, 5 skipped) all pass.