### PR TITLE
Remove stale references to Python 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Temporal Python SDK](https://assets.temporal.io/w/py.png)
 
-[![Python 3.9+](https://img.shields.io/pypi/pyversions/temporalio.svg?style=for-the-badge)](https://pypi.org/project/temporalio)
+[![Python 3.10+](https://img.shields.io/pypi/pyversions/temporalio.svg?style=for-the-badge)](https://pypi.org/project/temporalio)
 [![PyPI](https://img.shields.io/pypi/v/temporalio.svg?style=for-the-badge)](https://pypi.org/project/temporalio)
 [![MIT](https://img.shields.io/pypi/l/temporalio.svg?style=for-the-badge)](LICENSE)
 
@@ -2014,7 +2014,7 @@ users are encouraged to not use gevent in asyncio applications (including Tempor
 
 # Development
 
-The Python SDK is built to work with Python 3.9 and newer. It is built using
+The Python SDK is built to work with Python 3.10 and newer. It is built using
 [SDK Core](https://github.com/temporalio/sdk-rust/) which is written in Rust.
 
 ### Building

--- a/temporalio/worker/_activity.py
+++ b/temporalio/worker/_activity.py
@@ -727,8 +727,7 @@ class _RunningActivity:
                 )
             # If not sync and there's a task, cancel it
             if not self.sync and self.task:
-                # TODO(cretz): Set msg?
-                self.task.cancel()
+                self.task.cancel("Activity cancelled")
 
 
 class _ThreadExceptionRaiser:

--- a/temporalio/worker/_activity.py
+++ b/temporalio/worker/_activity.py
@@ -727,7 +727,7 @@ class _RunningActivity:
                 )
             # If not sync and there's a task, cancel it
             if not self.sync and self.task:
-                # TODO(cretz): Check that Python >= 3.9 and set msg?
+                # TODO(cretz): Set msg?
                 self.task.cancel()
 
 

--- a/tests/worker/test_activity.py
+++ b/tests/worker/test_activity.py
@@ -382,8 +382,13 @@ async def test_activity_cancel_catch(
             while True:
                 await asyncio.sleep(0.3)
                 activity.heartbeat()
-        except asyncio.CancelledError:
-            return "Got cancelled error, cancelled? " + str(activity.is_cancelled())
+        except asyncio.CancelledError as err:
+            return (
+                "Got cancelled error, cancelled? "
+                + str(activity.is_cancelled())
+                + ", reason: "
+                + str(err)
+            )
 
     result = await _execute_workflow_with_activity(
         client,
@@ -394,7 +399,10 @@ async def test_activity_cancel_catch(
         heartbeat_timeout_ms=2000,
         shared_state_manager=shared_state_manager,
     )
-    assert result.result == "Got cancelled error, cancelled? True"
+    assert (
+        result.result
+        == "Got cancelled error, cancelled? True, reason: Activity cancelled"
+    )
 
 
 async def test_activity_cancel_throw(

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -6431,12 +6431,6 @@ async def test_workflow_current_update(client: Client):
         )
 
 
-def skip_unfinished_handler_tests_in_older_python():
-    # These tests reliably fail or timeout in 3.9
-    if sys.version_info < (3, 10):
-        pytest.skip("Skipping unfinished handler tests in Python < 3.10")
-
-
 @workflow.defn
 class UnfinishedHandlersWarningsWorkflow:
     def __init__(self):
@@ -6494,7 +6488,6 @@ async def test_unfinished_update_handler(client: Client):
 
 
 async def test_unfinished_signal_handler(client: Client):
-    skip_unfinished_handler_tests_in_older_python()
     async with new_worker(client, UnfinishedHandlersWarningsWorkflow) as worker:
         test = _UnfinishedHandlersWarningsTest(client, worker, "signal")
         await test.test_wait_all_handlers_finished_and_unfinished_handlers_warning()
@@ -6736,7 +6729,6 @@ async def test_unfinished_handler_on_workflow_termination(
         "-cancellation-", "-failure-", "-continue-as-new-"
     ],
 ):
-    skip_unfinished_handler_tests_in_older_python()
     await _UnfinishedHandlersOnWorkflowTerminationTest(
         client,
         handler_type,


### PR DESCRIPTION
The SDK has required Python 3.10+ since #885, but a few doc lines and comments still mentioned 3.9. This also drops `skip_unfinished_handler_tests_in_older_python()`, whose `sys.version_info < (3, 10)` guard can no longer be true.