### PR TITLE
feat: expose runtime environment info option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ to include examples, links to docs, or any other relevant information.
 
 ### Added
 
+- Added the `Runtime(disable_environment_info=...)` option to control whether
+  runtime, hosting, and platform information is included in worker heartbeats.
+
 - `temporalio.workflow.uuid7()` generates a determinism-safe, time-sortable
   UUIDv7 (RFC 9562) from workflow time and the workflow's deterministic random
   generator, complementing the existing `workflow.uuid4()`

--- a/temporalio/bridge/runtime.py
+++ b/temporalio/bridge/runtime.py
@@ -99,6 +99,7 @@ class RuntimeOptions:
 
     telemetry: TelemetryConfig
     worker_heartbeat_interval_millis: int | None = 60_000  # 60s
+    disable_environment_info: bool = False
 
 
 # WARNING: This must match Rust runtime::BufferedLogEntry

--- a/temporalio/bridge/src/runtime.rs
+++ b/temporalio/bridge/src/runtime.rs
@@ -91,6 +91,7 @@ pub struct PrometheusConfig {
 pub struct RuntimeOptions {
     telemetry: TelemetryConfig,
     worker_heartbeat_interval_millis: Option<u64>,
+    disable_environment_info: bool,
 }
 
 const FORWARD_LOG_BUFFER_SIZE: usize = 2048;
@@ -100,6 +101,7 @@ pub fn init_runtime(options: RuntimeOptions) -> PyResult<RuntimeRef> {
     let RuntimeOptions {
         telemetry: TelemetryConfig { logging, metrics },
         worker_heartbeat_interval_millis,
+        disable_environment_info,
     } = options;
 
     // Have to build/start telemetry config pieces
@@ -134,6 +136,7 @@ pub fn init_runtime(options: RuntimeOptions) -> PyResult<RuntimeRef> {
                 .build(),
         )
         .heartbeat_interval(worker_heartbeat_interval_millis.map(Duration::from_millis))
+        .disable_environment_info(disable_environment_info)
         .build()
         .map_err(|err| PyValueError::new_err(format!("Invalid runtime options: {err}")))?;
 

--- a/temporalio/runtime.py
+++ b/temporalio/runtime.py
@@ -118,6 +118,7 @@ class Runtime:
         *,
         telemetry: TelemetryConfig,
         worker_heartbeat_interval: timedelta | None = timedelta(seconds=60),
+        disable_environment_info: bool = False,
     ) -> None:
         """Create a runtime with the provided configuration.
 
@@ -128,6 +129,8 @@ class Runtime:
                 ``runtime_options``.
             worker_heartbeat_interval: Interval for worker heartbeats. ``None``
                 disables heartbeating. Interval must be between 1s and 60s.
+            disable_environment_info: Whether to omit runtime, hosting, and
+                platform information from worker heartbeats.
 
         Raises:
             ValueError: If both ```runtime_options`` is a negative value.
@@ -142,6 +145,7 @@ class Runtime:
         runtime_options = temporalio.bridge.runtime.RuntimeOptions(
             telemetry=telemetry._to_bridge_config(),
             worker_heartbeat_interval_millis=heartbeat_millis,
+            disable_environment_info=disable_environment_info,
         )
 
         self._core_runtime = temporalio.bridge.runtime.Runtime(options=runtime_options)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -9,6 +9,8 @@ from urllib.request import urlopen
 
 import pytest
 
+import temporalio.bridge.metric
+import temporalio.bridge.runtime
 from temporalio import workflow
 from temporalio.client import Client
 from temporalio.runtime import (
@@ -367,6 +369,31 @@ def test_runtime_options_invalid_heartbeat() -> None:
         Runtime(
             telemetry=TelemetryConfig(), worker_heartbeat_interval=timedelta(seconds=-5)
         )
+
+
+def test_runtime_environment_info_option(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_options = []
+
+    class MockRuntime:
+        def __init__(self, *, options: Any) -> None:
+            captured_options.append(options)
+
+    monkeypatch.setattr(temporalio.bridge.runtime, "Runtime", MockRuntime)
+    monkeypatch.setattr(
+        temporalio.bridge.metric.MetricMeter, "create", staticmethod(lambda _: None)
+    )
+
+    Runtime(telemetry=TelemetryConfig())
+    Runtime(telemetry=TelemetryConfig(), disable_environment_info=True)
+
+    assert [option.disable_environment_info for option in captured_options] == [
+        False,
+        True,
+    ]
+
+
+def test_runtime_environment_info_can_be_enabled() -> None:
+    Runtime(telemetry=TelemetryConfig(), disable_environment_info=False)
 
 
 def test_runtime_ref_creates_default():


### PR DESCRIPTION
## Summary
- Expose the Runtime disable_environment_info option for controlling environment metadata in worker heartbeats.
- Pass the setting through the Python bridge to SDK Core.
- Add coverage for the default and opt-out behavior.

## Validation
- poe format
- poe test -s tests/test_runtime.py -k environment_info or runtime_ref_creates_default