### PR TITLE
AI-382: let a sandbox client omit its options

### DIFF
--- a/temporalio/contrib/openai_agents/README.md
+++ b/temporalio/contrib/openai_agents/README.md
@@ -481,7 +481,7 @@ Both `stateless_mcp_server()` and `stateful_mcp_server()` accept an optional `fa
 
 A stateless factory that declares no parameters — like the `lambda: MCPServerStdio(...)` example above — ignores the value, but it is still recorded in history.
 
-**Do not pass secrets, credentials, or API keys through `factory_argument`.** It is an activity argument, so it is recorded in workflow history and, without a payload codec, visible in the web UI. Resolve credentials worker-side inside the server factory instead.
+**Do not pass secrets, credentials, or API keys through `factory_argument`.** Its value is written into workflow history, where anyone who can read the workflow can read it in the web UI unless you have configured a payload codec. Resolve credentials worker-side inside the server factory instead.
 
 ### Hosted MCP Tool
 
@@ -525,7 +525,7 @@ from temporalio.client import Client
 from temporalio.worker import Worker
 from temporalio.contrib.openai_agents import OpenAIAgentsPlugin, SandboxClientProvider, ModelActivityParameters
 from agents.extensions.sandbox.daytona import DaytonaSandboxClient
-from agents.extensions.sandbox.unix_local import UnixLocalSandboxClient
+from agents.sandbox.sandboxes.unix_local import UnixLocalSandboxClient
 
 async def main():
     client = await Client.connect(
@@ -587,6 +587,20 @@ class MyWorkflow:
 ```
 
 The name passed to `temporal_sandbox_client()` must exactly match the name used in `SandboxClientProvider` on the worker.
+
+### Keeping Options Out of History
+
+Whatever you put in `options` — including any API key it carries — is written into workflow history, where anyone who can read the workflow can read it in the web UI unless you have configured a payload codec.
+
+When the worker-side sandbox client's class declares `supports_default_options = True` — meaning it supplies its own defaults — you can mirror that declaration in the `temporal_sandbox_client()` call and leave `options` out entirely. `UnixLocalSandboxClient` and `RunloopSandboxClient` declare it, and a client you write yourself can too. History then records the options as `null`:
+
+```python
+run_config = RunConfig(sandbox=SandboxRunConfig(
+    client=temporal_sandbox_client("local", supports_default_options=True),
+))
+```
+
+Set the flag only for a client you have confirmed supplies its own defaults: on one that requires its options the sandbox never starts, and the workflow fails immediately with a non-retryable error naming the flag and the backend.
 
 ### Multiple Backends
 

--- a/temporalio/contrib/openai_agents/sandbox/_sandbox_client_provider.py
+++ b/temporalio/contrib/openai_agents/sandbox/_sandbox_client_provider.py
@@ -117,6 +117,23 @@ class SandboxClientProvider:
 
         @activity.defn(name=f"{prefix}-sandbox_client_create")
         async def create_session(args: CreateSessionArgs) -> SessionResult:
+            # Non-retryable: every retry would hit the same mismatch.
+            if (
+                args.client_options is None
+                and not self._client.supports_default_options
+            ):
+                raise ApplicationError(
+                    f"Sandbox backend {self._name!r} "
+                    f"({type(self._client).__name__}) does not declare "
+                    "`supports_default_options`, so it cannot create a session "
+                    "without options. Either set `options` on `SandboxRunConfig` "
+                    "and drop `supports_default_options=True` from the "
+                    "`temporal_sandbox_client()` call, or, if the client does "
+                    "supply its own defaults, declare "
+                    "`supports_default_options = True` on its class.",
+                    type="sandbox_options_required",
+                    non_retryable=True,
+                )
             with _translate_sandbox_errors():
                 session = await self._client.create(
                     snapshot=args.snapshot_spec,

--- a/temporalio/contrib/openai_agents/sandbox/_temporal_sandbox_client.py
+++ b/temporalio/contrib/openai_agents/sandbox/_temporal_sandbox_client.py
@@ -28,12 +28,12 @@ from temporalio.contrib.openai_agents.sandbox._temporal_sandbox_session import (
 from temporalio.workflow import ActivityConfig
 
 
-class TemporalSandboxClient(BaseSandboxClient[BaseSandboxClientOptions]):
+class TemporalSandboxClient(BaseSandboxClient[BaseSandboxClientOptions | None]):
     """Stateless client that dispatches all lifecycle operations as Temporal activities.
 
     No inner client is needed -- session creation, resumption, and deletion are
     all handled by activities whose names are prefixed with the provider
-    ``name`` (e.g. ``"daytona-sandbox_create_session"``).  The real
+    ``name`` (e.g. ``"daytona-sandbox_client_create"``).  The real
     ``BaseSandboxClient`` lives inside :class:`SandboxClientProvider` on the worker.
 
     Users should never need to instantiate this directly -- use
@@ -46,12 +46,17 @@ class TemporalSandboxClient(BaseSandboxClient[BaseSandboxClientOptions]):
             sandbox backend is targeted.
         config: Optional activity configuration for controlling timeouts,
             retries, etc.  Defaults to a 5-minute ``start_to_close_timeout``.
+        supports_default_options: Your declaration that the worker-side sandbox
+            client registered under ``name`` supplies its own defaults, so
+            ``options`` may be omitted.
     """
 
     def __init__(
         self,
         name: str,
         config: ActivityConfig | None = None,
+        *,
+        supports_default_options: bool = False,
     ) -> None:
         """Initialize the client."""
         self._name = name
@@ -59,13 +64,14 @@ class TemporalSandboxClient(BaseSandboxClient[BaseSandboxClientOptions]):
             start_to_close_timeout=timedelta(minutes=5),
         )
         self.backend_id = name
+        self.supports_default_options = supports_default_options
 
     async def create(
         self,
         *,
         snapshot: SnapshotSpec | SnapshotBase | None = None,
         manifest: Manifest | None = None,
-        options: BaseSandboxClientOptions,
+        options: BaseSandboxClientOptions | None,
     ) -> SandboxSession:
         """Create a new sandbox session via activity."""
         result: SessionResult = await workflow.execute_activity(

--- a/temporalio/contrib/openai_agents/workflow.py
+++ b/temporalio/contrib/openai_agents/workflow.py
@@ -247,6 +247,8 @@ def nexus_operation_as_tool(
 def temporal_sandbox_client(
     name: str,
     config: ActivityConfig | None = None,
+    *,
+    supports_default_options: bool = False,
 ) -> Any:
     """Create a sandbox client reference for use in a Temporal workflow ``RunConfig``.
 
@@ -267,13 +269,33 @@ def temporal_sandbox_client(
             ),
         )
 
+    .. warning::
+        ``options`` -- including any API key they carry -- are written into
+        workflow history, so anyone who can read the workflow can read them in
+        the web UI unless a payload codec is configured.  Leaving ``options``
+        unset with ``supports_default_options=True`` keeps them out, but only
+        works on a client you have confirmed supplies its own defaults; on one
+        that requires its options the sandbox never starts and the workflow
+        fails immediately with a non-retryable error naming the flag.
+
     Args:
         name: The name of the ``SandboxClientProvider`` registered on the
             worker.  Must match exactly.
         config: Optional activity configuration for controlling timeouts,
             retries, etc.  Defaults to a 5-minute ``start_to_close_timeout``.
+        supports_default_options: Set to ``True`` to declare that the sandbox
+            client registered on the worker supplies its own defaults, allowing
+            ``options`` to be omitted from ``SandboxRunConfig``.  Set it when
+            that client's own ``supports_default_options`` attribute is
+            ``True`` -- ``UnixLocalSandboxClient`` and ``RunloopSandboxClient``
+            are two such clients, and a client you write yourself can declare
+            it as well.
     """
-    return TemporalSandboxClient(name=name, config=config)
+    return TemporalSandboxClient(
+        name=name,
+        config=config,
+        supports_default_options=supports_default_options,
+    )
 
 
 def stateless_mcp_server(

--- a/tests/contrib/openai_agents/test_openai_sandbox.py
+++ b/tests/contrib/openai_agents/test_openai_sandbox.py
@@ -1,7 +1,11 @@
 """Tests for sandbox validation in TemporalOpenAIRunner."""
 
 import io
+import json
+import sys
 import uuid
+from base64 import b64encode
+from collections.abc import Callable, Sequence
 from datetime import timedelta
 from pathlib import Path
 from typing import Any, Literal
@@ -27,7 +31,8 @@ from pydantic import TypeAdapter
 from pydantic_core import to_json
 
 from temporalio import workflow
-from temporalio.client import Client
+from temporalio.api.history.v1 import HistoryEvent
+from temporalio.client import Client, WorkflowFailureError
 from temporalio.contrib.openai_agents import (
     ModelActivityParameters,
     OpenAIAgentsPlugin,
@@ -285,6 +290,7 @@ class _MockSandboxClient(BaseSandboxClient[BaseSandboxClientOptions | None]):
         self.create_calls: int = 0
         self.resume_calls: int = 0
         self.delete_calls: int = 0
+        self.create_options: list[BaseSandboxClientOptions | None] = []
 
     async def create(
         self,
@@ -294,6 +300,7 @@ class _MockSandboxClient(BaseSandboxClient[BaseSandboxClientOptions | None]):
         options: BaseSandboxClientOptions | None = None,
     ) -> SandboxSession:
         self.create_calls += 1
+        self.create_options.append(options)
         if manifest is not None:
             self.inner_session.state.manifest = manifest
         return self.session
@@ -818,6 +825,12 @@ class SandboxE2EWorkflow:
         return result.final_output
 
 
+def _client_with_plugin(client: Client, plugin: OpenAIAgentsPlugin) -> Client:
+    new_config = client.config()
+    new_config["plugins"] = [plugin]
+    return Client(**new_config)
+
+
 async def test_sandbox_e2e_runner(client: Client):
     """End-to-end: Runner.run() with SandboxAgent exercises the full sandbox
     lifecycle (create, start, stop, shutdown, delete) through Temporal activities."""
@@ -843,9 +856,7 @@ async def test_sandbox_e2e_runner(client: Client):
         sandbox_clients=[SandboxClientProvider("mock", mock_sandbox_client)],
     )
 
-    new_config = client.config()
-    new_config["plugins"] = [plugin]
-    test_client = Client(**new_config)
+    test_client = _client_with_plugin(client, plugin)
 
     async with new_worker(
         test_client,
@@ -869,6 +880,361 @@ async def test_sandbox_e2e_runner(client: Client):
     assert mock_session.stop_calls >= 1, "session.stop() not called"
     assert mock_session.shutdown_calls >= 1, "session.shutdown() not called"
     assert mock_sandbox_client.delete_calls == 1, "client.delete() not called"
+
+
+# ── Default (omitted) client options ──
+
+_SANDBOX_OPTIONS_SECRET = "sk-sandbox-must-not-reach-history"
+
+
+class _SecretSandboxClientOptions(BaseSandboxClientOptions):
+    type: str = "secret-test"  # type: ignore[reportIncompatibleVariableOverride]
+    # Required so the workflow must set it: ``exclude_unset`` drops a defaulted field.
+    api_key: str
+
+
+def test_temporal_sandbox_client_supports_default_options_false_by_default():
+    assert temporal_sandbox_client("my-backend").supports_default_options is False
+
+
+def test_temporal_sandbox_client_supports_default_options():
+    client = temporal_sandbox_client("my-backend", supports_default_options=True)
+    assert client.supports_default_options is True
+
+
+@workflow.defn
+class SandboxOptionsRequiredWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        try:
+            await Runner.run(
+                starting_agent=SandboxAgent[None](name="sandbox-no-options"),
+                input="hello",
+                run_config=RunConfig(
+                    sandbox=SandboxRunConfig(client=temporal_sandbox_client("mock")),
+                ),
+            )
+        except ValueError as e:
+            return str(e)
+        return "FAIL: omitting options should have been rejected"
+
+
+async def test_sandbox_options_required_by_default(client: Client):
+    async with AgentEnvironment(model=_mock_model()) as env:
+        client = env.applied_on_client(client)
+        async with new_worker(
+            client,
+            SandboxOptionsRequiredWorkflow,
+            workflow_failure_exception_types=[ValueError, AssertionError],
+        ) as worker:
+            result = await client.execute_workflow(
+                SandboxOptionsRequiredWorkflow.run,
+                id=f"sandbox-options-required-{uuid.uuid4()}",
+                task_queue=worker.task_queue,
+                execution_timeout=timedelta(seconds=10),
+            )
+    assert "requires `run_config.sandbox.options`" in result
+
+
+@workflow.defn
+class SandboxDefaultOptionsWorkflow:
+    @workflow.run
+    async def run(self, include_options: bool) -> str:
+        agent = SandboxAgent[None](
+            name="sandbox-default-options", capabilities=[_TestSandboxCapability()]
+        )
+        result = await Runner.run(
+            starting_agent=agent,
+            input="run a command",
+            run_config=RunConfig(
+                sandbox=SandboxRunConfig(
+                    client=temporal_sandbox_client(
+                        "mock", supports_default_options=True
+                    ),
+                    options=_SecretSandboxClientOptions(api_key=_SANDBOX_OPTIONS_SECRET)
+                    if include_options
+                    else None,
+                ),
+            ),
+        )
+        return result.final_output
+
+
+def _mock_sandbox_plugin(provider: SandboxClientProvider) -> OpenAIAgentsPlugin:
+    return OpenAIAgentsPlugin(
+        model_params=ModelActivityParameters(
+            start_to_close_timeout=timedelta(seconds=30),
+        ),
+        model_provider=TestModelProvider(
+            TestModel.returning_responses(
+                [
+                    ResponseBuilders.tool_call('{"cmd": "echo one"}', "run_command"),
+                    ResponseBuilders.tool_call('{"cmd": "echo two"}', "run_command"),
+                    ResponseBuilders.output_message("Done."),
+                ]
+            )
+        ),
+        sandbox_clients=[provider],
+    )
+
+
+def _activity_payloads(
+    events: Sequence[HistoryEvent], activity_name: str
+) -> tuple[list[bytes], list[bytes]]:
+    """The ``(arguments, results)`` payload bytes of every ``activity_name`` activity."""
+    scheduled_ids: set[int] = set()
+    args: list[bytes] = []
+    results: list[bytes] = []
+    for event in events:
+        if event.HasField("activity_task_scheduled_event_attributes"):
+            scheduled = event.activity_task_scheduled_event_attributes
+            if scheduled.activity_type.name == activity_name:
+                scheduled_ids.add(event.event_id)
+                args.extend(p.data for p in scheduled.input.payloads)
+        elif event.HasField("activity_task_completed_event_attributes"):
+            completed = event.activity_task_completed_event_attributes
+            # A completion event carries no activity type, so the only way to
+            # attribute a result is through the scheduled event it points back to.
+            if completed.scheduled_event_id in scheduled_ids:
+                results.extend(p.data for p in completed.result.payloads)
+    return args, results
+
+
+@pytest.mark.parametrize("include_options", [False, True], ids=["omitted", "provided"])
+async def test_sandbox_client_options_reach_history_only_when_provided(
+    client: Client, include_options: bool
+):
+    mock_sandbox_client = _MockSandboxClient()
+    provider = SandboxClientProvider("mock", mock_sandbox_client)
+    test_client = _client_with_plugin(client, _mock_sandbox_plugin(provider))
+
+    async with new_worker(
+        test_client,
+        SandboxDefaultOptionsWorkflow,
+        workflow_failure_exception_types=[Exception],
+    ) as worker:
+        handle = await test_client.start_workflow(
+            SandboxDefaultOptionsWorkflow.run,
+            include_options,
+            id=f"sandbox-default-options-{uuid.uuid4()}",
+            task_queue=worker.task_queue,
+            execution_timeout=timedelta(seconds=20),
+        )
+        assert await handle.result() == "Done."
+        events = (await handle.fetch_history()).events
+
+    payloads, _ = _activity_payloads(events, "mock-sandbox_client_create")
+    assert len(payloads) == 1
+    serialized = json.loads(payloads[0])
+    if include_options:
+        assert _SANDBOX_OPTIONS_SECRET.encode() in payloads[0]
+        assert serialized["client_options"]["api_key"] == _SANDBOX_OPTIONS_SECRET
+        assert isinstance(
+            mock_sandbox_client.create_options[0], _SecretSandboxClientOptions
+        )
+    else:
+        assert _SANDBOX_OPTIONS_SECRET.encode() not in payloads[0]
+        assert serialized["client_options"] is None
+        assert mock_sandbox_client.create_options == [None]
+
+
+class _CacheEvictingSession(_MockSandboxSession):
+    """Mock session that drops the provider's session cache after its first exec,
+    so the next operation has to take the implicit-resume path."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.evict: Callable[[], None] | None = None
+
+    async def _exec_internal(
+        self,
+        *command: str | Path,
+        timeout: float | None = None,
+    ) -> ExecResult:
+        if self.evict is not None:
+            self.evict()
+            self.evict = None
+        return await super()._exec_internal(*command, timeout=timeout)
+
+
+async def test_sandbox_default_options_survive_worker_cache_miss(client: Client):
+    """Options only reach the create activity, so an implicit resume must not need them."""
+    inner_session = _CacheEvictingSession()
+    mock_sandbox_client = _MockSandboxClient(inner_session)
+    provider = SandboxClientProvider("mock", mock_sandbox_client)
+    inner_session.evict = provider._sessions.clear
+    test_client = _client_with_plugin(client, _mock_sandbox_plugin(provider))
+
+    async with new_worker(
+        test_client,
+        SandboxDefaultOptionsWorkflow,
+        workflow_failure_exception_types=[Exception],
+    ) as worker:
+        result = await test_client.execute_workflow(
+            SandboxDefaultOptionsWorkflow.run,
+            False,
+            id=f"sandbox-cache-miss-{uuid.uuid4()}",
+            task_queue=worker.task_queue,
+            execution_timeout=timedelta(seconds=20),
+        )
+
+    assert result == "Done."
+    assert mock_sandbox_client.create_options == [None]
+    assert len(inner_session.exec_calls) == 2
+    # One resume for the second exec, one for teardown after shutdown evicts again.
+    assert mock_sandbox_client.resume_calls == 2
+
+
+class _OptionsRequiringSandboxClient(_MockSandboxClient):
+    """Mock of a backend that reads a required field off ``options``."""
+
+    # Overrides the base mock's ``True``, which is what makes the guard fire.
+    supports_default_options = False
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.create_entries: int = 0
+
+    async def create(
+        self,
+        *,
+        snapshot: Any = None,
+        manifest: Manifest | None = None,
+        options: BaseSandboxClientOptions | None = None,
+    ) -> SandboxSession:
+        self.create_entries += 1
+        _ = options.image  # type: ignore[attr-defined, union-attr]
+        return await super().create(
+            snapshot=snapshot, manifest=manifest, options=options
+        )
+
+
+@workflow.defn
+class SandboxDefaultOptionsUnsupportedWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        result = await Runner.run(
+            starting_agent=SandboxAgent[None](name="sandbox-needs-options"),
+            input="hello",
+            run_config=RunConfig(
+                sandbox=SandboxRunConfig(
+                    client=temporal_sandbox_client(
+                        "needs-options", supports_default_options=True
+                    ),
+                ),
+            ),
+        )
+        return result.final_output
+
+
+async def test_sandbox_default_options_rejected_when_client_requires_them(
+    client: Client,
+):
+    """Claiming default options for a client that requires them fails the workflow fast."""
+    mock_sandbox_client = _OptionsRequiringSandboxClient()
+    provider = SandboxClientProvider("needs-options", mock_sandbox_client)
+    test_client = _client_with_plugin(client, _mock_sandbox_plugin(provider))
+
+    async with new_worker(
+        test_client,
+        SandboxDefaultOptionsUnsupportedWorkflow,
+        workflow_failure_exception_types=[Exception],
+    ) as worker:
+        with pytest.raises(WorkflowFailureError) as exc_info:
+            await test_client.execute_workflow(
+                SandboxDefaultOptionsUnsupportedWorkflow.run,
+                id=f"sandbox-needs-options-{uuid.uuid4()}",
+                task_queue=worker.task_queue,
+                execution_timeout=timedelta(seconds=15),
+            )
+
+    causes: list[BaseException] = []
+    err: BaseException | None = exc_info.value
+    while err is not None:
+        causes.append(err)
+        err = err.__cause__
+    app_error = next(e for e in causes if isinstance(e, ApplicationError))
+    assert app_error.non_retryable is True
+    assert app_error.type == "sandbox_options_required"
+    assert "supports_default_options" in str(app_error)
+    assert "'needs-options'" in str(app_error)
+    assert mock_sandbox_client.create_entries == 0
+
+
+@workflow.defn
+class SandboxUnixLocalWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        agent = SandboxAgent[None](
+            name="sandbox-unix-local", capabilities=[_TestSandboxCapability()]
+        )
+        result = await Runner.run(
+            starting_agent=agent,
+            input="write then read a file",
+            run_config=RunConfig(
+                sandbox=SandboxRunConfig(
+                    client=temporal_sandbox_client(
+                        "unix-local", supports_default_options=True
+                    ),
+                ),
+            ),
+        )
+        return result.final_output
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="agents.sandbox.sandboxes.unix_local raises ImportError at import time on Windows.",
+)
+async def test_sandbox_default_options_unix_local(client: Client):
+    """A real backend that advertises default options creates a working session
+    from an activity argument that carries no options at all."""
+    from agents.sandbox.sandboxes.unix_local import UnixLocalSandboxClient
+
+    plugin = OpenAIAgentsPlugin(
+        model_params=ModelActivityParameters(
+            start_to_close_timeout=timedelta(seconds=30),
+        ),
+        model_provider=TestModelProvider(
+            TestModel.returning_responses(
+                [
+                    ResponseBuilders.tool_call(
+                        '{"path": "greeting.txt", "data": "from-unix-local"}',
+                        "write_file",
+                    ),
+                    ResponseBuilders.tool_call(
+                        '{"cmd": "cat greeting.txt"}', "run_command"
+                    ),
+                    ResponseBuilders.output_message("Done."),
+                ]
+            )
+        ),
+        sandbox_clients=[SandboxClientProvider("unix-local", UnixLocalSandboxClient())],
+    )
+    test_client = _client_with_plugin(client, plugin)
+
+    async with new_worker(
+        test_client,
+        SandboxUnixLocalWorkflow,
+        workflow_failure_exception_types=[Exception],
+    ) as worker:
+        handle = await test_client.start_workflow(
+            SandboxUnixLocalWorkflow.run,
+            id=f"sandbox-unix-local-{uuid.uuid4()}",
+            task_queue=worker.task_queue,
+            execution_timeout=timedelta(seconds=30),
+        )
+        assert await handle.result() == "Done."
+        events = (await handle.fetch_history()).events
+
+    create_args, _ = _activity_payloads(events, "unix-local-sandbox_client_create")
+    assert len(create_args) == 1
+    assert json.loads(create_args[0])["client_options"] is None
+
+    _, exec_results = _activity_payloads(events, "unix-local-sandbox_session_exec")
+    stdouts = [json.loads(result)["stdout"] for result in exec_results]
+    # ``ExecResult.stdout`` is ``JsonSafeBytes``, so history holds it base64-encoded.
+    assert b64encode(b"from-unix-local").decode() in stdouts
 
 
 # ── JsonSafeBytes lossless serialization tests ──


### PR DESCRIPTION
Running an OpenAI Agents sandbox from a workflow means passing client options for whichever backend you use, and for most of them those options are where the API key goes. The options are sent to the worker as an activity argument, so they land in workflow history and stay there, readable by anyone who can open the run. There is no way out of it today: the SDK rejects a workflow that omits the options, even for the backends that would happily start without them.

This adds `temporal_sandbox_client("local", supports_default_options=True)`, which says the backend supplies its own defaults and lets the workflow leave the options out, so the key never reaches history at all.

It stays off by default because only two of the nine backends can start without options. Turning it on for one of the other seven used to be close to undiagnosable: the failure was retryable and the sandbox activity carries no retry policy, so the workflow would sit there retrying forever with nothing surfaced to whoever started it. That case now fails immediately, with an error naming the backend and both ways to fix it.

Note: a documented activity name never existed, and a documented import path raises `ModuleNotFoundError`. Both sit on the path a reader takes to get here, so they are fixed too.