### PR TITLE
chore: update SDK Core

### DIFF
--- a/temporalio/bridge/Cargo.lock
+++ b/temporalio/bridge/Cargo.lock
@@ -3082,6 +3082,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,10 +3102,13 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/temporalio/bridge/src/runtime.rs
+++ b/temporalio/bridge/src/runtime.rs
@@ -121,6 +121,7 @@ pub fn init_runtime(options: RuntimeOptions) -> PyResult<RuntimeRef> {
         } else {
             Logger::Console {
                 filter: logging_conf.filter.to_string(),
+                format: None,
             }
         })
     } else {


### PR DESCRIPTION
## Summary

- Update the SDK Core submodule to `00677170` (latest `main`).
- Regenerate protobuf bindings with `poe gen-protos-docker`.
- Adapt the bridge logger initialization to Core’s required `format` field, retaining the existing default behavior.
- Update `Cargo.lock` for Core’s new dependency.

## Validation

- `poe gen-protos-docker`
- `poe bridge-lint`
- `cargo fmt --check`
- `git diff --check`

Proto regeneration completed without additional generated-file changes.