### PR TITLE
Expose failure converter to system Nexus conversion

### DIFF
--- a/temporalio/nexus/system/__init__.py
+++ b/temporalio/nexus/system/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import contextlib
 import contextvars
 from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
 from typing import Any
 
 import temporalio.api.common.v1
@@ -21,31 +22,48 @@ from temporalio.converter._payload_converter import (
 )
 
 TEMPORAL_SYSTEM_ENDPOINT = "__temporal_system"
-_user_payload_converter: contextvars.ContextVar[
-    temporalio.converter.PayloadConverter | None
-] = contextvars.ContextVar("temporal-system-nexus-user-payload-converter", default=None)
+
+
+@dataclass(frozen=True)
+class _SystemNexusUserConverters:
+    payload_converter: temporalio.converter.PayloadConverter
+    failure_converter: temporalio.converter.FailureConverter
+
+
+_user_converters: contextvars.ContextVar[_SystemNexusUserConverters | None] = (
+    contextvars.ContextVar("temporal-system-nexus-user-converters", default=None)
+)
 _SYSTEM_PAYLOAD_METADATA_KEY = "__temporal_system_payload"
 _SYSTEM_PAYLOAD_METADATA_VALUE = b"true"
 
 
 @contextlib.contextmanager
-def _user_payload_converter_context(
-    payload_converter: temporalio.converter.PayloadConverter,
+def _user_converter_context(
+    converters: _SystemNexusUserConverters,
 ) -> Iterator[None]:
-    """Set the user payload converter for system Nexus model conversion."""
-    token = _user_payload_converter.set(payload_converter)
+    """Set the user converters for system Nexus model conversion."""
+    token = _user_converters.set(converters)
     try:
         yield
     finally:
-        _user_payload_converter.reset(token)
+        _user_converters.reset(token)
+
+
+def _current_user_converters() -> _SystemNexusUserConverters:
+    converters = _user_converters.get()
+    if converters is None:
+        raise RuntimeError("System Nexus user converter context is not active")
+    return converters
 
 
 def _current_user_payload_converter() -> temporalio.converter.PayloadConverter:  # pyright: ignore[reportUnusedFunction]
     """Return the active user payload converter for system Nexus model conversion."""
-    payload_converter = _user_payload_converter.get()
-    if payload_converter is None:
-        raise RuntimeError("System Nexus user payload converter context is not active")
-    return payload_converter
+    return _current_user_converters().payload_converter
+
+
+def _current_user_failure_converter() -> temporalio.converter.FailureConverter:  # pyright: ignore[reportUnusedFunction]
+    """Return the active user failure converter for system Nexus model conversion."""
+    return _current_user_converters().failure_converter
 
 
 class _SystemNexusOuterPayloadConverter(CompositePayloadConverter):
@@ -72,14 +90,18 @@ class _SystemNexusOuterPayloadConverter(CompositePayloadConverter):
 class _SystemNexusPayloadConverter(temporalio.converter.PayloadConverter):
     """Payload converter for system Nexus outer envelopes."""
 
-    _user_payload_converter: temporalio.converter.PayloadConverter
+    _user_converters: _SystemNexusUserConverters
     _outer_payload_converter: temporalio.converter.PayloadConverter
 
     def __init__(
-        self, user_payload_converter: temporalio.converter.PayloadConverter
+        self,
+        user_payload_converter: temporalio.converter.PayloadConverter,
+        user_failure_converter: temporalio.converter.FailureConverter,
     ) -> None:
         """Create a payload converter for system Nexus outer envelopes."""
-        self._user_payload_converter = user_payload_converter
+        self._user_converters = _SystemNexusUserConverters(
+            user_payload_converter, user_failure_converter
+        )
         self._outer_payload_converter = _TemporalTransferTypePayloadConverter.wrap(
             _SystemNexusOuterPayloadConverter()
         )
@@ -88,7 +110,7 @@ class _SystemNexusPayloadConverter(temporalio.converter.PayloadConverter):
         self, values: Sequence[Any]
     ) -> list[temporalio.api.common.v1.Payload]:
         """See base class."""
-        with _user_payload_converter_context(self._user_payload_converter):
+        with _user_converter_context(self._user_converters):
             return self._outer_payload_converter.to_payloads(values)
 
     def from_payloads(
@@ -97,7 +119,7 @@ class _SystemNexusPayloadConverter(temporalio.converter.PayloadConverter):
         type_hints: list[type] | None = None,
     ) -> list[Any]:
         """See base class."""
-        with _user_payload_converter_context(self._user_payload_converter):
+        with _user_converter_context(self._user_converters):
             return self._outer_payload_converter.from_payloads(payloads, type_hints)
 
 
@@ -140,9 +162,10 @@ async def maybe_visit_payload(
 
 def _get_payload_converter(  # pyright: ignore[reportUnusedFunction]
     user_payload_converter: temporalio.converter.PayloadConverter,
+    user_failure_converter: temporalio.converter.FailureConverter,
 ) -> temporalio.converter.PayloadConverter:
     """Return the fixed payload converter for system Nexus outer envelopes."""
-    return _SystemNexusPayloadConverter(user_payload_converter)
+    return _SystemNexusPayloadConverter(user_payload_converter, user_failure_converter)
 
 
 __all__ = [

--- a/temporalio/worker/_workflow_instance.py
+++ b/temporalio/worker/_workflow_instance.py
@@ -2135,7 +2135,8 @@ class _WorkflowInstanceImpl(  # type: ignore[reportImplicitAbstractClass]
 
         payload_converter = (
             temporalio.nexus.system._get_payload_converter(
-                self._workflow_context_payload_converter
+                self._workflow_context_payload_converter,
+                self._workflow_context_failure_converter,
             )
             if temporalio.nexus.system.is_system_endpoint(input.endpoint)
             else self._context_free_payload_converter

--- a/tests/nexus/test_temporal_system_nexus.py
+++ b/tests/nexus/test_temporal_system_nexus.py
@@ -11,8 +11,10 @@ from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.message import Message
 
 import temporalio.api.common.v1
+import temporalio.api.failure.v1
 import temporalio.api.workflowservice.v1.request_response_pb2 as workflowservice_pb2
 import temporalio.converter
+import temporalio.exceptions
 import temporalio.nexus.system as nexus_system
 from temporalio import workflow
 from temporalio.bridge._visitor import PayloadVisitor
@@ -36,6 +38,77 @@ from tests.test_extstore import InMemoryTestDriver
 
 interceptor_traces: list[tuple[str, object]] = []
 SYSTEM_NEXUS_PAYLOAD_METADATA_KEY = "__temporal_system_payload"
+
+
+@dataclasses.dataclass(frozen=True)
+class _FailureTransferValue:
+    error: BaseException
+
+
+class _FailureTransferValueConverter(
+    temporalio.converter.TransferTypeConverter[
+        _FailureTransferValue, temporalio.api.failure.v1.Failure
+    ]
+):
+    transfer_type = temporalio.api.failure.v1.Failure
+
+    def to_transfer_type(
+        self, value: _FailureTransferValue
+    ) -> temporalio.api.failure.v1.Failure:
+        failure = temporalio.api.failure.v1.Failure()
+        nexus_system._current_user_failure_converter().to_failure(
+            value.error,
+            nexus_system._current_user_payload_converter(),
+            failure,
+        )
+        return failure
+
+    def from_transfer_type(
+        self,
+        value: temporalio.api.failure.v1.Failure,
+        type_hint: type[_FailureTransferValue],
+    ) -> _FailureTransferValue:
+        assert type_hint is _FailureTransferValue
+        return _FailureTransferValue(
+            nexus_system._current_user_failure_converter().from_failure(
+                value,
+                nexus_system._current_user_payload_converter(),
+            )
+        )
+
+
+temporalio.converter.transfer_type_convertible(_FailureTransferValueConverter)(
+    _FailureTransferValue
+)
+
+
+class _TrackingFailureConverter(temporalio.converter.DefaultFailureConverter):
+    def __init__(
+        self, expected_payload_converter: temporalio.converter.PayloadConverter
+    ) -> None:
+        super().__init__()
+        self.expected_payload_converter = expected_payload_converter
+        self.to_failure_calls = 0
+        self.from_failure_calls = 0
+
+    def to_failure(
+        self,
+        exception: BaseException,
+        payload_converter: temporalio.converter.PayloadConverter,
+        failure: temporalio.api.failure.v1.Failure,
+    ) -> None:
+        assert payload_converter is self.expected_payload_converter
+        self.to_failure_calls += 1
+        super().to_failure(exception, payload_converter, failure)
+
+    def from_failure(
+        self,
+        failure: temporalio.api.failure.v1.Failure,
+        payload_converter: temporalio.converter.PayloadConverter,
+    ) -> BaseException:
+        assert payload_converter is self.expected_payload_converter
+        self.from_failure_calls += 1
+        return super().from_failure(failure, payload_converter)
 
 
 @workflow.defn
@@ -182,14 +255,14 @@ def _new_schedule_nexus_completion(
 
 
 def _new_system_nexus_request_payload() -> temporalio.api.common.v1.Payload:
-    nested_payload = temporalio.converter.PayloadConverter.default.to_payload(
-        "workflow-input"
-    )
+    data_converter = temporalio.converter.default()
+    nested_payload = data_converter.payload_converter.to_payload("workflow-input")
     assert nested_payload is not None
     request = workflowservice_pb2.SignalWithStartWorkflowExecutionRequest()
     request.input.payloads.add().CopyFrom(nested_payload)
     payload = nexus_system._get_payload_converter(
-        temporalio.converter.PayloadConverter.default
+        data_converter.payload_converter,
+        data_converter.failure_converter,
     ).to_payload(request)
     assert payload is not None
     return payload
@@ -211,8 +284,10 @@ async def test_schedule_marked_system_nexus_payload_ignores_endpoint() -> None:
     await PayloadVisitor().visit(visitor, completion)
 
     schedule = completion.successful.commands[0].schedule_nexus_operation
+    data_converter = temporalio.converter.default()
     decoded = nexus_system._get_payload_converter(
-        temporalio.converter.PayloadConverter.default
+        data_converter.payload_converter,
+        data_converter.failure_converter,
     ).from_payload(schedule.input)
     assert isinstance(
         decoded, workflowservice_pb2.SignalWithStartWorkflowExecutionRequest
@@ -236,8 +311,10 @@ async def test_schedule_unmarked_system_nexus_payload_visits_input_as_regular_pa
 
     schedule = completion.successful.commands[0].schedule_nexus_operation
     assert schedule.input.metadata["visited"] == b"true"
+    data_converter = temporalio.converter.default()
     decoded = nexus_system._get_payload_converter(
-        temporalio.converter.default().payload_converter
+        data_converter.payload_converter,
+        data_converter.failure_converter,
     ).from_payload(schedule.input)
     assert isinstance(
         decoded, workflowservice_pb2.SignalWithStartWorkflowExecutionRequest
@@ -360,8 +437,10 @@ def _field_is_repeated(field: FieldDescriptor) -> bool:
     ],
 )
 def test_system_nexus_proto_roundtrip(message_type: type[Message]) -> None:
+    data_converter = temporalio.converter.default()
     payload_converter = nexus_system._get_payload_converter(
-        temporalio.converter.PayloadConverter.default
+        data_converter.payload_converter,
+        data_converter.failure_converter,
     )
     proto_value = _build_proto_sample(message_type)
     payload = payload_converter.to_payload(proto_value)
@@ -372,6 +451,65 @@ def test_system_nexus_proto_roundtrip(message_type: type[Message]) -> None:
     roundtripped = payload_converter.from_payload(payload, message_type)
     assert isinstance(roundtripped, message_type)
     assert roundtripped == proto_value
+
+
+def test_system_nexus_uses_user_failure_converter() -> None:
+    payload_converter = temporalio.converter.default().payload_converter
+    failure_converter = _TrackingFailureConverter(payload_converter)
+    system_converter = nexus_system._get_payload_converter(
+        payload_converter, failure_converter
+    )
+
+    payload = system_converter.to_payload(
+        _FailureTransferValue(RuntimeError("test failure"))
+    )
+    converted = system_converter.from_payload(payload, _FailureTransferValue)
+
+    assert isinstance(converted, _FailureTransferValue)
+    assert isinstance(converted.error, temporalio.exceptions.ApplicationError)
+    assert converted.error.message == "test failure"
+    assert converted.error.type == "RuntimeError"
+    assert failure_converter.to_failure_calls == 1
+    assert failure_converter.from_failure_calls == 1
+    with pytest.raises(RuntimeError, match="converter context is not active"):
+        nexus_system._current_user_payload_converter()
+    with pytest.raises(RuntimeError, match="converter context is not active"):
+        nexus_system._current_user_failure_converter()
+
+
+def test_system_nexus_payload_converter_restores_user_context_on_failure() -> None:
+    outer_data_converter = temporalio.converter.default()
+    outer_converters = nexus_system._SystemNexusUserConverters(
+        outer_data_converter.payload_converter,
+        outer_data_converter.failure_converter,
+    )
+    inner_data_converter = temporalio.converter.DataConverter()
+
+    class RaisingFailureConverter(temporalio.converter.DefaultFailureConverter):
+        def to_failure(
+            self,
+            exception: BaseException,
+            payload_converter: temporalio.converter.PayloadConverter,
+            failure: temporalio.api.failure.v1.Failure,
+        ) -> None:
+            assert payload_converter is inner_data_converter.payload_converter
+            raise ValueError("conversion failed")
+
+    inner_system_converter = nexus_system._get_payload_converter(
+        inner_data_converter.payload_converter,
+        RaisingFailureConverter(),
+    )
+
+    with nexus_system._user_converter_context(outer_converters):
+        assert nexus_system._current_user_converters() is outer_converters
+        with pytest.raises(ValueError, match="conversion failed"):
+            inner_system_converter.to_payload(
+                _FailureTransferValue(RuntimeError("test failure"))
+            )
+        assert nexus_system._current_user_converters() is outer_converters
+
+    with pytest.raises(RuntimeError, match="converter context is not active"):
+        nexus_system._current_user_converters()
 
 
 # Cloud namespaces created by CI do not have the System Nexus dynamic config.

--- a/tests/worker/test_visitor.py
+++ b/tests/worker/test_visitor.py
@@ -233,8 +233,10 @@ async def test_system_nexus_envelope_is_detected_in_generic_payload_field():
     system_request = workflowservice_pb2.SignalWithStartWorkflowExecutionRequest(
         input=Payloads(payloads=[Payload(data=b"workflow-input")]),
     )
+    data_converter = temporalio.converter.default()
     payload_converter = nexus_system._get_payload_converter(
-        temporalio.converter.default().payload_converter
+        data_converter.payload_converter,
+        data_converter.failure_converter,
     )
     system_payload = payload_converter.to_payload(system_request)
     assert system_payload is not None
@@ -409,8 +411,9 @@ async def test_system_nexus_envelope_visit_is_bounded():
             finally:
                 active_visits -= 1
 
+    data_converter = temporalio.converter.default()
     payload_converter = nexus_system._get_payload_converter(
-        temporalio.converter.PayloadConverter.default
+        data_converter.payload_converter, data_converter.failure_converter
     )
     system_request = workflowservice_pb2.SignalWithStartWorkflowExecutionRequest(
         input=Payloads(payloads=[Payload(data=b"workflow-input")]),


### PR DESCRIPTION


## What was changed
<!-- Describe what has changed in this PR -->
System Nexus payload conversion now exposes the configured user failure converter alongside the payload converter.

The converters are stored together in a context-local holder and exposed through separate internal accessors. System Nexus workflow calls now provide both context-bound converters.


## Why?
<!-- Tell your future self why have you made these changes -->

Generated System Nexus models can contain Temporal failures as well as payloads. Those failures should use the user's configured failure converter instead of the default converter.

Keeping the payload and failure converters together ensures they come from the same converter configuration. It also preserves the existing workflow architecture, where codecs and external storage are applied outside the workflow sandbox.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

- Tests cover custom failure conversion, use of the matching payload converter for failure details, and context restoration when conversion raises.
