### PR TITLE
Set request ID for SAA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ to include examples, links to docs, or any other relevant information.
 
 ### Fixed
 
+- Standalone activity start requests now include a unique request ID so RPC retries are deduplicated.
 - The `google-adk` extra now depends on `mcp`, so fresh installs of
   `temporalio[google-adk]` can import `temporalio.contrib.google_adk_agents`
   without separately installing `mcp`. Previously the import failed with an

--- a/temporalio/client/_impl.py
+++ b/temporalio/client/_impl.py
@@ -627,6 +627,7 @@ class _ClientImpl(OutboundInterceptor):  # pyright: ignore[reportUnusedClass]
         req = temporalio.api.workflowservice.v1.StartActivityExecutionRequest(
             namespace=self._client.namespace,
             identity=self._client.identity,
+            request_id=str(uuid.uuid4()),
             activity_id=input.id,
             activity_type=temporalio.api.common.v1.ActivityType(
                 name=input.activity_type
@@ -677,8 +678,8 @@ class _ClientImpl(OutboundInterceptor):  # pyright: ignore[reportUnusedClass]
         # Set priority
         req.priority.CopyFrom(input.priority._to_proto())
 
-        # Add request_id, links, and completion callbacks from the Nexus context
-        # if not in a Nexus context, this is a no-op
+        # Nexus starts use the inbound request ID so retries across the Nexus
+        # boundary resolve to the same activity execution.
         temporalio.nexus._operation_context._apply_nexus_context_to_start_activity_request(
             req
         )

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -2,9 +2,11 @@ import asyncio
 import uuid
 from dataclasses import dataclass
 from datetime import timedelta
+from unittest import mock
 
 import pytest
 
+import temporalio.api.workflowservice.v1
 from temporalio import activity, workflow
 from temporalio.client import (
     ActivityExecutionCount,
@@ -76,6 +78,31 @@ class ActivityHolder:
     @activity.defn
     def sync_increment(self, x: int) -> int:
         return x + 1
+
+
+async def test_start_activity_generates_request_id() -> None:
+    start_activity_execution = mock.AsyncMock(
+        return_value=temporalio.api.workflowservice.v1.StartActivityExecutionResponse(
+            run_id="activity-run-id"
+        )
+    )
+    service_client = mock.MagicMock()
+    service_client.config.identity = "test-identity"
+    service_client.workflow_service.start_activity_execution = start_activity_execution
+    client = Client(service_client)
+
+    for activity_id in ("activity-id-1", "activity-id-2"):
+        await client.start_activity(
+            increment,
+            1,
+            id=activity_id,
+            task_queue="task-queue",
+            start_to_close_timeout=timedelta(seconds=1),
+        )
+
+    requests = [call.args[0] for call in start_activity_execution.call_args_list]
+    assert all(uuid.UUID(request.request_id).version == 4 for request in requests)
+    assert requests[0].request_id != requests[1].request_id
 
 
 class TestDescribe:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Set request ID for SAA.

## Why?
Set request ID for SAA so retried requests are not duplicate.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client RPC field change with Nexus override preserved; low blast radius and covered by a focused unit test.
> 
> **Overview**
> **Standalone activity starts** (`Client.start_activity`) now populate `StartActivityExecutionRequest.request_id` with a fresh UUIDv4 on each call, aligning with other client start RPCs and letting the server deduplicate retried `StartActivityExecution` calls instead of creating duplicate executions.
> 
> Nexus-backed activity starts still override that field via `_apply_nexus_context_to_start_activity_request` so retries across the Nexus boundary keep the inbound request ID. A unit test asserts each standalone start gets a valid, distinct `request_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28637d05ec28bf494ea642aeda17294570ff6d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->