### PR TITLE
test: support standalone activity cancellation status change

### DIFF
--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -738,8 +738,14 @@ async def test_manual_cancellation(client: Client, env: WorkflowEnvironment):
         # report_cancellation fails if activity is not in CANCELLATION_REQUESTED state
         with pytest.raises(RPCError) as err:
             await async_activity_handle.report_cancellation("Test cancellation")
-        assert err.value.status == RPCStatusCode.FAILED_PRECONDITION
-        assert "invalid transition from Started" in str(err.value)
+        assert err.value.status in {
+            RPCStatusCode.FAILED_PRECONDITION,
+            RPCStatusCode.INVALID_ARGUMENT,
+        }
+        assert (
+            "invalid transition from Started" in str(err.value)
+            or "unable to mark activity as canceled" in str(err.value)
+        )
 
         # Request cancellation to transition activity to CANCELLATION_REQUESTED state
         await activity_handle.cancel()

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -742,10 +742,9 @@ async def test_manual_cancellation(client: Client, env: WorkflowEnvironment):
             RPCStatusCode.FAILED_PRECONDITION,
             RPCStatusCode.INVALID_ARGUMENT,
         }
-        assert (
-            "invalid transition from Started" in str(err.value)
-            or "unable to mark activity as canceled" in str(err.value)
-        )
+        assert "invalid transition from Started" in str(
+            err.value
+        ) or "unable to mark activity as canceled" in str(err.value)
 
         # Request cancellation to transition activity to CANCELLATION_REQUESTED state
         await activity_handle.cancel()


### PR DESCRIPTION
## Summary

- Accept both legacy `FAILED_PRECONDITION` and current `INVALID_ARGUMENT` responses when a standalone activity cancellation is reported before cancellation is requested.
- Retain assertions that the request is rejected and reports the matching server error.

## Why

Temporal Cloud now returns the stable `INVALID_ARGUMENT` response for this standalone activity validation, while older server versions return `FAILED_PRECONDITION`.

## Validation

- `poe test -s tests/test_activity.py -k manual_cancellation`