### PR TITLE
Fix the sandbox examples in the OpenAI Agents README

### DIFF
--- a/temporalio/contrib/openai_agents/README.md
+++ b/temporalio/contrib/openai_agents/README.md
@@ -627,7 +627,7 @@ The name passed to `temporal_sandbox_client()` must exactly match the name used 
 
 ### Multiple Backends
 
-A single workflow can target different backends by name. Register all backends on the worker and reference each by name in the workflow. Each backend's options class ships with that backend: `DaytonaSandboxClientOptions` in `agents.extensions.sandbox.daytona`, `UnixLocalSandboxClientOptions` in `agents.sandbox.sandboxes.unix_local`.
+A single workflow can target different backends by name. Register all backends on the worker and reference each by name in the workflow:
 
 ```python
 # Run a task on the "daytona" backend

--- a/temporalio/contrib/openai_agents/README.md
+++ b/temporalio/contrib/openai_agents/README.md
@@ -556,12 +556,12 @@ Register one or more `SandboxClientProvider` instances with the plugin. Each pro
 
 ```python
 import asyncio
-import docker
+from datetime import timedelta
 from temporalio.client import Client
 from temporalio.worker import Worker
 from temporalio.contrib.openai_agents import OpenAIAgentsPlugin, SandboxClientProvider, ModelActivityParameters
 from agents.extensions.sandbox.daytona import DaytonaSandboxClient
-from agents.extensions.sandbox.unix_local import UnixLocalSandboxClient
+from agents.sandbox.sandboxes.unix_local import UnixLocalSandboxClient
 
 async def main():
     client = await Client.connect(
@@ -599,6 +599,7 @@ from temporalio.contrib.openai_agents.workflow import temporal_sandbox_client
 from agents import Runner
 from agents.sandbox import SandboxAgent, SandboxRunConfig
 from agents.run import RunConfig
+from agents.extensions.sandbox.daytona import DaytonaSandboxClientOptions
 
 @workflow.defn
 class MyWorkflow:
@@ -626,7 +627,7 @@ The name passed to `temporal_sandbox_client()` must exactly match the name used 
 
 ### Multiple Backends
 
-A single workflow can target different backends by name. Register all backends on the worker and reference each by name in the workflow:
+A single workflow can target different backends by name. Register all backends on the worker and reference each by name in the workflow. Each backend's options class ships with that backend: `DaytonaSandboxClientOptions` in `agents.extensions.sandbox.daytona`, `UnixLocalSandboxClientOptions` in `agents.sandbox.sandboxes.unix_local`.
 
 ```python
 # Run a task on the "daytona" backend


### PR DESCRIPTION
## What was changed

The sandbox section of `temporalio/contrib/openai_agents/README.md` imports the local sandbox client from `agents.extensions.sandbox.unix_local`, which does not exist. `agents.extensions.sandbox.*` holds only the remote backends (daytona, e2b, modal, blaxel, cloudflare, runloop, vercel); `UnixLocalSandboxClient` lives in `agents.sandbox.sandboxes.unix_local`.

Two other copy-paste breaks in the same examples:

- The worker example imports `docker`, which it never uses, and omits the `timedelta` its `ModelActivityParameters` needs.
- The workflow example constructs `DaytonaSandboxClientOptions` without importing it.

The Multiple Backends section now also names the module for each options class, since the two live in different packages.

## Why?

The worker example raises `ModuleNotFoundError` as written, so anyone following the sandbox docs has to go find the real import path themselves.

## Checklist

1. Closes <!-- no issue -->

2. How was this tested:

Ran every import line the corrected examples show against `openai-agents` 0.20.0, plus the constructor calls they make — `SandboxClientProvider("local", UnixLocalSandboxClient())`, `DaytonaSandboxClientOptions(pause_on_exit=False)`, and `UnixLocalSandboxClientOptions()`. All resolve. Confirmed `agents.extensions.sandbox.unix_local` does not import, while `agents.extensions.sandbox.daytona` (left unchanged) does.

Docs-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)