### PR TITLE
Move Nexus workflow update and signal logic into the Nexus package.

### DIFF
--- a/temporalio/client/_impl.py
+++ b/temporalio/client/_impl.py
@@ -244,15 +244,9 @@ class _ClientImpl(OutboundInterceptor):  # pyright: ignore[reportUnusedClass]
                 await data_converter.encode(input.start_signal_args)
             )
         await self._populate_start_workflow_execution_request(req, input)
-        # If this signal-with-start is issued from inside a Nexus operation handler (but not the
-        # nexus-backing workflow), forward the inbound Nexus task links so both the callee's
-        # WorkflowExecutionStarted and WorkflowExecutionSignaled events link back to the caller.
-        if not temporalio.nexus._operation_context._in_nexus_backing_start_context():
-            nexus_ctx = (
-                temporalio.nexus._operation_context._try_start_operation_context()
-            )
-            if nexus_ctx is not None:
-                req.links.extend(nexus_ctx._get_request_links())
+        temporalio.nexus._operation_context._apply_nexus_context_to_signal_with_start_workflow_request(
+            req
+        )
         return req
 
     async def _build_update_with_start_start_workflow_execution_request(
@@ -486,18 +480,15 @@ class _ClientImpl(OutboundInterceptor):  # pyright: ignore[reportUnusedClass]
             req.input.payloads.extend(await data_converter.encode(input.args))
         if input.headers is not None:  # type:ignore[reportUnnecessaryComparison]
             await self._apply_headers(input.headers, req.header.fields)
-        # If this signal is issued from inside a Nexus operation handler, forward the inbound
-        # Nexus task links so the WorkflowExecutionSignaled event links back to the caller.
-        nexus_ctx = temporalio.nexus._operation_context._try_start_operation_context()
-        if nexus_ctx is not None:
-            req.links.extend(nexus_ctx._get_request_links())
+        temporalio.nexus._operation_context._apply_nexus_context_to_signal_workflow_request(
+            req
+        )
         resp = await self._client.workflow_service.signal_workflow_execution(
             req, retry=True, metadata=input.rpc_metadata, timeout=input.rpc_timeout
         )
-        # Server >= 1.31 with EnableCHASMSignalBacklinks returns a response link pointing at the
-        # signal event; older servers leave it unset. Propagate when present.
-        if nexus_ctx is not None and resp.HasField("link"):
-            nexus_ctx._add_response_link(resp.link)
+        temporalio.nexus._operation_context._apply_signal_workflow_response_to_nexus_context(
+            resp
+        )
 
     async def terminate_workflow(self, input: TerminateWorkflowInput) -> None:
         data_converter = self._client.data_converter._with_contexts(

--- a/temporalio/client/_impl.py
+++ b/temporalio/client/_impl.py
@@ -772,10 +772,9 @@ class _ClientImpl(OutboundInterceptor):  # pyright: ignore[reportUnusedClass]
             ):
                 break
 
-        # Add response link if its a Nexus operation
-        nexus_ctx = temporalio.nexus._operation_context._try_start_operation_context()
-        if nexus_ctx is not None and resp.HasField("link"):
-            nexus_ctx._add_response_link(resp.link)
+        temporalio.nexus._operation_context._apply_start_workflow_update_response_to_nexus_context(
+            resp
+        )
 
         # Build the handle. If the user's wait stage is COMPLETED, make sure we
         # poll for result.
@@ -842,23 +841,10 @@ class _ClientImpl(OutboundInterceptor):  # pyright: ignore[reportUnusedClass]
                 )
             ),
         )
-        # Only set Nexus fields for StartWorkflowUpdateInput, skip for UpdateWithStartUpdateWorkflowInput
         if isinstance(input, StartWorkflowUpdateInput):
-            if input.request_id:
-                req.request.request_id = input.request_id
-            if input.links:
-                req.request.links.extend(input.links)
-            if input.callbacks:
-                req.request.completion_callbacks.extend(
-                    temporalio.api.common.v1.Callback(
-                        nexus=temporalio.api.common.v1.Callback.Nexus(
-                            url=callback.url,
-                            header=callback.headers,
-                        ),
-                        links=input.links or [],
-                    )
-                    for callback in input.callbacks
-                )
+            temporalio.nexus._operation_context._apply_nexus_context_to_start_workflow_update_request(
+                req
+            )
         if input.args:
             req.request.input.args.payloads.extend(
                 await data_converter.encode(input.args)

--- a/temporalio/client/_interceptor.py
+++ b/temporalio/client/_interceptor.py
@@ -22,8 +22,6 @@ from temporalio.converter import (
     DataConverter,
 )
 
-from ._callback import Callback
-
 if TYPE_CHECKING:
     from ._activity import (
         ActivityExecutionAsyncIterator,
@@ -318,10 +316,6 @@ class StartWorkflowUpdateInput:
     ret_type: type | None
     rpc_metadata: Mapping[str, str | bytes]
     rpc_timeout: timedelta | None
-    # The following options are for Workflow Updates exposed as Nexus Operations. Experimental and unstable
-    callbacks: Sequence[Callback] | None = None
-    links: Sequence[temporalio.api.common.v1.Link] | None = None
-    request_id: str | None = None
 
 
 @dataclass

--- a/temporalio/client/_workflow.py
+++ b/temporalio/client/_workflow.py
@@ -59,7 +59,6 @@ from ..types import (
     ReturnType,
     SelfType,
 )
-from ._callback import Callback
 from ._exceptions import (
     WorkflowContinuedAsNewError,
     WorkflowFailureError,
@@ -956,10 +955,6 @@ class WorkflowHandle(Generic[SelfType, ReturnType]):
         result_type: type | None = None,
         rpc_metadata: Mapping[str, str | bytes] = {},
         rpc_timeout: timedelta | None = None,
-        # The following options are for Workflow Updates exposed as Nexus Operations. Experimental and unstable
-        callbacks: Sequence[Callback] | None = None,
-        links: Sequence[temporalio.api.common.v1.Link] | None = None,
-        request_id: str | None = None,
     ) -> WorkflowUpdateHandle[Any]:
         if wait_for_stage == WorkflowUpdateStage.ADMITTED:
             raise ValueError("ADMITTED wait stage not supported")
@@ -981,9 +976,6 @@ class WorkflowHandle(Generic[SelfType, ReturnType]):
                 rpc_metadata=rpc_metadata,
                 rpc_timeout=rpc_timeout,
                 wait_for_stage=wait_for_stage,
-                callbacks=callbacks,
-                links=links,
-                request_id=request_id,
             )
         )
 

--- a/temporalio/nexus/_operation_context.py
+++ b/temporalio/nexus/_operation_context.py
@@ -777,6 +777,33 @@ def _apply_start_workflow_update_response_to_nexus_context(  # pyright: ignore[r
         nexus_ctx._add_response_link(resp.link)
 
 
+def _apply_nexus_context_to_signal_workflow_request(  # pyright: ignore[reportUnusedFunction]
+    req: temporalio.api.workflowservice.v1.SignalWorkflowExecutionRequest,
+) -> None:
+    """Apply the current Nexus operation context to a workflow signal request."""
+    nexus_ctx = _try_start_operation_context()
+    if nexus_ctx is not None:
+        req.links.extend(nexus_ctx._get_request_links())
+
+
+def _apply_signal_workflow_response_to_nexus_context(  # pyright: ignore[reportUnusedFunction]
+    resp: temporalio.api.workflowservice.v1.SignalWorkflowExecutionResponse,
+) -> None:
+    """Apply a workflow signal response link to the current Nexus context."""
+    nexus_ctx = _try_start_operation_context()
+    if nexus_ctx is not None and resp.HasField("link"):
+        nexus_ctx._add_response_link(resp.link)
+
+
+def _apply_nexus_context_to_signal_with_start_workflow_request(  # pyright: ignore[reportUnusedFunction]
+    req: temporalio.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest,
+) -> None:
+    """Apply the current Nexus operation context to a signal-with-start request."""
+    nexus_ctx = _try_start_operation_context()
+    if nexus_ctx is not None and not _in_nexus_backing_start_context():
+        req.links.extend(nexus_ctx._get_request_links())
+
+
 def _apply_nexus_context_to_start_workflow_request(  # pyright: ignore[reportUnusedFunction]
     req: temporalio.api.workflowservice.v1.StartWorkflowExecutionRequest,
 ) -> None:

--- a/temporalio/nexus/_operation_context.py
+++ b/temporalio/nexus/_operation_context.py
@@ -720,32 +720,61 @@ async def _start_nexus_operation_workflow_update(  # pyright: ignore[reportUnuse
 ) -> temporalio.client.WorkflowUpdateHandle[Any]:
     # Default update ID to the Nexus request ID for retry-safety (matches sdk-go).
     update_id = update_id or temporal_context.nexus_context.request_id
-    # This token is different from the actual token returned to the caller
-    # because return token will have the run_id that is unknowable before
-    # making the call. If run_id is passed, then it will be the same
-    token = OperationToken(
-        type=OperationTokenType.UPDATE_WORKFLOW,
-        namespace=temporal_context.client.namespace,
-        workflow_id=workflow_id,
-        update_id=update_id,
-        run_id=run_id,
-    ).encode()
     workflow_handle = temporal_context.client.get_workflow_handle(
         workflow_id, run_id=run_id, first_execution_run_id=first_execution_run_id
     )
-    return await workflow_handle._start_update(
-        update,
-        arg,
-        args=args,
-        wait_for_stage=temporalio.client.WorkflowUpdateStage.ACCEPTED,  # hardcoded as nexus only supports async updates
-        id=update_id,
-        result_type=result_type,
-        rpc_metadata=rpc_metadata,
-        rpc_timeout=rpc_timeout,
-        callbacks=temporal_context._get_callbacks(token),
-        links=temporal_context._get_request_links(),
-        request_id=temporal_context.nexus_context.request_id,
-    )
+    with _nexus_backing_start_context():
+        return await workflow_handle._start_update(
+            update,
+            arg,
+            args=args,
+            wait_for_stage=temporalio.client.WorkflowUpdateStage.ACCEPTED,  # hardcoded as nexus only supports async updates
+            id=update_id,
+            result_type=result_type,
+            rpc_metadata=rpc_metadata,
+            rpc_timeout=rpc_timeout,
+        )
+
+
+def _apply_nexus_context_to_start_workflow_update_request(  # pyright: ignore[reportUnusedFunction]
+    req: temporalio.api.workflowservice.v1.UpdateWorkflowExecutionRequest,
+) -> None:
+    """Apply the current Nexus operation context to a Workflow Update request.
+
+    This is a no-op unless the update is backing the current Nexus operation.
+    """
+    nexus_ctx = _try_start_operation_context()
+    if nexus_ctx is not None and _in_nexus_backing_start_context():
+        request_links = nexus_ctx._get_request_links()
+        req.request.request_id = nexus_ctx.nexus_context.request_id
+        req.request.links.extend(request_links)
+        callbacks = nexus_ctx._get_callbacks(
+            OperationToken(
+                type=OperationTokenType.UPDATE_WORKFLOW,
+                namespace=nexus_ctx.client.namespace,
+                workflow_id=req.workflow_execution.workflow_id,
+                update_id=req.request.meta.update_id,
+                run_id=req.workflow_execution.run_id or None,
+            ).encode()
+        )
+        req.request.completion_callbacks.extend(
+            temporalio.api.common.v1.Callback(
+                nexus=temporalio.api.common.v1.Callback.Nexus(
+                    url=callback.url,
+                    header=callback.headers,
+                ),
+                links=request_links,
+            )
+            for callback in callbacks
+        )
+
+
+def _apply_start_workflow_update_response_to_nexus_context(  # pyright: ignore[reportUnusedFunction]
+    resp: temporalio.api.workflowservice.v1.UpdateWorkflowExecutionResponse,
+) -> None:
+    nexus_ctx = _try_start_operation_context()
+    if nexus_ctx is not None and resp.HasField("link"):
+        nexus_ctx._add_response_link(resp.link)
 
 
 def _apply_nexus_context_to_start_workflow_request(  # pyright: ignore[reportUnusedFunction]

--- a/tests/nexus/test_link_propagation.py
+++ b/tests/nexus/test_link_propagation.py
@@ -1,8 +1,9 @@
 """Unit tests for Nexus link propagation.
 
-These exercise link propagation when a Nexus operation handler signals or starts a
-workflow or activity against a mocked workflow service. End-to-end signal backlinks
-require a server with EnableCHASMSignalBacklinks enabled and are not covered here.
+These exercise link propagation when a Nexus operation handler signals a workflow or
+starts a workflow, workflow update, or activity against a mocked workflow service.
+End-to-end signal backlinks require a server with EnableCHASMSignalBacklinks enabled
+and are not covered here.
 """
 
 from __future__ import annotations
@@ -27,7 +28,9 @@ from nexusrpc.handler._decorators import operation_handler
 import temporalio.api.common.v1
 import temporalio.api.enums.v1
 import temporalio.api.nexus.v1
+import temporalio.api.update.v1
 import temporalio.api.workflowservice.v1
+import temporalio.client
 import temporalio.common
 import temporalio.converter
 import temporalio.nexus._link_conversion
@@ -38,6 +41,8 @@ from temporalio.client._interceptor import (
     SignalWorkflowInput,
     StartActivityInput,
     StartWorkflowInput,
+    StartWorkflowUpdateInput,
+    UpdateWithStartUpdateWorkflowInput,
 )
 from temporalio.nexus._operation_context import _TemporalStartOperationContext
 from temporalio.worker._nexus import _NexusTaskCancellation, _NexusWorker
@@ -88,7 +93,7 @@ def nexus_ctx() -> Generator[_TemporalStartOperationContext]:
         request_id="req-id",
         callback_url="https://callback.example",
         inbound_links=[inbound],
-        callback_headers={},
+        callback_headers={"callback-header": "value"},
         task_cancellation=_NexusTaskCancellation(),
     )
     ctx = temporalio.nexus._operation_context._TemporalStartOperationContext(
@@ -183,6 +188,33 @@ def _start_activity_input() -> StartActivityInput:
         headers={},
         rpc_metadata={},
         rpc_timeout=None,
+    )
+
+
+def _start_workflow_update_input() -> StartWorkflowUpdateInput:
+    return StartWorkflowUpdateInput(
+        id=WORKFLOW_ID,
+        run_id="target-run",
+        first_execution_run_id=None,
+        update_id="update-id",
+        update="test-update",
+        args=[],
+        wait_for_stage=temporalio.client.WorkflowUpdateStage.ACCEPTED,
+        headers={},
+        ret_type=None,
+        rpc_metadata={},
+        rpc_timeout=None,
+    )
+
+
+def _update_with_start_update_input() -> UpdateWithStartUpdateWorkflowInput:
+    return UpdateWithStartUpdateWorkflowInput(
+        update_id="update-id",
+        update="test-update",
+        args=[],
+        wait_for_stage=temporalio.client.WorkflowUpdateStage.ACCEPTED,
+        headers={},
+        ret_type=None,
     )
 
 
@@ -486,7 +518,105 @@ async def test_start_outside_nexus_context_leaves_on_conflict_options_unset() ->
     assert not sent.HasField("on_conflict_options")
 
 
-# ── activity start ──────────────────────────────────────────────────────────────────────────
+# ── workflow update ──────────────────────────────────────────────────────────────
+
+
+def _workflow_update_response(
+    link: temporalio.api.common.v1.Link | None = None,
+) -> temporalio.api.workflowservice.v1.UpdateWorkflowExecutionResponse:
+    response = temporalio.api.workflowservice.v1.UpdateWorkflowExecutionResponse(
+        update_ref=temporalio.api.update.v1.UpdateRef(
+            workflow_execution=temporalio.api.common.v1.WorkflowExecution(
+                workflow_id=WORKFLOW_ID,
+                run_id="target-run",
+            ),
+            update_id="update-id",
+        ),
+        stage=temporalio.api.enums.v1.UpdateWorkflowExecutionLifecycleStage.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+    )
+    if link is not None:
+        response.link.CopyFrom(link)
+    return response
+
+
+async def test_backing_workflow_update_gets_nexus_request_fields_and_backlink(
+    nexus_ctx: _TemporalStartOperationContext,
+) -> None:
+    response_link = _workflow_event_link(
+        WORKFLOW_ID,
+        "target-run",
+        temporalio.api.enums.v1.EventType.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED,
+    )
+    workflow_service = mock.MagicMock()
+    workflow_service.update_workflow_execution = mock.AsyncMock(
+        return_value=_workflow_update_response(response_link)
+    )
+    impl = _make_client_impl(workflow_service)
+
+    with temporalio.nexus._operation_context._nexus_backing_start_context():
+        handle = await impl.start_workflow_update(_start_workflow_update_input())
+
+    assert handle.id == "update-id"
+    assert handle.workflow_id == WORKFLOW_ID
+    assert handle.workflow_run_id == "target-run"
+
+    sent = workflow_service.update_workflow_execution.call_args.args[0]
+    assert sent.request.request_id == "req-id"
+    assert list(sent.request.links) == [_inbound_nexus_link()]
+    assert len(sent.request.completion_callbacks) == 1
+    callback = sent.request.completion_callbacks[0]
+    assert callback.nexus.url == "https://callback.example"
+    assert callback.nexus.header["callback-header"] == "value"
+    operation_token = temporalio.nexus._token.OperationToken.decode(
+        callback.nexus.header["nexus-operation-token"]
+    )
+    assert (
+        operation_token.type
+        is temporalio.nexus._token.OperationTokenType.UPDATE_WORKFLOW
+    )
+    assert operation_token.namespace == NAMESPACE
+    assert operation_token.workflow_id == WORKFLOW_ID
+    assert operation_token.update_id == "update-id"
+    assert operation_token.run_id == "target-run"
+    assert list(callback.links) == [_inbound_nexus_link()]
+
+    assert len(nexus_ctx.nexus_context.outbound_links) == 1
+    assert WORKFLOW_ID in _outbound_link_urls(nexus_ctx)[0]
+
+
+async def test_non_backing_workflow_update_does_not_get_nexus_request_fields(
+    nexus_ctx: _TemporalStartOperationContext,
+) -> None:
+    workflow_service = mock.MagicMock()
+    workflow_service.update_workflow_execution = mock.AsyncMock(
+        return_value=_workflow_update_response()
+    )
+    impl = _make_client_impl(workflow_service)
+
+    await impl.start_workflow_update(_start_workflow_update_input())
+
+    sent = workflow_service.update_workflow_execution.call_args.args[0]
+    assert not sent.request.request_id
+    assert len(sent.request.links) == 0
+    assert len(sent.request.completion_callbacks) == 0
+    assert nexus_ctx.nexus_context.outbound_links == []
+
+
+@pytest.mark.usefixtures("nexus_ctx")
+async def test_update_with_start_does_not_get_nexus_request_fields() -> None:
+    impl = _make_client_impl(mock.MagicMock())
+
+    with temporalio.nexus._operation_context._nexus_backing_start_context():
+        req = await impl._build_update_workflow_execution_request(
+            _update_with_start_update_input(), WORKFLOW_ID
+        )
+
+    assert not req.request.request_id
+    assert len(req.request.links) == 0
+    assert len(req.request.completion_callbacks) == 0
+
+
+# ── activity start ─────────────────────────────────────────────────────────────────────────
 
 
 @pytest.mark.usefixtures("nexus_ctx")


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Moved Nexus-specific workflow update, signal, and signal-with-start logic into the Nexus operation context.

- Apply Nexus request IDs, completion callbacks, and links for workflow updates from the active Nexus context.
- Capture workflow update and signal response links through the Nexus package.
- Forward inbound Nexus links for signal and signal-with-start requests through the Nexus package.
- Remove Nexus-specific private arguments from `WorkflowHandle._start_update` and `StartWorkflowUpdateInput`.

## Why?
<!-- Tell your future self why have you made these changes -->

This keeps Nexus concerns out of the general client API and interceptor inputs while preserving link propagation, callback behavior, and request deduplication. It extends the pattern established for workflow starts in #1765 and matches the newer standalone activity implementation.

## Checklist
<!--- add/delete as needed --->

1. Second half of #1716

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

- `poe test -s tests/nexus/test_link_propagation.py`
- `poe test -s tests/nexus/test_signal_link_propagation_e2e.py`
- `poe lint`
