### PR TITLE
Decode system Nexus worker payloads

### DIFF
--- a/temporalio/worker/_nexus.py
+++ b/temporalio/worker/_nexus.py
@@ -31,6 +31,7 @@ import temporalio.client
 import temporalio.common
 import temporalio.converter
 import temporalio.nexus
+import temporalio.nexus.system
 from temporalio.bridge._visitor import PayloadVisitor
 from temporalio.bridge._visitor_functions import PayloadSequence, VisitorFunctions
 from temporalio.bridge.worker import PollShutdownError
@@ -428,7 +429,7 @@ class _NexusWorker:  # type:ignore[reportUnusedClass]
             _worker_shutdown_event=self._worker_shutdown_event,
         ).set()
         input = LazyValue(
-            serializer=_DummyPayloadSerializer(
+            serializer=_NexusPayloadSerializer(
                 data_converter=self._data_converter,
                 payload=start_request.payload,
             ),
@@ -527,7 +528,7 @@ def _is_payload_validation_error(err: BaseException) -> TypeGuard[ApplicationErr
 
 
 @dataclass
-class _DummyPayloadSerializer:
+class _NexusPayloadSerializer:
     data_converter: temporalio.converter.DataConverter
     payload: temporalio.api.common.v1.Payload
 
@@ -577,7 +578,13 @@ class _DummyPayloadSerializer:
             ) from err
 
         try:
-            [input] = dc.payload_converter.from_payloads(
+            payload_converter = dc.payload_converter
+            if temporalio.nexus.system._is_system_payload(payload):
+                payload_converter = temporalio.nexus.system._get_payload_converter(
+                    dc.payload_converter,
+                    dc.failure_converter,
+                )
+            [input] = payload_converter.from_payloads(
                 [payload],
                 type_hints=[as_type] if as_type else None,
             )

--- a/tests/nexus/test_temporal_system_nexus.py
+++ b/tests/nexus/test_temporal_system_nexus.py
@@ -337,7 +337,7 @@ def _new_unmarked_system_nexus_request_payload() -> temporalio.api.common.v1.Pay
     return payload
 
 
-async def test_nexus_payload_serializer_decodes_marked_system_input() -> None:
+async def test_nexus_payload_serializer_decodes_system_input() -> None:
     """A marked system request is decoded into its generated Nexus model."""
     data_converter = temporalio.converter.default()
     request = workflow_service_models.SignalWithStartWorkflowRequest(
@@ -367,9 +367,7 @@ async def test_nexus_payload_serializer_decodes_marked_system_input() -> None:
     assert decoded == request
 
 
-async def test_nexus_payload_serializer_decodes_nested_payloads_before_model_conversion() -> (
-    None
-):
+async def test_nexus_payload_serializer_codec_skips_outer_envelope() -> None:
     """The codec decodes nested user payloads but not the outer system envelope."""
     codec = RejectOuterSystemNexusCodec()
     data_converter = dataclasses.replace(
@@ -403,9 +401,7 @@ async def test_nexus_payload_serializer_decodes_nested_payloads_before_model_con
     assert decoded == request
 
 
-async def test_nexus_payload_serializer_uses_user_converter_for_unmarked_input() -> (
-    None
-):
+async def test_nexus_payload_serializer_uses_user_converter() -> None:
     """An unmarked Nexus input continues to use the configured user converter."""
     data_converter = temporalio.converter.default()
     payload = data_converter.payload_converter.to_payload("ordinary-input")

--- a/tests/nexus/test_temporal_system_nexus.py
+++ b/tests/nexus/test_temporal_system_nexus.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from datetime import timedelta
 from typing import Any, cast
 
+import nexusrpc
 import pytest
 from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.message import Message
@@ -41,6 +42,7 @@ from temporalio.worker import (
     WorkflowInterceptorClassInput,
     WorkflowOutboundInterceptor,
 )
+from temporalio.worker._nexus import _NexusPayloadSerializer
 from temporalio.worker._workflow_instance import UnsandboxedWorkflowRunner
 from tests.test_extstore import InMemoryTestDriver
 
@@ -166,6 +168,7 @@ def test_signal_with_start_serialization_context() -> None:
 class RejectOuterSystemNexusCodec(PayloadCodec):
     def __init__(self) -> None:
         self.encode_count = 0
+        self.decode_count = 0
 
     async def encode(
         self, payloads: Sequence[temporalio.api.common.v1.Payload]
@@ -202,6 +205,7 @@ class RejectOuterSystemNexusCodec(PayloadCodec):
                 raise RuntimeError(
                     "outer system nexus envelope should not be codec decoded"
                 )
+            self.decode_count += 1
             decoded.append(payload)
         return decoded
 
@@ -331,6 +335,92 @@ def _new_unmarked_system_nexus_request_payload() -> temporalio.api.common.v1.Pay
     payload = _new_system_nexus_request_payload()
     del payload.metadata[SYSTEM_NEXUS_PAYLOAD_METADATA_KEY]
     return payload
+
+
+async def test_nexus_payload_serializer_decodes_marked_system_input() -> None:
+    """A marked system request is decoded into its generated Nexus model."""
+    data_converter = temporalio.converter.default()
+    request = workflow_service_models.SignalWithStartWorkflowRequest(
+        workflow="test-workflow",
+        args=["workflow-input"],
+        id="target-workflow-id",
+        task_queue="target-task-queue",
+        signal="test-signal",
+        namespace="target-namespace",
+    )
+    payload = nexus_system._get_payload_converter(
+        data_converter.payload_converter,
+        data_converter.failure_converter,
+    ).to_payload(request)
+    assert payload is not None
+    assert payload.metadata[SYSTEM_NEXUS_PAYLOAD_METADATA_KEY] == b"true"
+    assert payload.metadata["encoding"] == b"binary/protobuf"
+
+    decoded = await _NexusPayloadSerializer(
+        data_converter=data_converter,
+        payload=payload,
+    ).deserialize(
+        nexusrpc.Content(headers={}, data=b""),
+        as_type=workflow_service_models.SignalWithStartWorkflowRequest,
+    )
+
+    assert decoded == request
+
+
+async def test_nexus_payload_serializer_decodes_nested_payloads_before_model_conversion() -> (
+    None
+):
+    """The codec decodes nested user payloads but not the outer system envelope."""
+    codec = RejectOuterSystemNexusCodec()
+    data_converter = dataclasses.replace(
+        temporalio.converter.default(),
+        payload_codec=codec,
+    )
+    request = workflow_service_models.SignalWithStartWorkflowRequest(
+        workflow="test-workflow",
+        args=["workflow-input"],
+        id="target-workflow-id",
+        task_queue="target-task-queue",
+        signal="test-signal",
+        namespace="target-namespace",
+    )
+    payload = nexus_system._get_payload_converter(
+        data_converter.payload_converter,
+        data_converter.failure_converter,
+    ).to_payload(request)
+    assert payload is not None
+
+    decoded = await _NexusPayloadSerializer(
+        data_converter=data_converter,
+        payload=payload,
+    ).deserialize(
+        nexusrpc.Content(headers={}, data=b""),
+        as_type=workflow_service_models.SignalWithStartWorkflowRequest,
+    )
+
+    assert codec.decode_count == 1
+    assert codec.encode_count == 0
+    assert decoded == request
+
+
+async def test_nexus_payload_serializer_uses_user_converter_for_unmarked_input() -> (
+    None
+):
+    """An unmarked Nexus input continues to use the configured user converter."""
+    data_converter = temporalio.converter.default()
+    payload = data_converter.payload_converter.to_payload("ordinary-input")
+    assert payload is not None
+    assert SYSTEM_NEXUS_PAYLOAD_METADATA_KEY not in payload.metadata
+
+    decoded = await _NexusPayloadSerializer(
+        data_converter=data_converter,
+        payload=payload,
+    ).deserialize(
+        nexusrpc.Content(headers={}, data=b""),
+        as_type=str,
+    )
+
+    assert decoded == "ordinary-input"
 
 
 async def test_schedule_marked_system_nexus_payload_ignores_endpoint() -> None:

--- a/tests/nexus/test_workflow_caller_errors.py
+++ b/tests/nexus/test_workflow_caller_errors.py
@@ -44,7 +44,7 @@ from temporalio.exceptions import (
 from temporalio.service import RPCError, RPCStatusCode
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
-from temporalio.worker._nexus import _DummyPayloadSerializer
+from temporalio.worker._nexus import _NexusPayloadSerializer
 from tests.helpers import LogCapturer, assert_eq_eventually
 from tests.helpers.nexus import make_nexus_endpoint_name
 
@@ -884,7 +884,7 @@ def _converter_class_raising(error: Exception) -> type[DefaultPayloadConverter]:
 
 async def _deserialize_input(data_converter: DataConverter) -> Any:
     [payload] = DataConverter.default.payload_converter.to_payloads(["input"])
-    serializer = _DummyPayloadSerializer(data_converter=data_converter, payload=payload)
+    serializer = _NexusPayloadSerializer(data_converter=data_converter, payload=payload)
     return await serializer.deserialize(nexusrpc.Content(headers={}, data=b""))
 
 


### PR DESCRIPTION
## Summary

- Select the system Nexus payload converter for marked worker inputs after nested external retrieval and codec decoding.
- Rename the Nexus payload serializer to reflect its real responsibilities.
- Add focused coverage for marked inputs, nested codec processing, unmarked inputs, and existing payload validation behavior.

## Testing

- poe test -s -k "nexus_worker or system_nexus or payload_validation" (23 passed)
- poe test -s -k "nexus_payload_serializer or payload_validation" (8 passed)
- poe format
- poe lint