### PR TITLE
Add Datadog tracing interceptor contrib package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ openai-agents = ["openai-agents>=0.19.2,<0.20", "mcp>=1.9.4, <2"]
 google-adk = ["google-adk>=2.2.0,<3", "mcp>=1.24,<2"]
 langgraph = ["langgraph>=1.1.0"]
 langsmith = ["langsmith>=0.7.34,<0.9"]
+datadog = ["ddtrace>=2.9,<4"]
 deepagents = [
   "deepagents>=0.6.12,<0.7; python_version >= '3.11'",
   "langchain>=1.3.11,<2; python_version >= '3.11'",
@@ -100,6 +101,7 @@ dev = [
   "strands-agents>=1.39.0",
   "strands-agents-tools>=0.5.2",
   "mcp>=1.9.4,<2",
+  "ddtrace>=2.9,<4",
 ]
 
 [tool.poe.tasks]

--- a/temporalio/contrib/datadog/README.md
+++ b/temporalio/contrib/datadog/README.md
@@ -1,0 +1,132 @@
+# Datadog Tracing Interceptor for Temporal Python
+
+## Background
+
+### Why this is more complex than Go
+
+The Python Temporal SDK does not provide a common tracing interface to
+implement. Instead, it exposes interceptor base classes that users extend to
+inject behaviour at each operation boundary. This is idiomatic Python but
+makes integration more involved than the Go equivalent.
+
+The more significant challenge is how the Python SDK executes workflow code.
+Workflows run inside a sandboxed environment where the worker re-imports the
+workflow module before every execution. The sandbox also enforces
+determinism constraints, so tracing logic (which depends on `ddtrace`, a
+module that schedules asyncio work during import) cannot live directly inside
+it.
+
+### Difference from the upstream OpenTelemetry interceptor
+
+The upstream OpenTelemetry tracing interceptor works around the sandbox
+limitation by emitting a zero-duration notification span whenever a workflow
+execution occurs. Activities and other events attach to that span. While
+functional, this approach does not produce actual workflow traces: the
+`RunWorkflow` span has no duration and the trace does not survive a worker
+restart.
+
+This implementation instead generates real workflow traces. The `RunWorkflow`
+span starts when the first worker picks up the workflow and finishes only when
+the workflow completes, matching Go's behaviour. Deterministic span IDs and
+context propagation ensure the trace remains coherent even if a worker
+restarts mid-execution.
+
+## Usage
+
+```python
+import ddtrace
+from temporalio.client import Client
+from temporalio.contrib.datadog import DatadogTracingInterceptor
+
+# Inject dd.trace_id and dd.span_id into every log record so workflow and
+# activity logs are correlated with their trace in Datadog Log Management.
+ddtrace.patch(logging=True)
+
+interceptor = DatadogTracingInterceptor(
+    service_name="my-service",
+    extra_tags={"deployment.environment": "prod"},
+)
+client = await Client.connect("localhost:7233", interceptors=[interceptor])
+```
+
+**Important**: Passing the `interceptor` instance to the client is enough.
+The worker will automatically pick up the interceptor from the client.
+
+## Deterministic span IDs
+
+The workflows' `RunWorkflow` spans may be long-running. If the worker
+restarts and the workflow is replayed, the new execution recreates
+the span with the **same span ID** so the trace remains coherent in APM.
+
+Span IDs for `RunWorkflow` (and any operation with an idempotency key) are
+derived via FNV-1 64-bit hash of a key:
+
+```
+WorkflowInboundInterceptor:<namespace>:<workflow_id>:<run_id>:<span_counter>
+```
+
+This matches the Go SDK's algorithm byte-for-byte, so a workflow started by a
+Go client and executed by a Python worker produces the same span ID. The
+counter starts at 1 (reserved for RunWorkflow) and increments for each
+subsequent handler span (HandleSignal, HandleUpdate) to give each a stable,
+unique ID across worker restarts.
+
+## Replay safety
+
+Temporal replays workflow history on every new worker to rebuild execution
+state. Without guards, replay would re-emit duplicate completed spans for
+operations that already finished on the dead worker.
+
+Two mechanisms prevent duplicates:
+
+**Inbound handlers** (HandleSignal, HandleUpdate): suppressed during replay
+via `temporalio.workflow.unsafe.is_replaying()`. A non-`None` idempotency key
+signals that the span completed within a single workflow task and must not be
+re-emitted. RunWorkflow is explicitly exempt — its span is in-flight and was
+never sent by the dead worker, so the new worker recreates it.
+
+**Outbound operations** (StartActivity, StartLocalActivity, StartChildWorkflow,
+SignalChildWorkflow, SignalExternalWorkflow): suppressed during replay by an
+early `is_replaying()` check at the top of each outbound interceptor method.
+The Temporal SDK matches these commands against history and returns cached
+results, but the interceptor code runs first — without the guard, a fresh span
+would be emitted for every replayed command.
+
+Queries and update validators are never suppressed: queries are not in
+history (they run on demand), and validators do not execute during replay.
+
+## Workflow sandbox
+
+Temporal runs workflow code inside a restricted import sandbox. Importing
+`ddtrace` from within that import path triggers an asyncio-loop conflict
+during ddtrace init and a `builtins.open` restriction from pytest's assertion
+rewriter.
+
+The interceptor works around this with an extern-function bridge:
+
+1. `DatadogTracingInterceptor` (host side) registers functions under
+   `unsafe_extern_functions` before the sandbox starts.
+2. `DatadogTracingWorkflowInboundInterceptor` (sandbox side) retrieves those
+   functions via `temporalio.workflow.extern_functions()` at init time and
+   holds them as instance attributes.
+3. All ddtrace calls (`start_span`, `finish_span`, baggage, annotation) go
+   through these externs, so the sandbox never imports ddtrace directly.
+
+Two `contextvars.ContextVar` values live on the host module and are accessed
+by the sandbox exclusively through externs:
+
+- `_active_workflow_span` — the live `RunWorkflow` ddtrace span for the
+  current execution. Used by outbound operations to parent their spans to
+  RunWorkflow when no propagated header is available.
+- `_trace_disconnected` — set by `disconnect_trace_span_from_workflow_context`
+  to suppress trace propagation into the next ContinueAsNew run.
+
+## ContinueAsNew
+
+`_WorkflowOutboundInterceptor.continue_as_new` injects the current RunWorkflow
+span context into the ContinueAsNew headers so the next run's RunWorkflow span
+is a child of the current one, forming a continuous trace across runs.
+
+Call `disconnect_trace_span_from_workflow_context()` before
+`workflow.continue_as_new()` to start a fresh root trace for the next run
+instead.

--- a/temporalio/contrib/datadog/__init__.py
+++ b/temporalio/contrib/datadog/__init__.py
@@ -1,0 +1,37 @@
+"""Datadog tracing integration for the Temporal Python SDK.
+
+This package provides a Datadog (``ddtrace``) tracing interceptor for the
+Temporal Python SDK.
+
+Usage::
+
+    from ddtrace import patch
+    from temporalio.client import Client
+    from temporalio.contrib.datadog import DatadogTracingInterceptor
+
+    patch(logging=True)  # opt in to dd.trace_id log injection
+
+    interceptor = DatadogTracingInterceptor(
+        service_name="my-service",
+        extra_tags={"deployment.environment": "prod"},
+    )
+    client = await Client.connect("localhost:7233", interceptors=[interceptor])
+"""
+
+from temporalio.contrib.datadog._interceptor import DatadogTracingInterceptor
+from temporalio.contrib.datadog._workflow_interceptor import (
+    disconnect_trace_span_from_workflow_context,
+    span_from_workflow_context,
+)
+from temporalio.contrib.datadog._wrapped_tracer import (
+    FinishContext,
+    FinishResult,
+)
+
+__all__ = [
+    "DatadogTracingInterceptor",
+    "FinishContext",
+    "FinishResult",
+    "disconnect_trace_span_from_workflow_context",
+    "span_from_workflow_context",
+]

--- a/temporalio/contrib/datadog/_activity_interceptor.py
+++ b/temporalio/contrib/datadog/_activity_interceptor.py
@@ -1,0 +1,67 @@
+"""Datadog tracing interceptor for Temporal activity inbound calls."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import temporalio.activity
+import temporalio.worker
+from temporalio.contrib.datadog._constants import (
+    OperationNames,
+    SpanAttributes,
+)
+from temporalio.contrib.datadog._id_generator import gen_span_id
+from temporalio.contrib.datadog._span_runner import _SpanRunner
+
+if TYPE_CHECKING:
+    from temporalio.contrib.datadog._interceptor import DatadogTracingInterceptor
+
+
+class _ActivityInboundInterceptor(  # type: ignore[reportUnsafeMultipleInheritance]
+    _SpanRunner, temporalio.worker.ActivityInboundInterceptor
+):
+    def __init__(
+        self,
+        next: temporalio.worker.ActivityInboundInterceptor,
+        root: DatadogTracingInterceptor,
+    ) -> None:
+        temporalio.worker.ActivityInboundInterceptor.__init__(self, next)
+        _SpanRunner.__init__(self, root)
+
+    async def execute_activity(
+        self, input: temporalio.worker.ExecuteActivityInput
+    ) -> Any:
+        return await self.run(
+            self._get_span(input),
+            OperationNames.RUN_ACTIVITY,
+            super().execute_activity(input),
+        )
+
+    def _get_span(self, input: temporalio.worker.ExecuteActivityInput) -> Any:
+        info = temporalio.activity.info()
+        return self.root.tracer.start_span(
+            operation_name=OperationNames.RUN_ACTIVITY,
+            parent_ctx=self.root.propagator.extract_headers(input.headers),
+            resource_name=info.activity_type,
+            activate=True,
+            span_id=gen_span_id(
+                f"{info.workflow_run_id}:{info.activity_id}:{info.attempt}"
+            ),
+            attributes=self._get_activity_attributes(info),
+            parent_from_header=True,
+        )
+
+    @staticmethod
+    def _get_activity_attributes(info: temporalio.activity.Info) -> dict[str, Any]:
+        attributes: dict[str, Any] = {
+            SpanAttributes.ACTIVITY_ID: info.activity_id,
+            SpanAttributes.ACTIVITY_TYPE: info.activity_type,
+            SpanAttributes.ATTEMPT: info.attempt,
+        }
+        if info.workflow_id:
+            attributes[SpanAttributes.WORKFLOW_ID] = info.workflow_id
+        if info.workflow_run_id:
+            attributes[SpanAttributes.RUN_ID] = info.workflow_run_id
+        if info.workflow_namespace:
+            attributes[SpanAttributes.NAMESPACE] = info.workflow_namespace
+        return attributes

--- a/temporalio/contrib/datadog/_client_interceptor.py
+++ b/temporalio/contrib/datadog/_client_interceptor.py
@@ -1,0 +1,184 @@
+"""Datadog tracing interceptor for Temporal client outbound calls."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+import temporalio.client
+from temporalio.contrib.datadog._constants import (
+    COMMON_ATTRIBUTE_MAP,
+    OperationNames,
+    SpanAttributes,
+)
+from temporalio.contrib.datadog._span_runner import _SpanRunner
+
+if TYPE_CHECKING:
+    from temporalio.contrib.datadog._interceptor import DatadogTracingInterceptor
+
+
+class _ClientOutboundInterceptor(  # type: ignore[reportUnsafeMultipleInheritance]
+    _SpanRunner, temporalio.client.OutboundInterceptor
+):
+    def __init__(
+        self,
+        next: temporalio.client.OutboundInterceptor,
+        root: DatadogTracingInterceptor,
+    ) -> None:
+        temporalio.client.OutboundInterceptor.__init__(self, next)
+        _SpanRunner.__init__(self, root)
+
+    async def start_workflow(
+        self, input: temporalio.client.StartWorkflowInput
+    ) -> temporalio.client.WorkflowHandle[Any, Any]:
+        operation_name = (
+            OperationNames.SIGNAL_WITH_START_WORKFLOW
+            if input.start_signal
+            else OperationNames.START_WORKFLOW
+        )
+        return await self._start_operation(
+            operation_name,
+            input,
+            input.workflow,
+            self._get_workflow_attributes(input),
+            super().start_workflow,
+        )
+
+    async def signal_workflow(
+        self, input: temporalio.client.SignalWorkflowInput
+    ) -> None:
+        if self.root.workflow_tracing_config.disable_signal_tracing:
+            return await super().signal_workflow(input)
+        return await self._start_operation(
+            OperationNames.SIGNAL_WORKFLOW,
+            input,
+            input.signal,
+            self._get_workflow_attributes(input),
+            super().signal_workflow,
+        )
+
+    async def query_workflow(self, input: temporalio.client.QueryWorkflowInput) -> Any:
+        if self.root.workflow_tracing_config.disable_query_tracing:
+            return await super().query_workflow(input)
+        return await self._start_operation(
+            OperationNames.QUERY_WORKFLOW,
+            input,
+            input.query,
+            self._get_workflow_attributes(input),
+            super().query_workflow,
+        )
+
+    async def create_schedule(
+        self, input: temporalio.client.CreateScheduleInput
+    ) -> temporalio.client.ScheduleHandle:
+        span = self._get_span(OperationNames.CREATE_SCHEDULE, input.id)
+        return await self.run(
+            span, OperationNames.CREATE_SCHEDULE, super().create_schedule(input)
+        )
+
+    async def start_workflow_update(
+        self, input: temporalio.client.StartWorkflowUpdateInput
+    ) -> temporalio.client.WorkflowUpdateHandle[Any]:
+        if self.root.workflow_tracing_config.disable_update_tracing:
+            return await super().start_workflow_update(input)
+        return await self._start_operation(
+            OperationNames.UPDATE_WORKFLOW,
+            input,
+            input.update,
+            self._get_workflow_attributes(input),
+            super().start_workflow_update,
+        )
+
+    async def start_update_with_start_workflow(
+        self, input: temporalio.client.StartWorkflowUpdateWithStartInput
+    ) -> temporalio.client.WorkflowUpdateHandle[Any]:
+        if self.root.workflow_tracing_config.disable_update_tracing:
+            # Update tracing is disabled, but this call also starts a new workflow.
+            # Propagate the currently active trace into the workflow start headers so
+            # RunWorkflow is not an unparented root when workflow tracing is enabled.
+            active_ctx = self.root.tracer.tracer.context_provider.active()
+            input.start_workflow_input.headers = self.root.propagator.inject_headers(
+                input.start_workflow_input.headers, active_ctx
+            )
+            return await super().start_update_with_start_workflow(input)
+
+        operation_name = OperationNames.UPDATE_WITH_START_WORKFLOW
+        span = self._get_span(
+            operation_name,
+            input.start_workflow_input.workflow,
+            self._get_workflow_attributes(input.start_workflow_input),
+        )
+
+        input.start_workflow_input.headers = self.root.propagator.inject_headers(
+            input.start_workflow_input.headers, span.context
+        )
+        input.update_workflow_input.headers = self.root.propagator.inject_headers(
+            input.update_workflow_input.headers, span.context
+        )
+
+        return await self.run(
+            span,
+            operation_name,
+            super().start_update_with_start_workflow(input),
+        )
+
+    async def start_activity(
+        self, input: temporalio.client.StartActivityInput
+    ) -> temporalio.client.ActivityHandle[Any]:
+        return await self._start_operation(
+            OperationNames.START_ACTIVITY,
+            input,
+            input.activity_type,
+            self._get_activity_attributes(input),
+            super().start_activity,
+        )
+
+    async def _start_operation(
+        self,
+        operation_name: str,
+        input: Any,
+        resource_name: str,
+        attributes: dict[str, Any],
+        awaitable: Callable[[Any], Awaitable[Any]],
+    ) -> Any:
+        span = self._get_span(operation_name, resource_name, attributes)
+        input.headers = self.root.propagator.inject_headers(input.headers, span.context)
+        return await self.run(span, operation_name, awaitable(input))
+
+    def _get_span(
+        self,
+        operation_name: str,
+        resource_name: str,
+        attributes: dict[str, Any] | None = None,
+    ) -> Any:
+        # Use the currently active ddtrace span as parent if one exists
+        parent_ctx = self.root.tracer.tracer.context_provider.active()
+        return self.root.tracer.start_span(
+            operation_name=operation_name,
+            parent_ctx=parent_ctx,
+            resource_name=resource_name,
+            activate=True,
+            attributes=attributes,
+            parent_from_header=False,
+        )
+
+    @classmethod
+    def _get_workflow_attributes(cls, input: Any) -> dict[str, Any]:
+        attributes: dict[str, Any] = {SpanAttributes.WORKFLOW_ID: input.id}
+        for field, span_key in COMMON_ATTRIBUTE_MAP:
+            if val := getattr(input, field, None):
+                attributes[span_key] = val
+        if getattr(input, "workflow", None):
+            attributes[SpanAttributes.WORKFLOW_TYPE] = input.workflow
+        if getattr(input, "update", None):
+            attributes[SpanAttributes.UPDATE_NAME] = input.update
+        if getattr(input, "update_id", None):
+            attributes[SpanAttributes.UPDATE_ID] = input.update_id
+        return attributes
+
+    @classmethod
+    def _get_activity_attributes(cls, input: Any) -> dict[str, Any]:
+        return {
+            SpanAttributes.ACTIVITY_ID: input.id,
+            SpanAttributes.ACTIVITY_TYPE: input.activity_type,
+        }

--- a/temporalio/contrib/datadog/_constants.py
+++ b/temporalio/contrib/datadog/_constants.py
@@ -1,0 +1,89 @@
+"""Package-wide constants for the Datadog tracing interceptor."""
+
+from collections.abc import Mapping
+from typing import TypeAlias
+
+import temporalio.api.common.v1
+
+Carrier: TypeAlias = dict[str, str]
+StringHeader: TypeAlias = Mapping[str, str]
+TemporalHeader: TypeAlias = Mapping[str, temporalio.api.common.v1.Payload]
+
+BAGGAGE_ITEM_SERVICE = "servicename"
+CONTINUE_AS_NEW_TAG = "temporal.continued_as_new"
+DEFAULT_HEADER_KEY = "dd_trace_span"
+TEMPORAL_TAG_PREFIX = "temporal."
+_MANUAL_KEEP_TAG = "manual.keep"
+
+
+class SpanAttributes:
+    ACTIVITY_ID = "ActivityID"
+    ACTIVITY_TYPE = "ActivityType"
+    ATTEMPT = "Attempt"
+    CHILD_WORKFLOW_ID = "ChildWorkflowID"
+    CHILD_WORKFLOW_TYPE = "ChildWorkflowType"
+    EXTERNAL_WORKFLOW_ID = "ExternalWorkflowID"
+    LOCAL = "Local"
+    NAMESPACE = "Namespace"
+    NEXUS_OPERATION = "NexusOperation"
+    NEXUS_SERVICE = "NexusService"
+    QUERY_TYPE = "QueryType"
+    RUN_ID = "RunID"
+    SIGNAL_NAME = "SignalName"
+    UPDATE_ID = "UpdateID"
+    UPDATE_NAME = "UpdateName"
+    WORKFLOW_ID = "WorkflowID"
+    WORKFLOW_TYPE = "WorkflowType"
+
+
+COMMON_ATTRIBUTE_MAP: tuple[tuple[str, str], ...] = (
+    ("signal", SpanAttributes.SIGNAL_NAME),
+    ("query", SpanAttributes.QUERY_TYPE),
+    ("activity", SpanAttributes.ACTIVITY_TYPE),
+    ("child_workflow_id", SpanAttributes.CHILD_WORKFLOW_ID),
+    ("workflow_id", SpanAttributes.EXTERNAL_WORKFLOW_ID),
+    ("service", SpanAttributes.NEXUS_SERVICE),
+    ("operation_name", SpanAttributes.NEXUS_OPERATION),
+)
+
+
+class OperationNames:
+    CREATE_SCHEDULE = "CreateSchedule"
+    HANDLE_QUERY = "HandleQuery"
+    HANDLE_SIGNAL = "HandleSignal"
+    HANDLE_UPDATE = "HandleUpdate"
+    QUERY_WORKFLOW = "QueryWorkflow"
+    RUN_ACTIVITY = "RunActivity"
+    RUN_WORKFLOW = "RunWorkflow"
+    SIGNAL_CHILD_WORKFLOW = "SignalChildWorkflow"
+    SIGNAL_EXTERNAL_WORKFLOW = "SignalExternalWorkflow"
+    SIGNAL_WITH_START_WORKFLOW = "SignalWithStartWorkflow"
+    SIGNAL_WORKFLOW = "SignalWorkflow"
+    START_ACTIVITY = "StartActivity"
+    START_CHILD_WORKFLOW = "StartChildWorkflow"
+    START_NEXUS_OPERATION = "StartNexusOperation"
+    RUN_NEXUS_OPERATION_START_HANDLER = "RunStartNexusOperationHandler"
+    RUN_NEXUS_OPERATION_CANCEL_HANDLER = "RunCancelNexusOperationHandler"
+    UPDATE_WITH_START_WORKFLOW = "UpdateWithStartWorkflow"
+    UPDATE_WORKFLOW = "UpdateWorkflow"
+    START_WORKFLOW = "StartWorkflow"
+    VALIDATE_UPDATE = "ValidateUpdate"
+
+
+# Temporal entry-point operations whose spans are assigned USER_KEEP when they
+# have no in-process parent.
+# StartActivity is included because clients can start standalone activities
+# without a workflow parent.
+_MANUAL_KEEP_OPS: frozenset[str] = frozenset(
+    {
+        OperationNames.RUN_WORKFLOW,
+        OperationNames.START_WORKFLOW,
+        OperationNames.SIGNAL_WITH_START_WORKFLOW,
+        OperationNames.SIGNAL_WORKFLOW,
+        OperationNames.QUERY_WORKFLOW,
+        OperationNames.UPDATE_WORKFLOW,
+        OperationNames.UPDATE_WITH_START_WORKFLOW,
+        OperationNames.CREATE_SCHEDULE,
+        OperationNames.START_ACTIVITY,
+    }
+)

--- a/temporalio/contrib/datadog/_id_generator.py
+++ b/temporalio/contrib/datadog/_id_generator.py
@@ -1,0 +1,40 @@
+"""Deterministic span ID generation for Temporal Datadog tracing."""
+
+_FNV_OFFSET_64 = 0xCBF29CE484222325
+_FNV_PRIME_64 = 0x100000001B3
+_FNV_MASK_64 = 0xFFFFFFFFFFFFFFFF
+
+
+def gen_trace_id(key: str) -> int:
+    """Compute a deterministic 64-bit trace ID for a root RunWorkflow span.
+
+    Used when no Datadog trace header is present (uninstrumented client), so
+    that the trace ID is stable across worker restarts for the same run.
+
+    Uses the same FNV-1 algorithm as gen_span_id but prefixes the input with
+    ``trace:`` to keep trace-ID inputs distinct from span-ID inputs.
+    """
+    return gen_span_id(f"trace:{key}")
+
+
+def gen_span_id(key: str) -> int:
+    """Compute a 64-bit FNV-1 hash of a UTF-8 encoded string.
+
+    Used to derive deterministic Datadog span IDs from the composite
+    idempotency keys built by the tracing interceptors.
+
+    Matches the byte-for-byte output of Go's ``hash/fnv.New64()`` (which is
+    FNV-1, not FNV-1a), so Go and Python workers hashing the same
+    idempotency key produce the same span ID.
+
+    Args:
+        key: The string to hash.
+
+    Returns:
+        A 64-bit unsigned integer suitable for use as a Datadog span ID.
+    """
+    h = _FNV_OFFSET_64
+    for byte in key.encode("utf-8"):
+        h = (h * _FNV_PRIME_64) & _FNV_MASK_64
+        h ^= byte
+    return h

--- a/temporalio/contrib/datadog/_interceptor.py
+++ b/temporalio/contrib/datadog/_interceptor.py
@@ -1,0 +1,159 @@
+"""Datadog tracing interceptor for Temporal."""
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import temporalio.client
+import temporalio.converter
+import temporalio.worker
+import temporalio.workflow
+from temporalio.contrib.datadog._activity_interceptor import _ActivityInboundInterceptor
+from temporalio.contrib.datadog._client_interceptor import _ClientOutboundInterceptor
+from temporalio.contrib.datadog._constants import (
+    CONTINUE_AS_NEW_TAG,
+    DEFAULT_HEADER_KEY,
+    OperationNames,
+)
+from temporalio.contrib.datadog._id_generator import gen_span_id, gen_trace_id
+from temporalio.contrib.datadog._nexus_interceptor import (
+    _NexusOperationInboundInterceptor,
+)
+from temporalio.contrib.datadog._propagator import _Propagator
+from temporalio.contrib.datadog._span_annotator import _SpanAnnotator
+from temporalio.contrib.datadog._workflow_interceptor import (
+    DatadogTracingWorkflowInboundInterceptor,
+    WorkflowTracingConfig,
+    _active_workflow_span,
+    _trace_disconnected,
+)
+from temporalio.contrib.datadog._wrapped_tracer import (
+    FinishContext,
+    FinishResult,
+    WrappedTracer,
+)
+
+
+class DatadogTracingInterceptor(
+    temporalio.client.Interceptor, temporalio.worker.Interceptor
+):
+    def __init__(  # type: ignore[reportMissingSuperCall]
+        self,
+        tracer: Any | None = None,
+        *,
+        service_name: str | None = None,
+        header_key: str = DEFAULT_HEADER_KEY,
+        extra_tags: Mapping[str, str] | None = None,
+        on_span_finish: Callable[[FinishContext], FinishResult | None] | None = None,
+        workflow_tracing_config: WorkflowTracingConfig = WorkflowTracingConfig.default_config(),
+        allow_invalid_parent_spans: bool = False,
+    ) -> None:
+        self.workflow_tracing_config = workflow_tracing_config
+
+        self.propagator = _Propagator(
+            header_key=header_key,
+            service_name=service_name,
+            payload_converter=temporalio.converter.PayloadConverter.default,
+            allow_invalid_parent_spans=allow_invalid_parent_spans,
+        )
+
+        self.tracer = WrappedTracer(
+            service_name=service_name,
+            tracer=tracer,
+            on_span_finish=on_span_finish,
+            annotator=_SpanAnnotator(service_name=service_name, extra_tags=extra_tags),
+            propagator=self.propagator,
+        )
+
+    def intercept_client(
+        self, next: temporalio.client.OutboundInterceptor
+    ) -> temporalio.client.OutboundInterceptor:
+        return _ClientOutboundInterceptor(next, self)
+
+    def intercept_activity(
+        self, next: temporalio.worker.ActivityInboundInterceptor
+    ) -> temporalio.worker.ActivityInboundInterceptor:
+        return _ActivityInboundInterceptor(next, self)
+
+    def intercept_nexus_operation(
+        self, next: temporalio.worker.NexusOperationInboundInterceptor
+    ) -> temporalio.worker.NexusOperationInboundInterceptor:
+        return _NexusOperationInboundInterceptor(next, self)
+
+    def workflow_interceptor_class(
+        self, input: temporalio.worker.WorkflowInterceptorClassInput
+    ) -> type[DatadogTracingWorkflowInboundInterceptor]:
+        input.unsafe_extern_functions["__temporal_datadog_start_sandboxed_span"] = (
+            self._start_sandboxed_span
+        )
+        input.unsafe_extern_functions["__temporal_datadog_finish_sandboxed_span"] = (
+            self._finish_sandboxed_span
+        )
+        input.unsafe_extern_functions[
+            "__temporal_datadog_configure_workflow_tracing"
+        ] = self._configure_workflow_tracing
+        # NOTE: fork-specific workaround; reconsider if this integration is ever proposed upstream.
+        # These two externs let workflow code cross the sandbox boundary to read/write
+        # ContextVars that live in the host module.  Without them, the sandbox's own
+        # copy of workflow_interceptor has fresh ContextVars that are never set.
+        input.unsafe_extern_functions["__temporal_datadog_get_workflow_span"] = (
+            _active_workflow_span.get
+        )
+        input.unsafe_extern_functions["__temporal_datadog_set_trace_disconnected"] = (
+            lambda: _trace_disconnected.set(True)
+        )
+        return DatadogTracingWorkflowInboundInterceptor
+
+    def _configure_workflow_tracing(self):
+        return self.propagator, self.workflow_tracing_config
+
+    def _start_sandboxed_span(
+        self,
+        operation_name: str,
+        resource_name: str,
+        attributes: dict[str, Any] | None,
+        parent_ctx: Any | None,
+        idempotency_key: str | None,
+        start_time: int | None = None,
+    ) -> Any:
+        # No DD header (uninstrumented client): pass a deterministic trace_id to keep
+        # the RunWorkflow trace consistent if the worker restarts mid-run.
+        det_trace_id = (
+            gen_trace_id(idempotency_key)
+            if operation_name == OperationNames.RUN_WORKFLOW
+            and parent_ctx is None
+            and idempotency_key is not None
+            else None
+        )
+        span = self.tracer.start_span(
+            operation_name=operation_name,
+            parent_ctx=parent_ctx,
+            resource_name=resource_name,
+            activate=False,
+            start_time=start_time,
+            span_id=gen_span_id(idempotency_key)
+            if idempotency_key is not None
+            else None,
+            attributes=attributes,
+            parent_from_header=True,
+            trace_id=det_trace_id,
+        )
+        # NOTE: fork-specific workaround; reconsider if this integration is ever proposed upstream.
+        # Expose the RunWorkflow span to the host-side ContextVar so that
+        # span_from_workflow_context() can return it via the extern.
+        if operation_name == OperationNames.RUN_WORKFLOW:
+            _active_workflow_span.set(span)
+        return span
+
+    def _finish_sandboxed_span(
+        self,
+        operation_name: str,
+        span: Any | None,
+        operation_exc: BaseException | None,
+    ) -> None:
+        if span is None:
+            return
+
+        if isinstance(operation_exc, temporalio.workflow.ContinueAsNewError):
+            span.set_tag(CONTINUE_AS_NEW_TAG, True)
+
+        self.tracer.finish_span(span, operation_name, operation_exc)

--- a/temporalio/contrib/datadog/_nexus_interceptor.py
+++ b/temporalio/contrib/datadog/_nexus_interceptor.py
@@ -1,0 +1,64 @@
+"""Datadog tracing interceptor for Temporal Nexus operation inbound calls."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import nexusrpc.handler
+
+import temporalio.worker
+from temporalio.contrib.datadog._constants import OperationNames, SpanAttributes
+from temporalio.contrib.datadog._span_runner import _SpanRunner
+
+if TYPE_CHECKING:
+    from temporalio.contrib.datadog._interceptor import DatadogTracingInterceptor
+
+
+class _NexusOperationInboundInterceptor(  # type: ignore[reportUnsafeMultipleInheritance]
+    _SpanRunner, temporalio.worker.NexusOperationInboundInterceptor
+):
+    def __init__(
+        self,
+        next: temporalio.worker.NexusOperationInboundInterceptor,
+        root: DatadogTracingInterceptor,
+    ) -> None:
+        temporalio.worker.NexusOperationInboundInterceptor.__init__(self, next)
+        _SpanRunner.__init__(self, root)
+
+    async def execute_nexus_operation_start(
+        self, input: temporalio.worker.ExecuteNexusOperationStartInput
+    ) -> (
+        nexusrpc.handler.StartOperationResultSync[Any]
+        | nexusrpc.handler.StartOperationResultAsync
+    ):
+        return await self.run(
+            self._get_span(input, OperationNames.RUN_NEXUS_OPERATION_START_HANDLER),
+            OperationNames.RUN_NEXUS_OPERATION_START_HANDLER,
+            super().execute_nexus_operation_start(input),
+        )
+
+    async def execute_nexus_operation_cancel(
+        self, input: temporalio.worker.ExecuteNexusOperationCancelInput
+    ) -> None:
+        return await self.run(
+            self._get_span(input, OperationNames.RUN_NEXUS_OPERATION_CANCEL_HANDLER),
+            OperationNames.RUN_NEXUS_OPERATION_CANCEL_HANDLER,
+            super().execute_nexus_operation_cancel(input),
+        )
+
+    def _get_span(self, input: Any, operation_name: str) -> Any:
+        return self.root.tracer.start_span(
+            operation_name=operation_name,
+            parent_ctx=self.root.propagator.extract(input.ctx.headers),
+            resource_name=f"{input.ctx.service}/{input.ctx.operation}",
+            activate=True,
+            attributes=self._get_nexus_attributes(input.ctx),
+            parent_from_header=True,
+        )
+
+    @staticmethod
+    def _get_nexus_attributes(nexus_ctx: Any) -> dict[str, Any]:
+        return {
+            SpanAttributes.NEXUS_SERVICE: nexus_ctx.service,
+            SpanAttributes.NEXUS_OPERATION: nexus_ctx.operation,
+        }

--- a/temporalio/contrib/datadog/_propagator.py
+++ b/temporalio/contrib/datadog/_propagator.py
@@ -1,0 +1,113 @@
+"""Datadog propagation wrapper for Temporal headers."""
+
+from typing import Any, cast
+
+import temporalio.api.common.v1
+import temporalio.converter
+from temporalio.contrib.datadog._constants import (
+    BAGGAGE_ITEM_SERVICE,
+    Carrier,
+    StringHeader,
+    TemporalHeader,
+)
+
+
+class _Propagator:  # type: ignore[reportUnusedClass]
+    """Wraps HTTPPropagator with Temporal header encode/decode logic.
+
+    The ``ddtrace`` import is deferred to ``__init__`` so sandbox re-importing
+    this module does not import ``ddtrace``.
+    """
+
+    def __init__(
+        self,
+        *,
+        header_key: str,
+        service_name: str | None,
+        payload_converter: temporalio.converter.PayloadConverter,
+        allow_invalid_parent_spans: bool = False,
+    ) -> None:
+        from ddtrace.propagation.http import HTTPPropagator
+
+        self._propagator = HTTPPropagator
+        self.header_key = header_key
+        self.service_name = service_name
+        self._payload_converter = payload_converter
+        self.allow_invalid_parent_spans = allow_invalid_parent_spans
+
+    @staticmethod
+    def get_baggage(ctx: Any) -> str | None:
+        if ctx is None:
+            return None
+
+        getter = getattr(ctx, "get_baggage_item", None)
+        if callable(getter):
+            return cast(str | None, getter(BAGGAGE_ITEM_SERVICE))
+
+        return None
+
+    def set_baggage(self, ctx: Any) -> None:
+        if self.service_name is None:
+            return
+        setter = getattr(ctx, "set_baggage_item", None)
+        if callable(setter):
+            setter(BAGGAGE_ITEM_SERVICE, self.service_name)
+
+    def inject(self, context: Any) -> Carrier:
+        carrier: Carrier = {}
+        if context is None:
+            return carrier
+        self._propagator.inject(context, carrier)
+        return carrier
+
+    def extract(self, header: StringHeader | None) -> Any:
+        if header is None:
+            return None
+
+        try:
+            ctx = self._propagator.extract(header)
+        except Exception:
+            if self.allow_invalid_parent_spans:
+                return None
+            raise
+
+        if ctx is None or getattr(ctx, "trace_id", None) is None:
+            return None
+
+        return ctx
+
+    def _carrier_to_payload(self, carrier: Carrier) -> temporalio.api.common.v1.Payload:
+        return self._payload_converter.to_payloads([carrier])[0]
+
+    def _payload_to_carrier(
+        self, payload: temporalio.api.common.v1.Payload
+    ) -> Carrier | None:
+        decoded = self._payload_converter.from_payloads([payload])[0]
+        if not isinstance(decoded, dict):
+            return None
+        return {str(k): str(v) for k, v in decoded.items()}
+
+    def inject_headers(
+        self,
+        headers: TemporalHeader,
+        context: Any,
+    ) -> TemporalHeader:
+        if context is None:
+            return headers
+
+        self.set_baggage(context)
+        carrier = self.inject(context)
+
+        return {**headers, self.header_key: self._carrier_to_payload(carrier)}
+
+    def extract_headers(self, headers: TemporalHeader) -> Any:
+        payload = headers.get(self.header_key)
+        if payload is None:
+            return None
+        try:
+            carrier = self._payload_to_carrier(payload)
+        except Exception:
+            if self.allow_invalid_parent_spans:
+                return None
+            raise
+        return self.extract(carrier)

--- a/temporalio/contrib/datadog/_span_annotator.py
+++ b/temporalio/contrib/datadog/_span_annotator.py
@@ -1,0 +1,93 @@
+"""Span annotation logic for the Datadog tracing interceptor."""
+
+from collections.abc import Mapping
+from typing import Any
+
+from temporalio.contrib.datadog._constants import (
+    _MANUAL_KEEP_OPS,
+    _MANUAL_KEEP_TAG,
+    TEMPORAL_TAG_PREFIX,
+    OperationNames,
+)
+
+
+class _SpanAnnotator:  # type: ignore[reportUnusedClass]
+    _PEER_SERVICE_TAG = "peer.service"
+    _SPAN_KIND_TAG = "span.kind"
+    _PRODUCER = "producer"
+    _CONSUMER = "consumer"
+
+    _SPAN_KIND: dict[str, str] = {
+        OperationNames.START_ACTIVITY: _PRODUCER,
+        OperationNames.RUN_ACTIVITY: _CONSUMER,
+        OperationNames.START_CHILD_WORKFLOW: _PRODUCER,
+        OperationNames.START_WORKFLOW: _PRODUCER,
+        OperationNames.SIGNAL_WITH_START_WORKFLOW: _PRODUCER,
+        OperationNames.RUN_WORKFLOW: _CONSUMER,
+        OperationNames.SIGNAL_WORKFLOW: _PRODUCER,
+        OperationNames.SIGNAL_CHILD_WORKFLOW: _PRODUCER,
+        OperationNames.SIGNAL_EXTERNAL_WORKFLOW: _PRODUCER,
+        OperationNames.HANDLE_SIGNAL: _CONSUMER,
+        OperationNames.QUERY_WORKFLOW: _PRODUCER,
+        OperationNames.HANDLE_QUERY: _CONSUMER,
+        OperationNames.UPDATE_WORKFLOW: _PRODUCER,
+        OperationNames.UPDATE_WITH_START_WORKFLOW: _PRODUCER,
+        OperationNames.VALIDATE_UPDATE: _CONSUMER,
+        OperationNames.HANDLE_UPDATE: _CONSUMER,
+        OperationNames.CREATE_SCHEDULE: _PRODUCER,
+        OperationNames.START_NEXUS_OPERATION: _PRODUCER,
+        OperationNames.RUN_NEXUS_OPERATION_START_HANDLER: _CONSUMER,
+        OperationNames.RUN_NEXUS_OPERATION_CANCEL_HANDLER: _CONSUMER,
+    }
+
+    def __init__(
+        self,
+        *,
+        service_name: str | None = None,
+        extra_tags: Mapping[str, str] | None = None,
+    ) -> None:
+        self.service_name = service_name
+        self.extra_tags: Mapping[str, str] = extra_tags or {}
+
+    @classmethod
+    def _normalize_key(cls, key: str) -> str:
+        if key.startswith(TEMPORAL_TAG_PREFIX):
+            return key
+        if key.lower().startswith("temporal"):
+            return TEMPORAL_TAG_PREFIX + key[len("temporal") :].lstrip(".")
+        return TEMPORAL_TAG_PREFIX + key
+
+    def annotate(
+        self,
+        span: Any,
+        operation: str,
+        attributes: Mapping[str, Any] | None,
+        parent_service_name: str | None,
+        force_keep: bool = False,
+    ) -> None:
+        # User-defined global custom tags
+        for key, value in self.extra_tags.items():
+            span.set_tag(key, value)
+
+        # Attributes from the operation
+        if attributes:
+            for key, value in attributes.items():
+                span.set_tag(self._normalize_key(key), value)
+
+        # Force-keep entry-point operations that have no local parent.
+        # Two parent shapes qualify: no parent (nil/None — scheduled or standalone
+        # execution) and parents extracted from Temporal task headers (cross-process).
+        # Parents from context_provider.active() are in-process producer spans and
+        # should inherit the caller's sampling decision instead.
+        if operation in _MANUAL_KEEP_OPS and force_keep:
+            span.set_tag(_MANUAL_KEEP_TAG, True)
+
+        kind = self._SPAN_KIND.get(operation)
+        if kind:
+            span.set_tag(self._SPAN_KIND_TAG, kind)
+            if (
+                kind == self._CONSUMER
+                and parent_service_name
+                and parent_service_name != self.service_name
+            ):
+                span.set_tag(self._PEER_SERVICE_TAG, parent_service_name)

--- a/temporalio/contrib/datadog/_span_runner.py
+++ b/temporalio/contrib/datadog/_span_runner.py
@@ -1,0 +1,27 @@
+"""Base span lifecycle management class for Datadog interceptors."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from temporalio.contrib.datadog._interceptor import DatadogTracingInterceptor
+
+
+class _SpanRunner:  # type: ignore[reportUnusedClass]
+    def __init__(self, root: DatadogTracingInterceptor) -> None:
+        self.root = root
+
+    async def run(
+        self, span: Any, operation_name: str, operation: Awaitable[Any]
+    ) -> Any:
+        operation_exc: BaseException | None = None
+        try:
+            result = await operation
+        except BaseException as exc:
+            operation_exc = exc
+            raise
+        finally:
+            self.root.tracer.finish_span(span, operation_name, operation_exc)
+        return result

--- a/temporalio/contrib/datadog/_workflow_interceptor.py
+++ b/temporalio/contrib/datadog/_workflow_interceptor.py
@@ -1,0 +1,407 @@
+"""Datadog tracing interceptors for Temporal workflow inbound and outbound calls."""
+
+import contextvars
+import logging
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, NoReturn, cast
+
+import temporalio.worker
+import temporalio.workflow
+from temporalio.contrib.datadog._constants import (
+    COMMON_ATTRIBUTE_MAP,
+    OperationNames,
+    SpanAttributes,
+)
+from temporalio.contrib.datadog._id_generator import gen_span_id
+from temporalio.contrib.datadog._propagator import _Propagator
+
+# ContextVar keeps this flag task-local. Sandboxed workflows load
+# non-passthrough modules into a per-instance module namespace; unsandboxed
+# workflow tasks capture their own context.
+_trace_disconnected: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_trace_disconnected", default=False
+)
+
+# Live RunWorkflow span for the current execution, set before user code runs.
+# Never None — RunWorkflow is exempt from the replay guard in span_ctx.
+# Isolated per execution by the same mechanism as _trace_disconnected.
+_active_workflow_span: contextvars.ContextVar[Any] = contextvars.ContextVar(
+    "_active_workflow_span", default=None
+)
+
+# Holds (trace_id, span_id) for the active RunWorkflow span so that the log
+# filter below can inject dd.trace_id / dd.span_id into every workflow.logger
+# call without activating the span (which is unsafe inside the sandbox).
+_current_span_info: contextvars.ContextVar[tuple[str, str] | None] = (
+    contextvars.ContextVar("_current_span_info", default=None)
+)
+
+
+class _DDTraceLogFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        info = _current_span_info.get()
+        if info is not None:
+            record.__dict__["dd.trace_id"] = info[0]
+            record.__dict__["dd.span_id"] = info[1]
+        return True
+
+
+# Each sandbox instance can import this module again; avoid adding the same
+# filter repeatedly to Temporal's shared workflow logger.
+if not getattr(
+    temporalio.workflow.logger.base_logger, "_dd_trace_filter_installed", False
+):
+    temporalio.workflow.logger.base_logger.addFilter(_DDTraceLogFilter())
+    temporalio.workflow.logger.base_logger._dd_trace_filter_installed = True  # type: ignore[attr-defined]
+
+
+@dataclass
+class WorkflowTracingConfig:
+    # Set the relevant flag to suppress signal, query, or update spans while
+    # keeping workflow and activity tracing enabled.
+    disable_signal_tracing: bool
+    disable_query_tracing: bool
+    disable_update_tracing: bool
+
+    @staticmethod
+    def default_config() -> "WorkflowTracingConfig":
+        return WorkflowTracingConfig(
+            disable_signal_tracing=False,
+            disable_query_tracing=False,
+            disable_update_tracing=False,
+        )
+
+
+class DatadogTracingWorkflowInboundInterceptor(
+    temporalio.worker.WorkflowInboundInterceptor
+):
+    def __init__(self, next: temporalio.worker.WorkflowInboundInterceptor) -> None:
+        super().__init__(next)
+        self._span_counter = 1  # Reserve the 1 for the RunWorkflow span
+
+        externs = temporalio.workflow.extern_functions()
+        self._start_span_extern = cast(
+            Callable[
+                [str, str, dict[str, Any], Any | None, str | None, int | None], Any
+            ],
+            externs["__temporal_datadog_start_sandboxed_span"],
+        )
+        self._finish_span_extern = cast(
+            Callable[[str, Any | None, BaseException | None], None],
+            externs["__temporal_datadog_finish_sandboxed_span"],
+        )
+        config_func = cast(
+            Callable[[], tuple[_Propagator, WorkflowTracingConfig]],
+            externs["__temporal_datadog_configure_workflow_tracing"],
+        )
+        self.propagator, self.config = config_func()
+
+    def init(self, outbound: temporalio.worker.WorkflowOutboundInterceptor) -> None:
+        super().init(_WorkflowOutboundInterceptor(outbound, self))
+
+    @contextmanager
+    def span_ctx(
+        self,
+        operation_name: str,
+        resource_name: str,
+        input: Any,
+        idempotency_key: str | None = None,
+        start_time: int | None = None,
+    ) -> Generator[tuple[Any, Any], None, None]:
+        attributes = self._get_span_attributes(input)
+        parent_ctx = self._parent_ctx_for(operation_name, input)
+
+        # Idempotency-keyed HandleSignal and HandleUpdate spans are suppressed
+        # while replaying. RunWorkflow is exempt so a restarted worker recreates
+        # its long-lived span. HandleQuery and ValidateUpdate pass no idempotency
+        # key, so this guard does not suppress them.
+        if (
+            idempotency_key is not None
+            and operation_name != OperationNames.RUN_WORKFLOW
+            and temporalio.workflow.unsafe.is_replaying()
+        ):
+            span = None
+        else:
+            span = self._start_span_extern(
+                operation_name,
+                resource_name,
+                attributes,
+                parent_ctx,
+                idempotency_key,
+                start_time,
+            )
+        exc: BaseException | None = None
+        try:
+            yield input, span
+        except BaseException as e:
+            exc = e
+            raise
+        finally:
+            self._finish_span_extern(operation_name, span, exc)
+
+    def _parent_ctx_for(self, operation_name: str, input: Any) -> Any:
+        # Parent from workflow header
+        if operation_name == OperationNames.RUN_WORKFLOW:
+            return self.propagator.extract_headers(temporalio.workflow.info().headers)
+
+        # Parent from input headers
+        ctx = self.propagator.extract_headers(input.headers)
+        if ctx is not None:
+            return ctx
+
+        # Make RunWorkflow the parent
+        return self.recover_workflow_span()
+
+    def recover_workflow_span(self) -> Any:
+        # Reconstruct the RunWorkflow context from the workflow start headers by
+        # reusing the trace_id from StartWorkflow and overriding the span_id with
+        # RunWorkflow's deterministic ID. Reliable across sandbox task boundaries
+        # because workflow.info().headers is always available.
+        ctx = self.propagator.extract_headers(temporalio.workflow.info().headers)
+        if ctx is not None:
+            ctx.span_id = gen_span_id(self._make_idempotency_key(1))
+            return ctx
+
+        # No start headers (uninstrumented client). Fall back to the live span.
+        span = span_from_workflow_context()
+        return span.context if span is not None else None
+
+    def _get_span_attributes(self, input: Any) -> dict[str, Any]:
+        info = temporalio.workflow.info()
+        attrs: dict[str, Any] = {
+            SpanAttributes.WORKFLOW_ID: info.workflow_id,
+            SpanAttributes.RUN_ID: info.run_id,
+            SpanAttributes.WORKFLOW_TYPE: info.workflow_type,
+        }
+        for field, span_key in COMMON_ATTRIBUTE_MAP:
+            if val := getattr(input, field, None):
+                attrs[span_key] = val
+        if getattr(input, "update", None):
+            attrs[SpanAttributes.UPDATE_NAME] = input.update
+            if getattr(input, "id", None):
+                attrs[SpanAttributes.UPDATE_ID] = input.id
+        if getattr(input, "workflow", None):
+            attrs[SpanAttributes.CHILD_WORKFLOW_TYPE] = input.workflow
+            if getattr(input, "id", None):
+                attrs[SpanAttributes.CHILD_WORKFLOW_ID] = input.id
+        if isinstance(input, temporalio.worker.StartLocalActivityInput):
+            attrs[SpanAttributes.LOCAL] = True
+        return attrs
+
+    def _make_idempotency_key(self, counter: int) -> str:
+        info = temporalio.workflow.info()
+        # Matches the Go SDK's idempotency key
+        return f"WorkflowInboundInterceptor:{info.namespace}:{info.workflow_id}:{info.run_id}:{counter}"
+
+    def _next_idempotency_key(self) -> str:
+        self._span_counter += 1
+        return self._make_idempotency_key(self._span_counter)
+
+    async def execute_workflow(
+        self, input: temporalio.worker.ExecuteWorkflowInput
+    ) -> Any:
+        info = temporalio.workflow.info()
+        with self.span_ctx(
+            OperationNames.RUN_WORKFLOW,
+            info.workflow_type,
+            input,
+            idempotency_key=self._make_idempotency_key(1),
+            start_time=int(info.workflow_start_time.timestamp() * 1e9),
+        ) as (i, span):
+            if span is not None:
+                i.headers = self.propagator.inject_headers(i.headers, span.context)
+                tid = span.context.trace_id
+                # Match ddtrace's format_trace_id: decimal for 64-bit IDs, 32-char hex for 128-bit.
+                formatted_tid = f"{tid:032x}" if tid > (1 << 64) - 1 else str(tid)
+                _current_span_info.set((formatted_tid, str(span.span_id)))
+            _active_workflow_span.set(span)
+            return await super().execute_workflow(i)
+
+    async def handle_signal(self, input: temporalio.worker.HandleSignalInput) -> None:
+        if self.config.disable_signal_tracing:
+            return await super().handle_signal(input)
+        with self.span_ctx(
+            OperationNames.HANDLE_SIGNAL,
+            input.signal,
+            input,
+            self._next_idempotency_key(),
+        ) as (i, _):
+            await super().handle_signal(i)
+
+    async def handle_query(self, input: temporalio.worker.HandleQueryInput) -> Any:
+        if self.config.disable_query_tracing:
+            return await super().handle_query(input)
+        with self.span_ctx(OperationNames.HANDLE_QUERY, input.query, input) as (i, _):
+            return await super().handle_query(i)
+
+    def handle_update_validator(
+        self, input: temporalio.worker.HandleUpdateInput
+    ) -> None:
+        if self.config.disable_update_tracing:
+            return super().handle_update_validator(input)
+        with self.span_ctx(OperationNames.VALIDATE_UPDATE, input.update, input) as (
+            i,
+            _,
+        ):
+            super().handle_update_validator(i)
+
+    async def handle_update_handler(
+        self, input: temporalio.worker.HandleUpdateInput
+    ) -> Any:
+        if self.config.disable_update_tracing:
+            return await super().handle_update_handler(input)
+        with self.span_ctx(
+            OperationNames.HANDLE_UPDATE,
+            input.update,
+            input,
+            self._next_idempotency_key(),
+        ) as (i, _):
+            return await super().handle_update_handler(i)
+
+
+class _WorkflowOutboundInterceptor(temporalio.worker.WorkflowOutboundInterceptor):
+    def __init__(
+        self,
+        next: temporalio.worker.WorkflowOutboundInterceptor,
+        root: DatadogTracingWorkflowInboundInterceptor,
+    ) -> None:
+        super().__init__(next)
+        self.root = root
+
+    def continue_as_new(self, input: temporalio.worker.ContinueAsNewInput) -> NoReturn:
+        if not _trace_disconnected.get():
+            input.headers = self.root.propagator.inject_headers(
+                input.headers, self.root.recover_workflow_span()
+            )
+        super().continue_as_new(input)
+
+    async def signal_child_workflow(
+        self, input: temporalio.worker.SignalChildWorkflowInput
+    ) -> None:
+        if self.root.config.disable_signal_tracing:
+            return await super().signal_child_workflow(input)
+        if temporalio.workflow.unsafe.is_replaying():
+            return await super().signal_child_workflow(input)
+        with self.root.span_ctx(
+            OperationNames.SIGNAL_CHILD_WORKFLOW, input.signal, input
+        ) as (i, span):
+            if span is not None:
+                i.headers = self.root.propagator.inject_headers(i.headers, span.context)
+            await super().signal_child_workflow(i)
+
+    async def signal_external_workflow(
+        self, input: temporalio.worker.SignalExternalWorkflowInput
+    ) -> None:
+        if self.root.config.disable_signal_tracing:
+            return await super().signal_external_workflow(input)
+        if temporalio.workflow.unsafe.is_replaying():
+            return await super().signal_external_workflow(input)
+        with self.root.span_ctx(
+            OperationNames.SIGNAL_EXTERNAL_WORKFLOW, input.signal, input
+        ) as (i, span):
+            if span is not None:
+                i.headers = self.root.propagator.inject_headers(i.headers, span.context)
+            await super().signal_external_workflow(i)
+
+    def start_activity(
+        self, input: temporalio.worker.StartActivityInput
+    ) -> temporalio.workflow.ActivityHandle:
+        if temporalio.workflow.unsafe.is_replaying():
+            return super().start_activity(input)
+        with self.root.span_ctx(
+            OperationNames.START_ACTIVITY, input.activity, input
+        ) as (i, span):
+            if span is not None:
+                i.headers = self.root.propagator.inject_headers(i.headers, span.context)
+            return super().start_activity(i)
+
+    async def start_child_workflow(
+        self, input: temporalio.worker.StartChildWorkflowInput
+    ) -> temporalio.workflow.ChildWorkflowHandle:
+        if temporalio.workflow.unsafe.is_replaying():
+            return await super().start_child_workflow(input)
+        with self.root.span_ctx(
+            OperationNames.START_CHILD_WORKFLOW, input.workflow, input
+        ) as (i, span):
+            if span is not None:
+                i.headers = self.root.propagator.inject_headers(i.headers, span.context)
+            return await super().start_child_workflow(i)
+
+    def start_local_activity(
+        self, input: temporalio.worker.StartLocalActivityInput
+    ) -> temporalio.workflow.ActivityHandle:
+        if temporalio.workflow.unsafe.is_replaying():
+            return super().start_local_activity(input)
+        with self.root.span_ctx(
+            OperationNames.START_ACTIVITY, input.activity, input
+        ) as (i, span):
+            if span is not None:
+                i.headers = self.root.propagator.inject_headers(i.headers, span.context)
+            return super().start_local_activity(i)
+
+    async def start_nexus_operation(
+        self, input: temporalio.worker.StartNexusOperationInput[Any, Any]
+    ) -> temporalio.workflow.NexusOperationHandle[Any]:
+        # Skip Nexus tracing during workflow replay so replay does not emit a
+        # duplicate StartNexusOperation span.
+        if temporalio.workflow.unsafe.is_replaying():
+            return await super().start_nexus_operation(input)
+
+        with self.root.span_ctx(
+            OperationNames.START_NEXUS_OPERATION,
+            f"{input.service}/{input.operation_name}",
+            input,
+        ) as (i, span):
+            if span is not None:
+                # Nexus uses plain string headers, not Temporal payload headers.
+                carrier = self.root.propagator.inject(span.context)
+                i.headers = {**(i.headers or {}), **carrier}
+            return await super().start_nexus_operation(i)
+
+
+def span_from_workflow_context() -> Any:
+    """Return the active RunWorkflow ddtrace span for this execution.
+
+    Always returns a live span, including during replay on a new worker, so
+    custom tags set here survive a worker restart::
+
+        span = span_from_workflow_context()
+        if span is not None:
+            span.set_tag("my.tag", value)
+
+    Python equivalent of the Go SDK's ``SpanFromWorkflowContext``.  Unlike the
+    Go version, which takes a ``workflow.Context`` and can return any
+    operation's span, this always returns the RunWorkflow span.
+    """
+    # NOTE: fork-specific workaround; reconsider if this integration is ever proposed upstream.
+    # Prefer the extern so that the call reaches the host-side ContextVar even
+    # when the workflow sandbox has reimported this module into its own namespace.
+    fn = temporalio.workflow.extern_functions().get(
+        "__temporal_datadog_get_workflow_span"
+    )
+    if fn is not None:
+        return fn()
+    return _active_workflow_span.get()
+
+
+def disconnect_trace_span_from_workflow_context() -> None:
+    """Prevent the current trace from propagating into the next ContinueAsNew execution.
+
+    Call before ``workflow.continue_as_new()``; the next run starts a fresh
+    root span rather than continuing this trace::
+
+        disconnect_trace_span_from_workflow_context()
+        workflow.continue_as_new(count + 1)
+
+    """
+    _trace_disconnected.set(True)
+    # NOTE: fork-specific workaround; reconsider if this integration is ever proposed upstream.
+    # Call through the extern so that the flag is set on the host-side ContextVar
+    # where _WorkflowOutboundInterceptor.continue_as_new reads it.
+    fn = temporalio.workflow.extern_functions().get(
+        "__temporal_datadog_set_trace_disconnected"
+    )
+    if fn is not None:
+        fn()

--- a/temporalio/contrib/datadog/_wrapped_tracer.py
+++ b/temporalio/contrib/datadog/_wrapped_tracer.py
@@ -1,0 +1,148 @@
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import temporalio.activity
+import temporalio.workflow
+from temporalio.contrib.datadog._constants import TEMPORAL_TAG_PREFIX
+
+# ``ddtrace`` is intentionally not imported at module level. ``WrappedTracer``
+# resolves and caches the tracer and Context class in the host process so sandbox
+# extern calls do not import ``ddtrace``.
+
+
+@dataclass(frozen=True)
+class FinishContext:
+    """Context passed to a user-supplied ``on_span_finish`` callback.
+
+    Attributes:
+        operation: The Temporal operation name (e.g. ``"RunWorkflow"``).
+        exception: The exception that caused the span to fail, or ``None``.
+    """
+
+    operation: str
+    exception: BaseException | None
+
+
+@dataclass(frozen=True)
+class FinishResult:
+    """Returned by ``on_span_finish`` to control how a span is finished.
+
+    All fields default to leaving the interceptor's default behavior in place;
+    return ``None`` from the callback (or omit the callback) for the default.
+
+    Attributes:
+        extra_tags: Tags applied to the span before it is finished.
+    """
+
+    extra_tags: Mapping[str, Any] | None = None
+
+
+class WrappedTracer:
+    tracer: Any
+
+    def __init__(
+        self,
+        *,
+        service_name: str | None,
+        tracer: Any,
+        on_span_finish: Callable[[FinishContext], FinishResult | None] | None = None,
+        annotator: Any,
+        propagator: Any,
+    ):
+        if tracer is None:
+            import ddtrace
+
+            tracer = ddtrace.tracer  # type: ignore[reportPrivateImportUsage]
+
+            # Cache Context here so start_span never imports it as an extern call.
+            # Deferred imports inside externs go through the sandbox's restricted
+            # importer and fail with RestrictedWorkflowAccessError.
+            from ddtrace._trace.context import (
+                Context,  # type: ignore[reportPrivateImportUsage]
+            )
+
+            self.ctx_cls: Any = Context
+        else:
+            self.ctx_cls = None
+        self.tracer = tracer
+        self.service_name = service_name
+        self.on_span_finish = on_span_finish
+        self.annotator = annotator
+        self.propagator = propagator
+
+    def start_span(
+        self,
+        *,
+        operation_name: str,
+        parent_ctx: Any,
+        resource_name: str,
+        activate: bool,
+        start_time: Any = None,
+        span_id: int | None = None,
+        attributes: Mapping[str, Any] | None = None,
+        parent_from_header: bool = False,
+        trace_id: int | None = None,
+    ) -> Any:
+        # No DD header (uninstrumented client) the call passes a deterministic trace_id
+        # to keep the RunWorkflow trace consistent if the worker restarts mid-run.
+        # Mutating span.trace_id after creation breaks the tracer's internal trace registry.
+        effective_parent = parent_ctx
+        if trace_id is not None and parent_ctx is None and self.ctx_cls is not None:
+            effective_parent = self.ctx_cls(
+                trace_id=trace_id, span_id=None, is_remote=True
+            )
+        span = self.tracer.start_span(
+            name=f"{TEMPORAL_TAG_PREFIX}{operation_name}",
+            child_of=effective_parent,
+            service=self.service_name,
+            resource=resource_name,
+            activate=activate,
+        )
+        if start_time is not None:
+            span.start_ns = start_time
+        if span_id is not None:
+            span.span_id = span_id
+            if getattr(span, "context", None) is not None:
+                span.context.span_id = span_id
+        force_keep = parent_ctx is None or parent_from_header
+        self.annotator.annotate(
+            span,
+            operation_name,
+            attributes,
+            self.propagator.get_baggage(parent_ctx),
+            force_keep,
+        )
+        self.propagator.set_baggage(span.context)
+        return span
+
+    def finish_span(
+        self,
+        span: Any,
+        operation_name: str,
+        exc: BaseException | None,
+    ) -> None:
+        try:
+            result: FinishResult | None = None
+            if self.on_span_finish is not None:
+                result = self.on_span_finish(
+                    FinishContext(operation=operation_name, exception=exc)
+                )
+
+            if exc and not self._should_skip_error(exc):
+                span.set_exc_info(type(exc), exc, exc.__traceback__)
+
+            if result is not None and result.extra_tags:
+                for key, value in result.extra_tags.items():
+                    span.set_tag(key, value)
+        finally:
+            span.finish()
+
+    def _should_skip_error(self, exc: BaseException | None) -> bool:
+        if exc is None:
+            return True
+        if isinstance(exc, temporalio.workflow.ContinueAsNewError):
+            return True
+        if isinstance(exc, temporalio.activity._CompleteAsyncError):
+            return True
+        return False

--- a/tests/contrib/datadog/_workflows.py
+++ b/tests/contrib/datadog/_workflows.py
@@ -1,0 +1,309 @@
+"""Workflow and activity definitions for Datadog tracing tests.
+
+Kept separate from ``test_tracing.py`` so the workflow sandbox can re-import
+workflow definitions without importing that test module's host-only ``ddtrace``
+setup.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+
+from temporalio import activity, workflow
+from temporalio.common import RetryPolicy
+from temporalio.contrib.datadog import (
+    disconnect_trace_span_from_workflow_context,
+    span_from_workflow_context,
+)
+from temporalio.exceptions import ApplicationError
+
+
+@dataclass
+class TestRequest:
+    use_activity: bool = False
+    use_local_activity: bool = False
+    use_child_workflow: bool = False
+    wait_for_kick: bool = False
+
+
+@activity.defn
+async def echo_activity(value: str) -> str:
+    return value
+
+
+@activity.defn
+async def failing_activity() -> str:
+    raise ApplicationError("boom")
+
+
+@workflow.defn
+class TestWorkflow:
+    def __init__(self) -> None:
+        self._kicked = False
+
+    @workflow.run
+    async def run(self, param: TestRequest) -> str:
+        if param.use_activity:
+            await workflow.execute_activity(
+                echo_activity,
+                "hello",
+                start_to_close_timeout=timedelta(seconds=10),
+                retry_policy=RetryPolicy(maximum_attempts=1),
+            )
+        if param.use_local_activity:
+            await workflow.execute_local_activity(
+                echo_activity,
+                "hello",
+                start_to_close_timeout=timedelta(seconds=10),
+            )
+        if param.use_child_workflow:
+            await workflow.execute_child_workflow(
+                ChildWorkflow.run,
+                "hello",
+                id=f"{workflow.info().workflow_id}-child",
+            )
+        if param.wait_for_kick:
+            await workflow.wait_condition(lambda: self._kicked)
+        return "done"
+
+    @workflow.signal
+    def kick(self) -> None:
+        self._kicked = True
+
+    @workflow.query
+    def get_status(self) -> str:
+        return "running"
+
+
+@workflow.defn
+class UpdateTestWorkflow:
+    def __init__(self) -> None:
+        self._result: str | None = None
+
+    @workflow.run
+    async def run(self) -> str:
+        await workflow.wait_condition(lambda: self._result is not None)
+        return self._result or ""
+
+    @workflow.update
+    async def do_update(self, value: str) -> str:
+        self._result = value
+        return f"updated:{value}"
+
+    @do_update.validator
+    def validate_do_update(self, value: str) -> None:
+        if value == "invalid":
+            raise ApplicationError("invalid value")
+
+
+@workflow.defn
+class ChildWorkflow:
+    @workflow.run
+    async def run(self, value: str) -> str:
+        return f"child:{value}"
+
+
+@workflow.defn
+class WaitingChildWorkflow:
+    def __init__(self) -> None:
+        self._done = False
+
+    @workflow.run
+    async def run(self) -> str:
+        await workflow.wait_condition(lambda: self._done)
+        return "done"
+
+    @workflow.signal
+    def finish(self) -> None:
+        self._done = True
+
+
+@workflow.defn
+class ParentWithSignalChildWorkflow:
+    """Starts a child, signals it via signal_child_workflow, awaits it, then waits for kick."""
+
+    def __init__(self) -> None:
+        self._kicked = False
+
+    @workflow.run
+    async def run(self) -> str:
+        child_handle = await workflow.start_child_workflow(
+            WaitingChildWorkflow.run,
+            id=f"{workflow.info().workflow_id}-child",
+        )
+        await child_handle.signal(WaitingChildWorkflow.finish)
+        await child_handle
+        await workflow.wait_condition(lambda: self._kicked)
+        return "done"
+
+    @workflow.signal
+    def kick(self) -> None:
+        self._kicked = True
+
+    @workflow.query
+    def get_status(self) -> str:
+        return "running"
+
+
+@workflow.defn
+class ParentWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        return await workflow.execute_child_workflow(
+            ChildWorkflow.run,
+            "hello",
+            id=f"{workflow.info().workflow_id}-child",
+        )
+
+
+@workflow.defn
+class LocalActivityWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        return await workflow.execute_local_activity(
+            echo_activity,
+            "hello",
+            start_to_close_timeout=timedelta(seconds=10),
+        )
+
+
+@workflow.defn
+class FailingWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        return await workflow.execute_activity(
+            failing_activity,
+            start_to_close_timeout=timedelta(seconds=10),
+            retry_policy=RetryPolicy(maximum_attempts=1),
+        )
+
+
+@workflow.defn
+class ContinueAsNewWorkflow:
+    @workflow.run
+    async def run(self, iteration: int = 0) -> str:
+        if iteration == 0:
+            workflow.continue_as_new(1)
+        return "done"
+
+
+@workflow.defn
+class DisconnectedContinueAsNewWorkflow:
+    @workflow.run
+    async def run(self, iteration: int = 0) -> str:
+        if iteration == 0:
+            disconnect_trace_span_from_workflow_context()
+            workflow.continue_as_new(1)
+        return "done"
+
+
+@workflow.defn
+class CustomTagWorkflow:
+    def __init__(self) -> None:
+        self._kicked = False
+
+    @workflow.run
+    async def run(self, wait_for_kick: bool = False) -> str:
+        span = span_from_workflow_context()
+        if span is not None:
+            span.set_tag("custom.workflow.tag", "hello-from-workflow")
+        if wait_for_kick:
+            await workflow.wait_condition(lambda: self._kicked)
+        return "done"
+
+    @workflow.signal
+    def kick(self) -> None:
+        self._kicked = True
+
+    @workflow.query
+    def get_status(self) -> str:
+        return "running"
+
+
+@workflow.defn
+class DirectlyFailingWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        raise ApplicationError("workflow failed directly")
+
+
+@activity.defn
+async def logging_activity() -> str:
+    activity.logger.info("test log message from activity")
+    return "done"
+
+
+@activity.defn
+async def custom_span_activity() -> tuple[int | None, int | None]:
+    """Create a custom ddtrace span and return its (parent_id, trace_id).
+
+    Uses tracer.trace() which auto-parents from the active context span.
+    """
+    import ddtrace
+
+    child = ddtrace.tracer.trace("custom.span")  # type: ignore[reportPrivateImportUsage]
+    try:
+        return (child.parent_id, child.trace_id)
+    finally:
+        child.finish()
+
+
+@workflow.defn
+class LoggingWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        workflow.logger.info("test log message from workflow")
+        return "done"
+
+
+@workflow.defn
+class CustomSpanActivityWorkflow:
+    @workflow.run
+    async def run(self) -> tuple[int | None, int | None]:
+        return await workflow.execute_activity(
+            custom_span_activity,
+            start_to_close_timeout=timedelta(seconds=10),
+            retry_policy=RetryPolicy(maximum_attempts=1),
+        )
+
+
+@workflow.defn
+class LoggingActivityWorkflow:
+    @workflow.run
+    async def run(self) -> str:
+        return await workflow.execute_activity(
+            logging_activity,
+            start_to_close_timeout=timedelta(seconds=10),
+            retry_policy=RetryPolicy(maximum_attempts=1),
+        )
+
+
+@workflow.defn
+class ConcurrentLoggingWorkflow:
+    """Logs before and after a signal barrier so two instances provably overlap.
+
+    The test starts both workflows, waits until both have logged "start:<label>"
+    (confirmed via is_started()), then signals both to proceed.  This guarantees
+    they are in-flight at the same time before the second log is emitted.
+    """
+
+    def __init__(self) -> None:
+        self._proceed = False
+        self._started = False
+
+    @workflow.run
+    async def run(self, label: str) -> str:
+        self._started = True
+        workflow.logger.info(f"start:{label}")
+        await workflow.wait_condition(lambda: self._proceed)
+        workflow.logger.info(f"end:{label}")
+        return "done"
+
+    @workflow.signal
+    def proceed(self) -> None:
+        self._proceed = True
+
+    @workflow.query
+    def is_started(self) -> bool:
+        return self._started

--- a/tests/contrib/datadog/conftest.py
+++ b/tests/contrib/datadog/conftest.py
@@ -1,0 +1,109 @@
+"""Shared test helpers for Datadog tracing interceptor tests.
+
+The ``event_loop``, ``env``, and ``client`` fixtures used here come from the
+top-level ``tests/conftest.py``.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from typing import Any
+
+import pytest
+from ddtrace.internal.writer.writer import TraceWriter
+from ddtrace.trace import tracer as _dd_tracer
+
+from temporalio.client import Client
+from temporalio.contrib.datadog import DatadogTracingInterceptor
+
+
+class _SpanCollector(TraceWriter):
+    """Minimal ddtrace-compatible writer that captures emitted span batches in memory.
+
+    Installed as the span aggregator's writer, it records spans that the aggregator
+    flushes without forwarding them to a Datadog agent.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._spans: list[Any] = []
+
+    def write(self, spans: list[Any] | None = None) -> None:
+        if spans:
+            with self._lock:
+                self._spans.extend(spans)
+
+    def flush_queue(self) -> None:
+        pass
+
+    def stop(self, timeout: float | None = None) -> None:
+        pass
+
+    def recreate(
+        self, appsec_enabled: bool | None = None, llmobs_enabled: bool | None = None
+    ) -> _SpanCollector:
+        return self
+
+    @property
+    def spans(self) -> list[Any]:
+        with self._lock:
+            return list(self._spans)
+
+    def by_op(self, op: str) -> list[Any]:
+        target = f"temporal.{op}"
+        return [s for s in self.spans if s.name == target]
+
+    def one(self, op: str) -> Any:
+        found = self.by_op(op)
+        assert len(found) == 1, (
+            f"Expected exactly 1 '{op}' span, got {len(found)}: {[s.name for s in found]}"
+        )
+        return found[0]
+
+    def tag(self, span: Any, key: str) -> Any:
+        """Get a Temporal-namespaced tag or metric from a span.
+
+        ddtrace stores integer/float values as *metrics* rather than string
+        tags, so this helper checks both storages and returns whichever is set.
+        """
+        if not key.startswith("temporal."):
+            key = "temporal." + key
+        value = span.get_tag(key)
+        if value is None:
+            value = span.get_metric(key)
+        return value
+
+
+@pytest.fixture
+def span_collector() -> Any:
+    """Replace the global ddtrace writer with an in-memory collector."""
+    collector = _SpanCollector()
+    orig = _dd_tracer._span_aggregator.writer
+    _dd_tracer._span_aggregator.writer = collector
+    yield collector
+    _dd_tracer._span_aggregator.writer = orig
+
+
+def _make_interceptor(  # type: ignore[reportUnusedFunction]
+    **kwargs: Any,
+) -> DatadogTracingInterceptor:
+    return DatadogTracingInterceptor(service_name="test-svc", **kwargs)
+
+
+def _traced_client(  # type: ignore[reportUnusedFunction]
+    client: Client, interceptor: DatadogTracingInterceptor
+) -> Client:
+    """Return a new client that carries the Datadog interceptor.
+
+    The Temporal Worker automatically merges client interceptors into its own
+    list, so registering the interceptor only on the client avoids
+    double-registration in the worker interceptor chain.
+    """
+    cfg = client.config()
+    cfg["interceptors"] = [interceptor]
+    return Client(**cfg)
+
+
+def _task_queue() -> str:  # type: ignore[reportUnusedFunction]
+    return f"dd-test-{uuid.uuid4()}"

--- a/tests/contrib/datadog/test_datadog.py
+++ b/tests/contrib/datadog/test_datadog.py
@@ -1,0 +1,2177 @@
+"""Tests for the Datadog tracing interceptor."""
+
+import asyncio
+import logging
+import uuid
+from typing import Any
+
+import pytest
+from ddtrace.internal.utils.formats import format_trace_id
+from ddtrace.trace import tracer as _dd_tracer
+
+import temporalio.client
+import temporalio.common
+import temporalio.converter
+from temporalio.client import Client
+from temporalio.contrib.datadog import (
+    DatadogTracingInterceptor,
+    FinishContext,
+    FinishResult,
+)
+from temporalio.contrib.datadog._id_generator import gen_span_id, gen_trace_id
+from temporalio.contrib.datadog._workflow_interceptor import WorkflowTracingConfig
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+from tests.contrib.datadog._workflows import (
+    ChildWorkflow,
+    ConcurrentLoggingWorkflow,
+    ContinueAsNewWorkflow,
+    CustomSpanActivityWorkflow,
+    CustomTagWorkflow,
+    DirectlyFailingWorkflow,
+    DisconnectedContinueAsNewWorkflow,
+    FailingWorkflow,
+    LocalActivityWorkflow,
+    LoggingActivityWorkflow,
+    LoggingWorkflow,
+    ParentWithSignalChildWorkflow,
+    ParentWorkflow,
+    TestRequest,
+    TestWorkflow,
+    UpdateTestWorkflow,
+    WaitingChildWorkflow,
+    custom_span_activity,
+    echo_activity,
+    failing_activity,
+    logging_activity,
+)
+from tests.contrib.datadog.conftest import (
+    _make_interceptor,
+    _SpanCollector,
+    _task_queue,
+    _traced_client,
+)
+from tests.helpers import LogCapturer
+
+
+@pytest.mark.asyncio
+async def test_workflow_spans(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """StartWorkflow and RunWorkflow spans are created with correct names and tags."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        wf_id = f"wf-{uuid.uuid4()}"
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(use_activity=False),
+            id=wf_id,
+            task_queue=tq,
+        )
+        await handle.result()
+
+    start = span_collector.one("StartWorkflow")
+    run = span_collector.one("RunWorkflow")
+
+    assert start.resource == "TestWorkflow"
+    assert run.resource == "TestWorkflow"
+
+    # StartWorkflow is the trace root; RunWorkflow is its child.
+    assert start.parent_id is None
+    assert run.parent_id == start.span_id
+    assert run.trace_id == start.trace_id
+
+    # Tags on StartWorkflow
+    assert span_collector.tag(start, "WorkflowID") == wf_id
+    assert start.get_tag("span.kind") == "producer"
+
+    # Tags on RunWorkflow
+    assert span_collector.tag(run, "WorkflowID") == wf_id
+    assert span_collector.tag(run, "WorkflowType") == "TestWorkflow"
+    assert run.get_tag("span.kind") == "consumer"
+
+
+@pytest.mark.asyncio
+async def test_activity_spans(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """StartActivity and RunActivity spans are created with correct tags."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(use_activity=True),
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await handle.result()
+
+    start_act = span_collector.one("StartActivity")
+    run_act = span_collector.one("RunActivity")
+
+    assert start_act.resource == "echo_activity"
+    assert run_act.resource == "echo_activity"
+
+    # Activity inbound span is a child of the outbound span.
+    assert run_act.parent_id == start_act.span_id
+
+    # RunActivity carries activity-specific tags.
+    assert span_collector.tag(run_act, "ActivityType") == "echo_activity"
+    assert span_collector.tag(run_act, "Attempt") is not None
+    assert span_collector.tag(run_act, "ActivityID") is not None
+    assert run_act.get_tag("span.kind") == "consumer"
+
+    # The RunActivity span_id is deterministically derived from the idempotency key.
+    run_id = span_collector.tag(run_act, "RunID")
+    act_id = span_collector.tag(run_act, "ActivityID")
+    attempt = span_collector.tag(run_act, "Attempt")
+    expected_id = gen_span_id(f"{run_id}:{act_id}:{attempt}")
+    assert run_act.span_id == expected_id
+
+
+@pytest.mark.asyncio
+async def test_uninstrumented_client_spans(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """Outbound spans are children of RunWorkflow when no DD header is present.
+
+    Simulates a workflow started from an uninstrumented client (Temporal UI,
+    scheduler, uninstrumented service) — no dd_trace_span in workflow headers.
+    StartActivity must still be a child of RunWorkflow, not an independent root.
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tq = _task_queue()
+
+    # Use the plain client to start the workflow — no DD header injected.
+    # Pass the interceptor only to the Worker so RunWorkflow/StartActivity
+    # spans are created on the worker side without a propagated trace root.
+    async with Worker(
+        client,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+        interceptors=[interceptor],
+    ):
+        handle = await client.start_workflow(
+            TestWorkflow.run,
+            TestRequest(use_activity=True),
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await handle.result()
+
+    run = span_collector.one("RunWorkflow")
+    start_act = span_collector.one("StartActivity")
+
+    # StartActivity must be in the same trace as RunWorkflow.
+    assert start_act.trace_id == run.trace_id, (
+        "StartActivity started an independent trace instead of being a child of RunWorkflow"
+    )
+    # StartActivity must be a direct child of RunWorkflow.
+    assert start_act.parent_id == run.span_id, (
+        f"StartActivity.parent_id={start_act.parent_id} does not match RunWorkflow.span_id={run.span_id}"
+    )
+    # RunWorkflow is a trace root (no incoming DD header).
+    assert run.parent_id is None
+
+
+@pytest.mark.asyncio
+async def test_uninstrumented_client_trace_id_stable_across_worker_restart(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """RunWorkflow trace_id is deterministic and stable across worker restarts
+    when no DD header is present (uninstrumented client).
+
+    Without a propagated trace_id, each worker restart would normally generate
+    a fresh random trace_id, breaking APM correlation.  The interceptor instead
+    derives a deterministic trace_id from the idempotency key so both workers
+    produce the same value.
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tq = _task_queue()
+    wf_id = f"wf-{uuid.uuid4()}"
+
+    # First worker: start the workflow (no DD header — plain client) and wait
+    # until it is blocked on wait_condition so the RunWorkflow span is live.
+    async with Worker(
+        client,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+        interceptors=[interceptor],
+    ):
+        handle = await client.start_workflow(
+            TestWorkflow.run,
+            TestRequest(wait_for_kick=True),
+            id=wf_id,
+            task_queue=tq,
+        )
+        for _ in range(50):
+            try:
+                await handle.query(TestWorkflow.get_status)
+                break
+            except Exception:
+                await asyncio.sleep(0.05)
+
+    # Simulate process restart: discard the first worker's in-flight span.
+    _dd_tracer._span_aggregator._traces.clear()
+
+    # Second worker: replay history and complete the workflow.
+    async with Worker(
+        client,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+        interceptors=[interceptor],
+    ):
+        await handle.signal(TestWorkflow.kick)
+        await handle.result()
+
+    run = span_collector.one("RunWorkflow")
+
+    run_id = handle.first_execution_run_id or ""
+    key = f"WorkflowInboundInterceptor:default:{wf_id}:{run_id}:1"
+    expected_trace_id = gen_trace_id(key)
+
+    assert run.trace_id == expected_trace_id, (
+        f"RunWorkflow trace_id {run.trace_id} does not match expected deterministic "
+        f"value {expected_trace_id} for key {key!r} — trace_id is not stable across worker restarts"
+    )
+    assert run.parent_id is None, (
+        "RunWorkflow must be a trace root when started without a DD header"
+    )
+
+
+@pytest.mark.asyncio
+async def test_signal_spans(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """SignalWorkflow (client) and HandleSignal (worker) spans are created."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(wait_for_kick=True),
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await tc.get_workflow_handle(handle.id).signal(TestWorkflow.kick)
+        await handle.result()
+
+    sig_client = span_collector.one("SignalWorkflow")
+    sig_worker = span_collector.one("HandleSignal")
+
+    assert sig_client.resource == "kick"
+    assert sig_worker.resource == "kick"
+    assert sig_client.get_tag("span.kind") == "producer"
+    assert sig_worker.get_tag("span.kind") == "consumer"
+    assert sig_worker.parent_id == sig_client.span_id, (
+        "HandleSignal must be a child of SignalWorkflow, not RunWorkflow"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handler_spans_fall_back_to_run_workflow_when_no_trace_header(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """Handler spans parent under RunWorkflow when the operation carries no trace header.
+
+    Simulates an uninstrumented client sending a signal — no dd_trace_span in
+    the signal headers.  HandleSignal must still be in the same trace and must
+    be a child of RunWorkflow rather than an independent root.
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(wait_for_kick=True),
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        # Send the signal from the plain (uninstrumented) client — no DD headers injected.
+        await client.get_workflow_handle(handle.id).signal(TestWorkflow.kick)
+        await handle.result()
+
+    run = span_collector.one("RunWorkflow")
+    sig_worker = span_collector.one("HandleSignal")
+
+    assert span_collector.by_op("SignalWorkflow") == [], (
+        "Uninstrumented client must not produce a SignalWorkflow span"
+    )
+    assert sig_worker.trace_id == run.trace_id
+    assert sig_worker.parent_id == run.span_id, (
+        "HandleSignal must fall back to RunWorkflow as parent when signal carries no trace header"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_query_falls_back_to_run_workflow_when_no_trace_header(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """HandleQuery parents under RunWorkflow when the query carries no trace header."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(wait_for_kick=True),
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        # Query from the plain (uninstrumented) client — no DD headers injected.
+        await client.get_workflow_handle(handle.id).query(TestWorkflow.get_status)
+        await client.get_workflow_handle(handle.id).signal(TestWorkflow.kick)
+        await handle.result()
+
+    run = span_collector.one("RunWorkflow")
+    q_worker = span_collector.one("HandleQuery")
+
+    assert span_collector.by_op("QueryWorkflow") == [], (
+        "Uninstrumented client must not produce a QueryWorkflow span"
+    )
+    assert q_worker.trace_id == run.trace_id
+    assert q_worker.parent_id == run.span_id, (
+        "HandleQuery must fall back to RunWorkflow as parent when query carries no trace header"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_update_falls_back_to_run_workflow_when_no_trace_header(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """HandleUpdate and ValidateUpdate parent under RunWorkflow when the update carries no trace header."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[UpdateTestWorkflow],
+    ):
+        handle = await tc.start_workflow(
+            UpdateTestWorkflow.run,
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        # Update from the plain (uninstrumented) client — no DD headers injected.
+        await client.get_workflow_handle(handle.id).execute_update(
+            UpdateTestWorkflow.do_update, "hello"
+        )
+        await handle.result()
+
+    run = span_collector.one("RunWorkflow")
+    validate = span_collector.one("ValidateUpdate")
+    handle_upd = span_collector.one("HandleUpdate")
+
+    assert span_collector.by_op("UpdateWorkflow") == [], (
+        "Uninstrumented client must not produce an UpdateWorkflow span"
+    )
+    assert validate.trace_id == run.trace_id
+    assert validate.parent_id == run.span_id, (
+        "ValidateUpdate must fall back to RunWorkflow as parent when update carries no trace header"
+    )
+    assert handle_upd.trace_id == run.trace_id
+    assert handle_upd.parent_id == run.span_id, (
+        "HandleUpdate must fall back to RunWorkflow as parent when update carries no trace header"
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_spans(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """QueryWorkflow (client) and HandleQuery (worker) spans are created."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(wait_for_kick=True),
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        result = await tc.get_workflow_handle(handle.id).query(TestWorkflow.get_status)
+        assert result == "running"
+        await tc.get_workflow_handle(handle.id).signal(TestWorkflow.kick)
+        await handle.result()
+
+    q_client = span_collector.one("QueryWorkflow")
+    q_worker = span_collector.one("HandleQuery")
+
+    assert q_client.resource == "get_status"
+    assert q_worker.resource == "get_status"
+    assert q_client.get_tag("span.kind") == "producer"
+    assert q_worker.get_tag("span.kind") == "consumer"
+    assert q_worker.parent_id == q_client.span_id, (
+        "HandleQuery must be a child of QueryWorkflow, not RunWorkflow"
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_spans(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """UpdateWorkflow, ValidateUpdate, and HandleUpdate spans are created.
+
+    The worker-side update spans carry the updateID tag.
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    update_id = f"upd-{uuid.uuid4()}"
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[UpdateTestWorkflow],
+    ):
+        handle = await tc.start_workflow(
+            UpdateTestWorkflow.run,
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await handle.execute_update(
+            UpdateTestWorkflow.do_update,
+            "hello",
+            id=update_id,
+        )
+        await handle.result()
+
+    upd_client = span_collector.one("UpdateWorkflow")
+    validate = span_collector.one("ValidateUpdate")
+    handle_upd = span_collector.one("HandleUpdate")
+
+    assert upd_client.resource == "do_update"
+    assert validate.resource == "do_update"
+    assert handle_upd.resource == "do_update"
+
+    # Client span carries the update_id.
+    assert span_collector.tag(upd_client, "UpdateID") == update_id
+
+    # Worker spans also carry the update_id.
+    assert span_collector.tag(validate, "UpdateID") == update_id
+    assert span_collector.tag(handle_upd, "UpdateID") == update_id
+
+    assert upd_client.get_tag("span.kind") == "producer"
+    assert validate.get_tag("span.kind") == "consumer"
+    assert handle_upd.get_tag("span.kind") == "consumer"
+
+    assert validate.parent_id == upd_client.span_id, (
+        "ValidateUpdate must be a child of UpdateWorkflow, not RunWorkflow"
+    )
+    assert handle_upd.parent_id == upd_client.span_id, (
+        "HandleUpdate must be a child of UpdateWorkflow, not RunWorkflow"
+    )
+
+    # Verify that the update.id is the update request ID, not a child workflow ID.
+    assert span_collector.tag(validate, "ChildWorkflowID") is None
+    assert span_collector.tag(handle_upd, "ChildWorkflowID") is None
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_span_id_is_deterministic(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """RunWorkflow span_id is derived from the FNV-64 idempotency key."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(use_activity=False),
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await handle.result()
+
+    run = span_collector.one("RunWorkflow")
+
+    # Counter starts at 1; RunWorkflow is always the first span.
+    namespace = span_collector.tag(run, "Namespace") or "default"
+    wf_id = span_collector.tag(run, "WorkflowID") or ""
+    run_id = span_collector.tag(run, "RunID") or ""
+    key = f"WorkflowInboundInterceptor:{namespace}:{wf_id}:{run_id}:1"
+    assert run.span_id == gen_span_id(key)
+
+
+@pytest.mark.asyncio
+async def test_handle_signal_span_id_is_deterministic(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """HandleSignal span_id is derived from the FNV-64 idempotency key.
+
+    The exact counter depends on task ordering (a signal that arrives in the
+    same task as the workflow start may be processed before execute_workflow),
+    so we verify that the span_id matches the hash for *some* valid counter
+    rather than hard-coding counter=2.
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(wait_for_kick=True),
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await tc.get_workflow_handle(handle.id).signal(TestWorkflow.kick)
+        await handle.result()
+
+    sig = span_collector.one("HandleSignal")
+
+    namespace = span_collector.tag(sig, "Namespace") or "default"
+    wf_id = span_collector.tag(sig, "WorkflowID") or ""
+    run_id = span_collector.tag(sig, "RunID") or ""
+
+    # Verify the span_id matches one of the first few counter values.
+    valid_ids = {
+        gen_span_id(f"WorkflowInboundInterceptor:{namespace}:{wf_id}:{run_id}:{n}")
+        for n in range(1, 5)
+    }
+    assert sig.span_id in valid_ids, (
+        f"HandleSignal span_id {sig.span_id} does not match any expected deterministic value (tried counters 1-4)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_failing_activity_marks_span_as_error(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """A failing activity records an error on the RunActivity span."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[FailingWorkflow],
+        activities=[failing_activity],
+    ):
+        handle = await tc.start_workflow(
+            FailingWorkflow.run,
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        with pytest.raises(Exception):
+            await handle.result()
+
+    run_act = span_collector.one("RunActivity")
+    assert run_act.error == 1, "Expected RunActivity span to be marked as error"
+
+
+@pytest.mark.asyncio
+async def test_extra_tags(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """Custom extra_tags are applied to every span."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = DatadogTracingInterceptor(
+        service_name="test-svc",
+        extra_tags={"deployment.environment": "test", "team": "platform"},
+    )
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(use_activity=False),
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await handle.result()
+
+    run = span_collector.one("RunWorkflow")
+    assert run.get_tag("deployment.environment") == "test"
+    assert run.get_tag("team") == "platform"
+
+
+@pytest.mark.asyncio
+async def test_disable_signal_tracing(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """When disable_signal_tracing=True, no signal spans are created."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    config = WorkflowTracingConfig(
+        disable_signal_tracing=True,
+        disable_query_tracing=False,
+        disable_update_tracing=False,
+    )
+    interceptor = _make_interceptor(workflow_tracing_config=config)
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(wait_for_kick=True),
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await tc.get_workflow_handle(handle.id).signal(TestWorkflow.kick)
+        await handle.result()
+
+    assert span_collector.by_op("SignalWorkflow") == [], (
+        "Expected no SignalWorkflow span when signal tracing is disabled"
+    )
+    assert span_collector.by_op("HandleSignal") == [], (
+        "Expected no HandleSignal span when signal tracing is disabled"
+    )
+    # RunWorkflow should still appear.
+    span_collector.one("RunWorkflow")
+
+
+@pytest.mark.asyncio
+async def test_disable_query_tracing(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """When disable_query_tracing=True, no query spans are created."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    config = WorkflowTracingConfig(
+        disable_signal_tracing=False,
+        disable_query_tracing=True,
+        disable_update_tracing=False,
+    )
+    interceptor = _make_interceptor(workflow_tracing_config=config)
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(wait_for_kick=True),
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await tc.get_workflow_handle(handle.id).query(TestWorkflow.get_status)
+        await tc.get_workflow_handle(handle.id).signal(TestWorkflow.kick)
+        await handle.result()
+
+    assert span_collector.by_op("QueryWorkflow") == [], (
+        "Expected no QueryWorkflow span when query tracing is disabled"
+    )
+    assert span_collector.by_op("HandleQuery") == [], (
+        "Expected no HandleQuery span when query tracing is disabled"
+    )
+
+
+@pytest.mark.asyncio
+async def test_disable_update_tracing(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """When disable_update_tracing=True, no update spans are created."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    config = WorkflowTracingConfig(
+        disable_signal_tracing=False,
+        disable_query_tracing=False,
+        disable_update_tracing=True,
+    )
+    interceptor = _make_interceptor(workflow_tracing_config=config)
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[UpdateTestWorkflow],
+    ):
+        handle = await tc.start_workflow(
+            UpdateTestWorkflow.run,
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await handle.execute_update(UpdateTestWorkflow.do_update, "hi")
+        await handle.result()
+
+    assert span_collector.by_op("UpdateWorkflow") == [], (
+        "Expected no UpdateWorkflow span when update tracing is disabled"
+    )
+    assert span_collector.by_op("ValidateUpdate") == [], (
+        "Expected no ValidateUpdate span when update tracing is disabled"
+    )
+    assert span_collector.by_op("HandleUpdate") == [], (
+        "Expected no HandleUpdate span when update tracing is disabled"
+    )
+
+
+@pytest.mark.asyncio
+async def test_disable_update_tracing_still_propagates_into_new_workflow(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """With disable_update_tracing=True, update-with-start still injects the
+    active trace into the new workflow's start headers.
+
+    Without the fix the early return in start_update_with_start_workflow skips
+    header injection entirely, so RunWorkflow has no parent even when there is
+    an active caller trace.
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    config = WorkflowTracingConfig(
+        disable_signal_tracing=False,
+        disable_query_tracing=False,
+        disable_update_tracing=True,
+    )
+    interceptor = _make_interceptor(workflow_tracing_config=config)
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(tc, task_queue=tq, workflows=[UpdateTestWorkflow]):
+        with _dd_tracer.trace("caller") as caller_span:
+            start_op = temporalio.client.WithStartWorkflowOperation(
+                UpdateTestWorkflow.run,
+                id=f"wf-{uuid.uuid4()}",
+                task_queue=tq,
+                id_conflict_policy=temporalio.common.WorkflowIDConflictPolicy.FAIL,
+            )
+            await tc.execute_update_with_start_workflow(
+                UpdateTestWorkflow.do_update,
+                "hello",
+                start_workflow_operation=start_op,
+            )
+            await (await start_op.workflow_handle()).result()
+
+    run = span_collector.one("RunWorkflow")
+
+    # No UpdateWithStart span should exist — update tracing is disabled.
+    assert span_collector.by_op("UpdateWithStartWorkflow") == [], (
+        "Expected no UpdateWithStartWorkflow span when update tracing is disabled"
+    )
+    # RunWorkflow must still be a child of the active caller span, not a root.
+    assert run.trace_id == caller_span.trace_id, (
+        "RunWorkflow started an independent trace even though a caller span was active"
+    )
+    assert run.parent_id == caller_span.span_id, (
+        f"RunWorkflow.parent_id={run.parent_id} does not match caller span_id={caller_span.span_id}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_span_kind_tags(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """Every span carries the correct span.kind tag (producer / consumer)."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(use_activity=True),
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await handle.result()
+
+    expected = {
+        "StartWorkflow": "producer",
+        "RunWorkflow": "consumer",
+        "StartActivity": "producer",
+        "RunActivity": "consumer",
+    }
+    for op, kind in expected.items():
+        spans = span_collector.by_op(op)
+        assert spans, f"Expected at least one '{op}' span"
+        assert spans[0].get_tag("span.kind") == kind, (
+            f"Expected span.kind={kind!r} for {op}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_baggage_service_name_same_service(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """set_baggage propagates the service name through headers.
+
+    When client and worker share the same service name the consumer spans must
+    NOT carry a peer.service tag (the annotator only sets it when the parent
+    service differs from the current one).
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()  # service_name="test-svc" for both sides
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(use_activity=True),
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await handle.result()
+
+    for span in span_collector.spans:
+        assert span.context.get_baggage_item("servicename") == "test-svc", (
+            f"Expected servicename baggage on span {span.name}"
+        )
+
+    run_wf = span_collector.one("RunWorkflow")
+    run_act = span_collector.one("RunActivity")
+    assert run_wf.get_tag("peer.service") is None
+    assert run_act.get_tag("peer.service") is None
+
+
+@pytest.mark.asyncio
+async def test_baggage_peer_service_cross_service(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """peer.service is set on consumer spans when client and worker differ.
+
+    The client interceptor injects its service name into baggage via
+    set_baggage. The worker interceptor reads it via get_baggage and the
+    annotator sets peer.service when it differs from the worker service name.
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    client_interceptor = DatadogTracingInterceptor(service_name="client-svc")
+    worker_interceptor = DatadogTracingInterceptor(service_name="worker-svc")
+    tc_client = _traced_client(client, client_interceptor)
+    tc_worker = _traced_client(client, worker_interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc_worker,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc_client.start_workflow(
+            TestWorkflow.run,
+            TestRequest(use_activity=True),
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await handle.result()
+
+    start_wf = span_collector.one("StartWorkflow")
+    run_wf = span_collector.one("RunWorkflow")
+    run_act = span_collector.one("RunActivity")
+
+    assert start_wf.context.get_baggage_item("servicename") == "client-svc"
+    # RunWorkflow's parent is StartWorkflow (client-svc) → peer.service is set.
+    assert run_wf.get_tag("peer.service") == "client-svc"
+    # RunActivity's parent is StartActivity (also worker-svc) → no peer.service.
+    assert run_act.get_tag("peer.service") is None
+
+
+@pytest.mark.asyncio
+async def test_trace_context_propagation(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """Trace context is propagated through Temporal headers across all boundaries.
+
+    All spans for a single workflow execution must share one trace_id, and the
+    parent-child chain must be unbroken:
+      StartWorkflow → RunWorkflow → StartActivity → RunActivity
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(use_activity=True),
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await handle.result()
+
+    start_wf = span_collector.one("StartWorkflow")
+    run_wf = span_collector.one("RunWorkflow")
+    start_act = span_collector.one("StartActivity")
+    run_act = span_collector.one("RunActivity")
+
+    trace_id = start_wf.trace_id
+    assert trace_id is not None
+
+    # Every span belongs to the same trace.
+    assert run_wf.trace_id == trace_id
+    assert start_act.trace_id == trace_id
+    assert run_act.trace_id == trace_id
+
+    # Parent-child chain is intact across the header boundary.
+    assert run_wf.parent_id == start_wf.span_id  # client → worker (workflow headers)
+    assert (
+        start_act.parent_id == run_wf.span_id
+    )  # workflow outbound → activity scheduled
+    assert run_act.parent_id == start_act.span_id  # activity headers → activity worker
+
+
+@pytest.mark.asyncio
+async def test_child_workflow_spans(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """Child workflow spans form a continuous chain from the parent trace.
+
+    StartChildWorkflow is a child of the parent RunWorkflow. The child's own
+    RunWorkflow is a child of StartChildWorkflow, keeping everything in one trace:
+      StartWorkflow → RunWorkflow(parent) → StartChildWorkflow → RunWorkflow(child)
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[ParentWorkflow, ChildWorkflow],
+    ):
+        handle = await tc.start_workflow(
+            ParentWorkflow.run,
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await handle.result()
+
+    start_wf = span_collector.one("StartWorkflow")
+    start_child = span_collector.one("StartChildWorkflow")
+    run_wfs = span_collector.by_op("RunWorkflow")
+    assert len(run_wfs) == 2, f"Expected 2 RunWorkflow spans, got {len(run_wfs)}"
+    run_parent = next(s for s in run_wfs if s.resource == "ParentWorkflow")
+    run_child = next(s for s in run_wfs if s.resource == "ChildWorkflow")
+
+    trace_id = start_wf.trace_id
+    assert start_child.trace_id == trace_id
+    assert run_parent.trace_id == trace_id
+    assert run_child.trace_id == trace_id
+
+    assert (
+        run_parent.parent_id == start_wf.span_id
+    )  # workflow headers → RunWorkflow(parent)
+    assert (
+        start_child.parent_id == run_parent.span_id
+    )  # parent RunWorkflow → StartChildWorkflow
+    assert (
+        run_child.parent_id == start_child.span_id
+    )  # child workflow headers → RunWorkflow(child)
+
+    assert start_child.resource == "ChildWorkflow"
+    assert start_child.get_tag("span.kind") == "producer"
+    assert run_child.get_tag("span.kind") == "consumer"
+
+
+@pytest.mark.asyncio
+async def test_failing_workflow_marks_span_as_error(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """A workflow that raises records an error on the RunWorkflow span."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[DirectlyFailingWorkflow],
+    ):
+        handle = await tc.start_workflow(
+            DirectlyFailingWorkflow.run,
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        with pytest.raises(Exception):
+            await handle.result()
+
+    run_wf = span_collector.one("RunWorkflow")
+    assert run_wf.error == 1, "Expected RunWorkflow span to be marked as error"
+    assert run_wf.get_tag("error.type") is not None
+
+
+@pytest.mark.asyncio
+async def test_continue_as_new(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """ContinueAsNew sets the continued_as_new tag and does not mark the span as error."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[ContinueAsNewWorkflow],
+    ):
+        handle = await tc.start_workflow(
+            ContinueAsNewWorkflow.run,
+            0,
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await handle.result()
+
+    run_wfs = span_collector.by_op("RunWorkflow")
+    assert len(run_wfs) == 2, (
+        f"Expected 2 RunWorkflow spans (one per run), got {len(run_wfs)}"
+    )
+
+    continued = next(s for s in run_wfs if s.get_tag("temporal.continued_as_new"))
+    completed = next(s for s in run_wfs if not s.get_tag("temporal.continued_as_new"))
+
+    assert continued.get_tag("temporal.continued_as_new") is not None
+    assert continued.error == 0, "ContinueAsNew should not mark the span as error"
+    assert completed.error == 0
+
+    # The second execution is a child of the first RunWorkflow span (same as Go SDK).
+    assert completed.parent_id == continued.span_id
+    assert completed.trace_id == continued.trace_id
+
+
+@pytest.mark.asyncio
+async def test_on_span_finish_callback(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """on_span_finish is called for every span and its extra_tags are applied."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    finished: list[FinishContext] = []
+
+    def on_finish(ctx: FinishContext) -> FinishResult | None:
+        finished.append(ctx)
+        return FinishResult(extra_tags={"custom.operation": ctx.operation})
+
+    interceptor = DatadogTracingInterceptor(
+        service_name="test-svc",
+        on_span_finish=on_finish,
+    )
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(use_activity=True),
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await handle.result()
+
+    # Callback was invoked for every span.
+    finished_ops = {ctx.operation for ctx in finished}
+    assert "StartWorkflow" in finished_ops
+    assert "RunWorkflow" in finished_ops
+    assert "StartActivity" in finished_ops
+    assert "RunActivity" in finished_ops
+
+    # No callback received a non-None exception for a successful run.
+    assert all(ctx.exception is None for ctx in finished)
+
+    # extra_tags from FinishResult are applied to each span.
+    for span in span_collector.spans:
+        op = span.name.removeprefix("temporal.")
+        assert span.get_tag("custom.operation") == op, (
+            f"Expected custom.operation={op!r} on span {span.name}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_on_span_finish_callback_receives_exception(
+    client: Client,
+    env: WorkflowEnvironment,
+) -> None:
+    """on_span_finish receives the exception on the FinishContext when a span fails."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    finish_contexts: list[FinishContext] = []
+
+    def on_finish(ctx: FinishContext) -> FinishResult | None:
+        finish_contexts.append(ctx)
+        return None
+
+    interceptor = DatadogTracingInterceptor(
+        service_name="test-svc",
+        on_span_finish=on_finish,
+    )
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[DirectlyFailingWorkflow],
+    ):
+        handle = await tc.start_workflow(
+            DirectlyFailingWorkflow.run,
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        with pytest.raises(Exception):
+            await handle.result()
+
+    run_wf_ctx = next(ctx for ctx in finish_contexts if ctx.operation == "RunWorkflow")
+    assert run_wf_ctx.exception is not None
+    assert "workflow failed directly" in str(run_wf_ctx.exception)
+
+    # The client-side StartWorkflow span finishes without an exception.
+    start_wf_ctx = next(
+        ctx for ctx in finish_contexts if ctx.operation == "StartWorkflow"
+    )
+    assert start_wf_ctx.exception is None
+
+
+@pytest.mark.asyncio
+async def test_worker_restart_recovery(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """RunWorkflow span is recovered correctly after a worker restart."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+    wf_id = f"wf-{uuid.uuid4()}"
+
+    # First worker: start the workflow and wait until it is blocked on
+    # wait_condition (i.e., the initial workflow task has completed).  We poll
+    # with a query because that only succeeds once execute_workflow is live.
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(wait_for_kick=True),
+            id=wf_id,
+            task_queue=tq,
+        )
+        for _ in range(50):
+            try:
+                await handle.query(TestWorkflow.get_status)
+                break
+            except Exception:
+                await asyncio.sleep(0.05)
+
+        # Capture the server-side start time while the first worker is still alive.
+        description = await handle.describe()
+        expected_start_ns = int(description.start_time.timestamp() * 1e9)
+
+    # Simulate process restart: discard all in-flight spans from the dead worker.
+    # In production the ddtrace singleton is destroyed with the process, so these
+    # spans are never sent. Clearing _traces here reproduces that behaviour and also
+    # unblocks the trace flush for the recovery spans (they share the same trace_id
+    # as the abandoned span, so without this the aggregator would wait for the
+    # abandoned span to finish before flushing the recovery span).
+    _dd_tracer._span_aggregator._traces.clear()
+
+    # Second worker: replay the workflow history, receive the signal, complete.
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        await handle.signal(TestWorkflow.kick)
+        await handle.result()
+
+    # Exactly one RunWorkflow span — recovered on the second worker.
+    run = span_collector.one("RunWorkflow")
+
+    # Verify the deterministic span_id using the known workflow_id, run_id from
+    # the handle, and "default" namespace (test server default).
+    run_id = handle.first_execution_run_id or ""
+    key = f"WorkflowInboundInterceptor:default:{wf_id}:{run_id}:1"
+    assert run.span_id == gen_span_id(key), (
+        f"Recovered RunWorkflow span_id {run.span_id} does not match expected deterministic value for key {key!r}"
+    )
+
+    # The recovered span must carry workflow tags (set by the annotation fix).
+    assert span_collector.tag(run, "WorkflowID") == wf_id
+    assert span_collector.tag(run, "RunID") == run_id
+
+    # The recovered span's start_ns must exactly match the server-recorded workflow
+    # start time (workflow initialization time, not first-task execution time).
+    assert run.start_ns == expected_start_ns, (
+        f"RunWorkflow start_ns {run.start_ns} does not match original workflow "
+        f"start time {expected_start_ns} — start time was not preserved across worker restart"
+    )
+
+    # The recovered span must still be a child of the original StartWorkflow.
+    start = span_collector.one("StartWorkflow")
+    assert run.parent_id == start.span_id
+
+
+async def _wait_for_history_events(handle: Any, *event_fields: str) -> None:
+    """Poll workflow history until all named event fields appear at least once."""
+    for _ in range(100):
+        history = await handle.fetch_history()
+        if all(
+            any(e.HasField(field) for e in history.events) for field in event_fields
+        ):
+            return
+        await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_no_duplicate_outbound_spans_on_worker_restart(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """StartActivity, StartLocalActivity, and StartChildWorkflow spans are not re-emitted on replay."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+    wf_id = f"wf-{uuid.uuid4()}"
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow, ChildWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(
+                use_activity=True,
+                use_local_activity=True,
+                use_child_workflow=True,
+                wait_for_kick=True,
+            ),
+            id=wf_id,
+            task_queue=tq,
+        )
+        # Wait until all three outbound operations are recorded in history.
+        await _wait_for_history_events(
+            handle,
+            "activity_task_completed_event_attributes",
+            "marker_recorded_event_attributes",
+            "child_workflow_execution_completed_event_attributes",
+        )
+
+    _dd_tracer._span_aggregator._traces.clear()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow, ChildWorkflow],
+        activities=[echo_activity],
+    ):
+        await handle.signal(TestWorkflow.kick)
+        await handle.result()
+
+    assert span_collector.by_op("StartActivity") == [], (
+        "Worker restart emitted duplicate StartActivity/StartLocalActivity span(s) during replay"
+    )
+    assert span_collector.by_op("StartChildWorkflow") == [], (
+        "Worker restart emitted duplicate StartChildWorkflow span(s) during replay"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_duplicate_signal_child_workflow_spans_on_worker_restart(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """SignalChildWorkflow spans are not re-emitted when a worker replays history."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+    wf_id = f"wf-{uuid.uuid4()}"
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[ParentWithSignalChildWorkflow, WaitingChildWorkflow],
+        activities=[],
+    ):
+        handle = await tc.start_workflow(
+            ParentWithSignalChildWorkflow.run,
+            id=wf_id,
+            task_queue=tq,
+        )
+        # Wait until the child has completed (signal received and child done).
+        await _wait_for_history_events(
+            handle,
+            "child_workflow_execution_completed_event_attributes",
+        )
+
+    _dd_tracer._span_aggregator._traces.clear()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[ParentWithSignalChildWorkflow, WaitingChildWorkflow],
+        activities=[],
+    ):
+        await handle.signal(ParentWithSignalChildWorkflow.kick)
+        await handle.result()
+
+    assert span_collector.by_op("SignalChildWorkflow") == [], (
+        "Worker restart emitted duplicate SignalChildWorkflow span(s) during replay"
+    )
+    assert span_collector.by_op("StartChildWorkflow") == [], (
+        "Worker restart emitted duplicate StartChildWorkflow span(s) during replay"
+    )
+
+
+@pytest.mark.asyncio
+async def test_local_activity_spans(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """Local activities produce a StartActivity span with temporal.local=True."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[LocalActivityWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            LocalActivityWorkflow.run,
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await handle.result()
+
+    start_act = span_collector.one("StartActivity")
+    run_act = span_collector.one("RunActivity")
+
+    assert start_act.resource == "echo_activity"
+    assert run_act.resource == "echo_activity"
+    assert span_collector.tag(start_act, "Local") == "True"
+    assert run_act.parent_id == start_act.span_id
+
+
+@pytest.mark.asyncio
+async def test_allow_invalid_parent_spans(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """With allow_invalid_parent_spans=True, a malformed trace header is ignored
+    and the workflow still produces a RunWorkflow span (with no parent)."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    payload_converter = temporalio.converter.PayloadConverter.default
+    bad_header = payload_converter.to_payloads(
+        [{"x-datadog-trace-id": "not-a-number"}]
+    )[0]
+
+    class _BadHeaderOutbound(temporalio.client.OutboundInterceptor):
+        async def start_workflow(
+            self, input: temporalio.client.StartWorkflowInput
+        ) -> Any:
+            input.headers = {**input.headers, "dd_trace_span": bad_header}
+            return await super().start_workflow(input)
+
+    class _BadHeaderInterceptor(temporalio.client.Interceptor):
+        def intercept_client(
+            self, next: temporalio.client.OutboundInterceptor
+        ) -> temporalio.client.OutboundInterceptor:
+            return _BadHeaderOutbound(next)
+
+    interceptor = DatadogTracingInterceptor(
+        service_name="test-svc",
+        allow_invalid_parent_spans=True,
+    )
+    cfg = client.config()
+    cfg["interceptors"] = [interceptor, _BadHeaderInterceptor()]
+    tc = Client(**cfg)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[TestWorkflow],
+        activities=[echo_activity],
+    ):
+        handle = await tc.start_workflow(
+            TestWorkflow.run,
+            TestRequest(use_activity=False),
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await handle.result()
+
+    run = span_collector.one("RunWorkflow")
+    assert run.parent_id is None or run.parent_id == 0
+
+
+@pytest.mark.asyncio
+async def test_disconnect_trace_span_from_workflow_context(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """disconnect_trace_span_from_workflow_context() causes the next execution to start
+    a fresh root span rather than inheriting the current trace."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[DisconnectedContinueAsNewWorkflow],
+    ):
+        handle = await tc.start_workflow(
+            DisconnectedContinueAsNewWorkflow.run,
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await handle.result()
+
+    runs = span_collector.by_op("RunWorkflow")
+    assert len(runs) == 2
+
+    first_run, second_run = sorted(runs, key=lambda s: s.start_ns)
+
+    # First execution is a child of StartWorkflow.
+    start = span_collector.one("StartWorkflow")
+    assert first_run.parent_id == start.span_id
+
+    # Second execution has no parent — the trace was disconnected.
+    assert second_run.parent_id is None or second_run.parent_id == 0
+    assert second_run.trace_id != first_run.trace_id
+
+
+@pytest.mark.asyncio
+async def test_span_from_workflow_context(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """span_from_workflow_context() lets workflow code tag the active RunWorkflow span."""
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(tc, task_queue=tq, workflows=[CustomTagWorkflow]):
+        handle = await tc.start_workflow(
+            CustomTagWorkflow.run,
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        await handle.result()
+
+    run = span_collector.one("RunWorkflow")
+    assert run.get_tag("custom.workflow.tag") == "hello-from-workflow"
+
+
+@pytest.mark.asyncio
+async def test_span_from_workflow_context_tag_preserved_after_worker_restart(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """Custom tags set via span_from_workflow_context() are preserved across a
+    worker restart.  RunWorkflow always creates a live span (no is_replaying()
+    guard), so user code re-runs set_tag during replay on the second worker,
+    matching the behaviour of the Go SDK.
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+    wf_id = f"wf-{uuid.uuid4()}"
+
+    # First worker: run until the workflow is blocked on wait_condition so the
+    # custom tag has been set on the live span but the span is not yet finished.
+    async with Worker(tc, task_queue=tq, workflows=[CustomTagWorkflow]):
+        handle = await tc.start_workflow(
+            CustomTagWorkflow.run,
+            True,
+            id=wf_id,
+            task_queue=tq,
+        )
+        for _ in range(50):
+            try:
+                await handle.query(CustomTagWorkflow.get_status)
+                break
+            except Exception:
+                await asyncio.sleep(0.05)
+
+    # Simulate process restart: discard all in-flight spans from the dead worker.
+    _dd_tracer._span_aggregator._traces.clear()
+
+    # Second worker: replay creates a live span, user code re-runs set_tag,
+    # then the kick signal is received and the workflow completes.
+    async with Worker(tc, task_queue=tq, workflows=[CustomTagWorkflow]):
+        await handle.signal(CustomTagWorkflow.kick)
+        await handle.result()
+
+    # The RunWorkflow span from the second worker carries the custom tag.
+    run = span_collector.one("RunWorkflow")
+    assert run.get_tag("custom.workflow.tag") == "hello-from-workflow"
+
+
+@pytest.mark.asyncio
+async def test_manual_keep_root_spans(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """Entry-point spans are force-sampled (USER_KEEP) when they are trace roots.
+
+    StartWorkflow with no active parent and RunWorkflow with a parent from
+    Temporal headers both carry sampling_priority == 2, matching Go's
+    manualKeepOps behavior. StartWorkflow with an in-process parent inherits
+    that parent's sampling decision.
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc, task_queue=tq, workflows=[TestWorkflow], activities=[echo_activity]
+    ):
+        await (
+            await tc.start_workflow(
+                TestWorkflow.run,
+                TestRequest(use_activity=False),
+                id=f"wf-{uuid.uuid4()}",
+                task_queue=tq,
+            )
+        ).result()
+
+    start = span_collector.one("StartWorkflow")
+    run = span_collector.one("RunWorkflow")
+
+    # USER_KEEP == 2: span is force-sampled, overriding the global sample rate.
+    assert start.context.sampling_priority == 2, (
+        f"StartWorkflow expected sampling_priority=2 (USER_KEEP), got {start.context.sampling_priority}"
+    )
+    assert run.context.sampling_priority == 2, (
+        f"RunWorkflow expected sampling_priority=2 (USER_KEEP), got {run.context.sampling_priority}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_manual_keep_not_applied_with_local_active_parent(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """StartWorkflow inherits the caller's sampling decision when there is an
+    active local parent span; only RunWorkflow (parent from Temporal headers)
+    is force-sampled to USER_KEEP.
+
+    Guards against the regression where unconditional manual.keep on entry-point
+    operations promoted the caller's entire trace to USER_KEEP when StartWorkflow
+    was called from inside an instrumented HTTP handler.
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    with _dd_tracer.trace("caller.request") as caller_span:
+        async with Worker(
+            tc, task_queue=tq, workflows=[TestWorkflow], activities=[echo_activity]
+        ):
+            handle = await tc.start_workflow(
+                TestWorkflow.run,
+                TestRequest(use_activity=False),
+                id=f"wf-{uuid.uuid4()}",
+                task_queue=tq,
+            )
+            await handle.result()
+
+    start_wf = span_collector.one("StartWorkflow")
+    run_wf = span_collector.one("RunWorkflow")
+
+    # StartWorkflow is a child of the active caller span — it must not be
+    # force-promoted to USER_KEEP, so the caller's sampling decision applies.
+    assert start_wf.parent_id == caller_span.span_id
+    assert start_wf.context.sampling_priority != 2, (
+        f"StartWorkflow must not be USER_KEEP when called with a local active parent, "
+        f"got sampling_priority={start_wf.context.sampling_priority}"
+    )
+
+    # RunWorkflow's parent arrives via Temporal task headers (cross-process),
+    # so it is force-sampled regardless of the caller's sampling decision.
+    assert run_wf.context.sampling_priority == 2, (
+        f"RunWorkflow expected sampling_priority=2 (USER_KEEP), got {run_wf.context.sampling_priority}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_workflow_logger_trace_correlation(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """workflow.logger calls are enriched with dd.trace_id and dd.span_id.
+
+    The _DDTraceLogFilter registered at module import time injects the active
+    RunWorkflow span IDs into every log record emitted via workflow.logger,
+    enabling Datadog log-to-trace correlation without activating the span.
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    capturer = LogCapturer()
+    with capturer.logs_captured(logging.getLogger("temporalio.workflow")):
+        async with Worker(tc, task_queue=tq, workflows=[LoggingWorkflow]):
+            handle = await tc.start_workflow(
+                LoggingWorkflow.run,
+                id=f"wf-{uuid.uuid4()}",
+                task_queue=tq,
+            )
+            await handle.result()
+
+    run = span_collector.one("RunWorkflow")
+
+    records = capturer.find_all(
+        lambda r: "test log message from workflow" in r.getMessage()
+    )
+    assert len(records) == 1, (
+        f"Expected exactly 1 workflow log record, got {len(records)}"
+    )
+    record = records[0]
+
+    assert record.__dict__.get("dd.trace_id") == format_trace_id(run.trace_id), (
+        f"Expected dd.trace_id={format_trace_id(run.trace_id)}, got {record.__dict__.get('dd.trace_id')}"
+    )
+    assert record.__dict__.get("dd.span_id") == str(run.span_id), (
+        f"Expected dd.span_id={run.span_id}, got {record.__dict__.get('dd.span_id')}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_workflow_logger_trace_correlation_64bit(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """workflow.logger uses ddtrace's log-correlation trace-ID format.
+
+    IDs that fit in 64 bits use decimal; larger IDs use 32-character hexadecimal.
+    Disabling 128-bit generation exercises the 64-bit path.
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    import ddtrace
+
+    orig = ddtrace.config._128_bit_trace_id_enabled
+    ddtrace.config._128_bit_trace_id_enabled = False
+    capturer = LogCapturer()
+    try:
+        interceptor = _make_interceptor()
+        tc = _traced_client(client, interceptor)
+        tq = _task_queue()
+
+        with capturer.logs_captured(logging.getLogger("temporalio.workflow")):
+            async with Worker(tc, task_queue=tq, workflows=[LoggingWorkflow]):
+                handle = await tc.start_workflow(
+                    LoggingWorkflow.run,
+                    id=f"wf-{uuid.uuid4()}",
+                    task_queue=tq,
+                )
+                await handle.result()
+    finally:
+        ddtrace.config._128_bit_trace_id_enabled = orig
+
+    run = span_collector.one("RunWorkflow")
+    assert run.trace_id <= (1 << 64) - 1, "expected a 64-bit trace ID"
+
+    records = capturer.find_all(
+        lambda r: "test log message from workflow" in r.getMessage()
+    )
+    assert len(records) == 1, (
+        f"Expected exactly 1 workflow log record, got {len(records)}"
+    )
+    record = records[0]
+
+    expected = str(
+        run.trace_id
+    )  # decimal, matching ddtrace's format_trace_id for 64-bit IDs
+    assert record.__dict__.get("dd.trace_id") == expected, (
+        f"Expected dd.trace_id={expected!r} (decimal), got {record.__dict__.get('dd.trace_id')!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_activity_logger_trace_correlation(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """activity.logger calls are enriched with dd.trace_id and dd.span_id.
+
+    Unlike the workflow path (which uses the module-level _DDTraceLogFilter),
+    activity logs run outside the sandbox with a real active ddtrace span
+    (activated with activate=True in the activity interceptor), so correlation
+    relies on ddtrace's own stdlib logging patch instead of a custom filter.
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    import ddtrace
+
+    ddtrace.patch(logging=True)
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    capturer = LogCapturer()
+    with capturer.logs_captured(logging.getLogger("temporalio.activity")):
+        async with Worker(
+            tc,
+            task_queue=tq,
+            workflows=[LoggingActivityWorkflow],
+            activities=[logging_activity],
+        ):
+            handle = await tc.start_workflow(
+                LoggingActivityWorkflow.run,
+                id=f"wf-{uuid.uuid4()}",
+                task_queue=tq,
+            )
+            await handle.result()
+
+    run_act = span_collector.one("RunActivity")
+
+    records = capturer.find_all(
+        lambda r: "test log message from activity" in r.getMessage()
+    )
+    assert len(records) == 1, (
+        f"Expected exactly 1 activity log record, got {len(records)}"
+    )
+    record = records[0]
+
+    assert record.__dict__.get("dd.trace_id") == format_trace_id(run_act.trace_id), (
+        f"Expected dd.trace_id={format_trace_id(run_act.trace_id)}, got {record.__dict__.get('dd.trace_id')}"
+    )
+    assert record.__dict__.get("dd.span_id") == str(run_act.span_id), (
+        f"Expected dd.span_id={run_act.span_id}, got {record.__dict__.get('dd.span_id')}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_custom_span_in_activity_is_child_of_run_activity(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """A custom ddtrace span created inside an activity is a child of RunActivity.
+
+    The activity interceptor activates the RunActivity span with activate=True
+    so that user-created spans inside the activity automatically inherit the
+    correct trace context.
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    async with Worker(
+        tc,
+        task_queue=tq,
+        workflows=[CustomSpanActivityWorkflow],
+        activities=[custom_span_activity],
+    ):
+        handle = await tc.start_workflow(
+            CustomSpanActivityWorkflow.run,
+            id=f"wf-{uuid.uuid4()}",
+            task_queue=tq,
+        )
+        parent_id, trace_id = await handle.result()
+
+    run_act = span_collector.one("RunActivity")
+
+    assert trace_id == run_act.trace_id, (
+        f"Custom span trace_id {trace_id} != RunActivity trace_id {run_act.trace_id} — "
+        "custom span is an independent trace, not a child of RunActivity"
+    )
+    assert parent_id == run_act.span_id, (
+        f"Custom span parent_id {parent_id} != RunActivity span_id {run_act.span_id}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_custom_span_in_activity_inherits_caller_trace(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """Custom spans in activities are in the same trace as the workflow caller.
+
+    Simulates a caller service that already has an active span when
+    start_workflow is called (e.g. an HTTP request handler span). StartWorkflow
+    must be a child of that span, and all downstream spans — RunWorkflow,
+    StartActivity, RunActivity, and user-created custom spans inside the
+    activity — must share the caller's trace_id.
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    with _dd_tracer.trace("caller.request") as caller_span:
+        async with Worker(
+            tc,
+            task_queue=tq,
+            workflows=[CustomSpanActivityWorkflow],
+            activities=[custom_span_activity],
+        ):
+            handle = await tc.start_workflow(
+                CustomSpanActivityWorkflow.run,
+                id=f"wf-{uuid.uuid4()}",
+                task_queue=tq,
+            )
+            custom_parent_id, custom_trace_id = await handle.result()
+
+    start_wf = span_collector.one("StartWorkflow")
+    run_act = span_collector.one("RunActivity")
+
+    assert start_wf.trace_id == caller_span.trace_id, (
+        f"StartWorkflow trace_id {start_wf.trace_id} != caller trace_id {caller_span.trace_id}"
+    )
+    assert start_wf.parent_id == caller_span.span_id, (
+        f"StartWorkflow parent_id {start_wf.parent_id} != caller span_id {caller_span.span_id}"
+    )
+    assert run_act.trace_id == caller_span.trace_id, (
+        f"RunActivity trace_id {run_act.trace_id} != caller trace_id {caller_span.trace_id} — "
+        "trace context did not propagate through Temporal headers"
+    )
+    assert custom_trace_id == caller_span.trace_id, (
+        f"Custom span trace_id {custom_trace_id} != caller trace_id {caller_span.trace_id} — "
+        "custom span is not in the caller's trace"
+    )
+    assert custom_parent_id == run_act.span_id, (
+        f"Custom span parent_id {custom_parent_id} != RunActivity span_id {run_act.span_id}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_workflows_log_isolation(
+    client: Client,
+    env: WorkflowEnvironment,
+    span_collector: _SpanCollector,
+) -> None:
+    """Two workflows running concurrently on the same worker log their own trace IDs.
+
+    ConcurrentLoggingWorkflow emits logs before and after an activity, giving
+    the Temporal SDK a chance to interleave the two executions.  Each log record
+    must carry the dd.trace_id/dd.span_id of its own RunWorkflow span, not the
+    other workflow's span.
+    """
+    if env.supports_time_skipping:
+        pytest.skip("time-skipping server not supported")
+
+    interceptor = _make_interceptor()
+    tc = _traced_client(client, interceptor)
+    tq = _task_queue()
+
+    wf_id_a = f"wf-a-{uuid.uuid4()}"
+    wf_id_b = f"wf-b-{uuid.uuid4()}"
+
+    capturer = LogCapturer()
+    with capturer.logs_captured(logging.getLogger("temporalio.workflow")):
+        async with Worker(
+            tc,
+            task_queue=tq,
+            workflows=[ConcurrentLoggingWorkflow],
+            activities=[logging_activity],
+        ):
+            handle_a = await tc.start_workflow(
+                ConcurrentLoggingWorkflow.run,
+                "A",
+                id=wf_id_a,
+                task_queue=tq,
+            )
+            handle_b = await tc.start_workflow(
+                ConcurrentLoggingWorkflow.run,
+                "B",
+                id=wf_id_b,
+                task_queue=tq,
+            )
+            # Wait until both workflows have logged "start:<label>" and are blocked
+            # on the signal barrier — this proves they are in-flight concurrently.
+            for handle in (handle_a, handle_b):
+                for _ in range(50):
+                    try:
+                        if await handle.query(ConcurrentLoggingWorkflow.is_started):
+                            break
+                    except Exception:
+                        pass
+                    await asyncio.sleep(0.05)
+            await handle_a.signal(ConcurrentLoggingWorkflow.proceed)
+            await handle_b.signal(ConcurrentLoggingWorkflow.proceed)
+            await asyncio.gather(handle_a.result(), handle_b.result())
+
+    run_wfs = span_collector.by_op("RunWorkflow")
+    assert len(run_wfs) == 2, f"Expected 2 RunWorkflow spans, got {len(run_wfs)}"
+
+    span_by_wf_id = {span_collector.tag(s, "WorkflowID"): s for s in run_wfs}
+    span_a = span_by_wf_id[wf_id_a]
+    span_b = span_by_wf_id[wf_id_b]
+
+    for label, span in [("A", span_a), ("B", span_b)]:
+        expected_trace_id = format_trace_id(span.trace_id)
+        expected_span_id = str(span.span_id)
+
+        for marker in (f"start:{label}", f"end:{label}"):
+            records = capturer.find_all(lambda r, marker=marker: marker in r.getMessage())
+            assert len(records) >= 1, f"Expected at least 1 log record for {marker!r}"
+            record = records[0]
+            assert record.__dict__.get("dd.trace_id") == expected_trace_id, (
+                f"{marker}: expected dd.trace_id={expected_trace_id}, got {record.__dict__.get('dd.trace_id')}"
+            )
+            assert record.__dict__.get("dd.span_id") == expected_span_id, (
+                f"{marker}: expected dd.span_id={expected_span_id}, got {record.__dict__.get('dd.span_id')}"
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -4,12 +4,13 @@ requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
-    "python_full_version >= '3.11' and python_full_version < '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
 
 [options]
-exclude-newer = "2026-08-05T18:42:17.193687502Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P2W"
 
 [[package]]
@@ -476,6 +477,33 @@ wheels = [
 ]
 
 [[package]]
+name = "bytecode"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/c4/4818b392104bd426171fc2ce9c79c8edb4019ba6505747626d0f7107766c/bytecode-0.17.0.tar.gz", hash = "sha256:0c37efa5bd158b1b873f530cceea2c645611d55bd2dc2a4758b09f185749b6fd", size = 105863, upload-time = "2025-09-03T19:55:45.703Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/80/379e685099841f8501a19fb58b496512ef432331fed38276c3938ab09d8e/bytecode-0.17.0-py3-none-any.whl", hash = "sha256:64fb10cde1db7ef5cc39bd414ecebd54ba3b40e1c4cf8121ca5e72f170916ff8", size = 43045, upload-time = "2025-09-03T19:55:43.879Z" },
+]
+
+[[package]]
+name = "bytecode"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/8f/7d12c539869a5cbd801d550b86cc0f030ecaeb12f57f8b3ff19f2d2a184c/bytecode-0.18.1.tar.gz", hash = "sha256:d9564f1565fe1ae6a1173e544ef43a85f093e83997ef45af65d0d250eb48d7a1", size = 104631, upload-time = "2026-06-03T14:17:59.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/ef/6a629424ec08adc3819ddfd7ec0a710361eaa29d1e5fffb4e02f074be5c9/bytecode-0.18.1-py3-none-any.whl", hash = "sha256:9535bfdd665260b2888ec4121569e3ca5106965a7fedbb6de6ba1bafebc5c7d7", size = 42868, upload-time = "2026-06-03T14:17:57.654Z" },
+]
+
+[[package]]
 name = "cachecontrol"
 version = "0.14.4"
 source = { registry = "https://pypi.org/simple" }
@@ -938,6 +966,75 @@ wheels = [
 ]
 
 [[package]]
+name = "ddtrace"
+version = "3.19.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bytecode", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "bytecode", version = "0.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "envier" },
+    { name = "opentelemetry-api" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/08/04c149c1e8106bfb5837d7b037d6630d8ef374906ce5f6ab218836808e26/ddtrace-3.19.8.tar.gz", hash = "sha256:4717fcfd15718aabcf9f80abd452673807609f7300978afb9e536ef21f12e04b", size = 7669503, upload-time = "2026-07-13T14:09:24.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/2c/aa1733b8278d03e1001a61dfcd80dd2aa268037cb3d537f6ae9760cc1e08/ddtrace-3.19.8-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:874b0166a78fdac1e18a4b0289951cea86acc3032eaff98820da5084bec16b35", size = 6532940, upload-time = "2026-07-13T14:05:43.392Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/05/8aa69071db224d9751de4d8863a14b107b3a7c9ec13101febb1e2ab673fa/ddtrace-3.19.8-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:1c62e5715652acac6db3ea395bdda36f0dc01e483790f894fac7adf66165fa0e", size = 6926099, upload-time = "2026-07-13T14:05:49.528Z" },
+    { url = "https://files.pythonhosted.org/packages/46/b5/4ed7904ea4ac87f4bdc4a1febc985e2833382bf7d0ea6028bbc4ffe16c15/ddtrace-3.19.8-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ebe664ace86b6cf5a2c1ad7ee3128d50cd4009c5fe3ffa11e58c7c7e7a217e62", size = 7478306, upload-time = "2026-07-13T14:05:51.477Z" },
+    { url = "https://files.pythonhosted.org/packages/67/fc/54f5c48232d2e1c7944abd11d08234077140e6a565be73b67617b03812ee/ddtrace-3.19.8-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3831507ad2474d7a1801e1ee46ae1ec33a28f7d50205b5c1e707a5a52ad48db0", size = 7756195, upload-time = "2026-07-13T14:05:53.286Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/34/69e0c2e7861b1ee8c3560742d8ef89b2f8df39aee18a60f57f443088f294/ddtrace-3.19.8-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:d5308793a66237471696da36f0bf2fc283a3adb5a1d1b7e7922b2ed0fae57132", size = 5569185, upload-time = "2026-07-13T14:05:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ad/e49b3f6fe8309ddf64816569d7fa079aac4309748fb0ba22df7f9aee8af6/ddtrace-3.19.8-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f321b658f861d8a20c74efe681310dbea51329d1b14b12ace051b16236302cdd", size = 8481577, upload-time = "2026-07-13T14:05:56.917Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/60/e3737dcb77fd231cbd7889a2df022beec71fa07779c836398c11e2cd4daf/ddtrace-3.19.8-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3a8f1b82c4e8ff2d7fe7b677279b2e2dd018026f436070643defbc63869abbd6", size = 6695942, upload-time = "2026-07-13T14:05:59.2Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b4/4133ee91fe9a8ff5e4225c30d9ac6c2c1f476efc4fd2e0df9fd216da7ac1/ddtrace-3.19.8-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:371f174b93c25c92781f57ca8b7f38c9ff2861c8fb6876f8c7ca9c4e5719cca1", size = 8812736, upload-time = "2026-07-13T14:06:01.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/05/fe384f40d6be8c03df9a6ff15512a65167c7ea6629f2f03a9bc2c3f252c5/ddtrace-3.19.8-cp310-cp310-win32.whl", hash = "sha256:46927b74246dbc4caad101617c40cd44eb8835a5f17251e0100b21fb01e74545", size = 5107449, upload-time = "2026-07-13T14:06:03.379Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5d/7ba444e07369097d769a95987e4f304b1b4ed4166aa9ac1bd755a89f5628/ddtrace-3.19.8-cp310-cp310-win_amd64.whl", hash = "sha256:803ce9eb58826ac7d21d4dcc66de531b942cf49a6588cf52f3242fe65f744d45", size = 5657823, upload-time = "2026-07-13T14:06:05.262Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/46/02d49ff919a6ece62faeff05e211d928d720d0fee18e64e89ba289c18633/ddtrace-3.19.8-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:090aacdb9b52bf2bbd23739b786263e3f604bc03f33c5eef78b4368720ac3858", size = 6535743, upload-time = "2026-07-13T14:06:07.62Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c6/79ec1312e8ff992ba648b3bebed74e55ad39e52cb078ac61c0c14f545328/ddtrace-3.19.8-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:6ee167d3811ebe5d2a5dc6d9e8301962238512497494ec50b64dc238993b7685", size = 6929508, upload-time = "2026-07-13T14:06:09.603Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/92/dfc2a644f27848e9e3043ba6422c08be3151c37b4d86ae67339d1f96509e/ddtrace-3.19.8-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:395d6b9624a1be832c6118ca74afb285fe6bdca4dc2c14650e84362976911957", size = 7481100, upload-time = "2026-07-13T14:06:11.745Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/00/c9bcd693b5efd9f884d4aaefc9f1cccb8fd59b464b0a47b87406bd85d069/ddtrace-3.19.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac5089cb32429d7d3671c4d1cd7abbeb38bd668e9d36a0940f771d88fd4a2db8", size = 7759927, upload-time = "2026-07-13T14:06:14.092Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d8/ef399201b6bada22ca7f93c7b987000668d82ddf442d75fc2219fd352c67/ddtrace-3.19.8-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:836c0486e3e4f196c933f9eb9fdd5b698fc0de979e5bd1145be21e7a41c27fc8", size = 5570280, upload-time = "2026-07-13T14:06:16.269Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1d/f849c17b4adf80df01c181eb0f220103e5512d91e06c72cba058d83cfb81/ddtrace-3.19.8-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5a92cc27786b130a21c4c7aa82f41d4ccf701faf5c723800cb0fabc43b7ca885", size = 8483961, upload-time = "2026-07-13T14:06:18.379Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/38/c36f560b0a6c4978c85b1c8d693b8151c5884faf157997da297e008e1248/ddtrace-3.19.8-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5e1abb116ca0be548b67b30f59be8bba55ac748194e28ea9f60a1ba8b37e5f99", size = 6696362, upload-time = "2026-07-13T14:06:21.005Z" },
+    { url = "https://files.pythonhosted.org/packages/47/05/126234ad3e4583262c7e063751c960735461c69722d3ecf8b9d716ce2312/ddtrace-3.19.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8985ad4c92fe149f631ee69c627702a855c529f85c07ed07617f824747b0bb63", size = 8821532, upload-time = "2026-07-13T14:06:23.306Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/8a/cf34fa9c58042c07bed0f549fa9f109d4454923a8a3f0aef1b049031aa2f/ddtrace-3.19.8-cp311-cp311-win32.whl", hash = "sha256:3f6a135725536b0dd2b2cb8f60b1d90a51415613f918d24dbeb241b4de4370d9", size = 5107234, upload-time = "2026-07-13T14:06:25.853Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7d/409d0660d33de519a65ded0512997609ecad6ef0c4741285fb321bc86ee2/ddtrace-3.19.8-cp311-cp311-win_amd64.whl", hash = "sha256:92dff4ab387b40ceee9ec61758ff8da37c68ad5017ec61e5ba11e475280f0b6c", size = 5663056, upload-time = "2026-07-13T14:06:28.022Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f6/78f031655b4a0df56e0bfd79014d60ef69ac3cfa72c0e333ba49231fb67d/ddtrace-3.19.8-cp311-cp311-win_arm64.whl", hash = "sha256:44884fb25c30197855d07be1e77ef456b1fd7674e278f0e8728d5437a49d4462", size = 5323809, upload-time = "2026-07-13T14:06:30.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b0/a90709baecdfd6c09a462768e2354b2ff830d02511edef9bedd0383a6159/ddtrace-3.19.8-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:010815764845034b936264e228a0e1beefd61c97acac015413229eeae324e380", size = 6536773, upload-time = "2026-07-13T14:06:32.514Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2d/6652b73ba174d1ca826f9f4e0e9399350db1d3c36754fe561420c87d731d/ddtrace-3.19.8-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:243b917f5b82f112f40c23de91e81f5996bf76e9f3035cd5d96abaf3ba16642f", size = 6934637, upload-time = "2026-07-13T14:06:34.874Z" },
+    { url = "https://files.pythonhosted.org/packages/38/61/98a5d7dfcb97eff16fd8be89919224fe6293cad71cc8ce521280e926f1f6/ddtrace-3.19.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:65defc5af52c13df76c65403b03597cd6b09abf49236d7c4ad42391de777057f", size = 7462789, upload-time = "2026-07-13T14:06:37.274Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/21/4b4f0aeb1e1d0c69e0259082c650ef081b5a91500c09b354f91e7943b912/ddtrace-3.19.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:459711a63e065ad6c2d27cd7f0518563bb997898e0eae3711d70bc09b9d74101", size = 7751028, upload-time = "2026-07-13T14:06:39.635Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/43/890804ffbdbe1a66e37ea10b78a093882be368f46ceae292d649a981a925/ddtrace-3.19.8-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:1c8ba94ccae67cd7b34efd4f683bf674de5d06b3fae80292f1ce0976e313aa30", size = 5565795, upload-time = "2026-07-13T14:06:42.075Z" },
+    { url = "https://files.pythonhosted.org/packages/83/cc/6c0a6e0c008f8aa86edde7dd79993bf2ae464b819e7ae5407e637bc8bb84/ddtrace-3.19.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:32c013f8be724781b154c90e1acb208449097f1dc502040a1c81abc18a036996", size = 8474478, upload-time = "2026-07-13T14:06:44.513Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f9/098028242f9fa3f3b413d15f03071ae8a4b392a354742743e9f727b43562/ddtrace-3.19.8-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:693adbed7762da9975994cd8f0925ba9d81609db214cce37e15c32dfa0d80018", size = 6688096, upload-time = "2026-07-13T14:06:47.219Z" },
+    { url = "https://files.pythonhosted.org/packages/19/f2/a6bfb6c3538c7b83d94f1f8c74fa17573e61d7a656486712b1e670bde630/ddtrace-3.19.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd6d43ed6551df47920703b0c45b67adf81e819d1b4840eaa7966c387dabd684", size = 8820433, upload-time = "2026-07-13T14:06:49.739Z" },
+    { url = "https://files.pythonhosted.org/packages/72/2f/b838b773b01936fdd505c9d715cb283b7706a0eb7274d01fe0292b788ab9/ddtrace-3.19.8-cp312-cp312-win32.whl", hash = "sha256:da6ac4f1ae2d65ea8b3df8d911714519e91afd409d63a9e0a54310cd83a7f16a", size = 5102081, upload-time = "2026-07-13T14:06:52.418Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/26/f8ff5e4ac30732322e3a0132cd182cabbf21412a388cf607c8717e12a469/ddtrace-3.19.8-cp312-cp312-win_amd64.whl", hash = "sha256:8279702e2f6918399bba63ea6b4683bc60e6e0c0929cd864e9dec67229c9056d", size = 5655629, upload-time = "2026-07-13T14:06:54.965Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3c/d05f0f452ff5504a65301295b5e6fbdf9fe13017398d48784a3ecdedecf0/ddtrace-3.19.8-cp312-cp312-win_arm64.whl", hash = "sha256:09cc72993a8e66a73efba94aa164ab13c42dacc09a90094a5f85b49e2a5cb1e9", size = 5312622, upload-time = "2026-07-13T14:06:57.65Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d7/d71c8236cc5e0fe4bb8574681a6c9004b41ecd70523432ebeef3faa6b40a/ddtrace-3.19.8-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:7d11acd51001acc3ed511b588469a50b5224700791eb2820a02b0d6d5ed9b099", size = 6531305, upload-time = "2026-07-13T14:07:00.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/68/f7db91f6ff8e776ed2eb2296d5fbffc524926d03884de98bc1d276222be9/ddtrace-3.19.8-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:a19c244612a01c97539851f35f1ae9f17bd4096ae63a042d51a2c05e92c28a49", size = 6930377, upload-time = "2026-07-13T14:07:02.781Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ce/df943e83d80cc02f622f85da6e07366632eebb21fc2f62be536063c1964f/ddtrace-3.19.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6766d506178ab9f1b1f8bd7b9573c2d2c01152f9b5d6817f4ed9b33111e09391", size = 7453436, upload-time = "2026-07-13T14:07:06.07Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/c9/590f54adf88f52642532c91d9d0abf1ec012cf408baa235652d7c3b6fde4/ddtrace-3.19.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a97dd0ad5c0c3fed37143ae487e18ab685aa560f8d20c4aacb5791535dd6397", size = 7740986, upload-time = "2026-07-13T14:07:08.811Z" },
+    { url = "https://files.pythonhosted.org/packages/57/2f/cb377d397ea828a503c10c81044d029b2d7da7202172a74a15c0987e78b0/ddtrace-3.19.8-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:92c2f74eda8afd1cce3a5c062670350a6071ba651967c39d8625b63063933c0b", size = 5556062, upload-time = "2026-07-13T14:07:11.529Z" },
+    { url = "https://files.pythonhosted.org/packages/96/97/4b6c28c6632b8ca466b26cd4736ea4c30a1af43490453ac9c072c321c2ab/ddtrace-3.19.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:93319ae25664e21893fe500e6be7c2ab4ff8935a07b756f22e1444136061dc6c", size = 8468820, upload-time = "2026-07-13T14:07:14.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ce/22ce3a209a5e9b4da5a4dd6e6b81a7916808eb9f6fac5c1635efc2debe76/ddtrace-3.19.8-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e860c1da2674424629511dba251cb90aac07b2b79c22a59b0f470ec95d293310", size = 6680611, upload-time = "2026-07-13T14:07:17.906Z" },
+    { url = "https://files.pythonhosted.org/packages/20/75/abe3bb528ffb0f3bec238b8f1bd0c003075eb6c6f594ff196e696657b650/ddtrace-3.19.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5638ff043a4212421d7e3311ab3ddbf8cc049ebe5955ec55a34bab35e395903d", size = 8811305, upload-time = "2026-07-13T14:07:21.308Z" },
+    { url = "https://files.pythonhosted.org/packages/90/d9/9baaa096d25fa7288d15491bb6bc4dfb3568a6ed915cd3ba28849094df11/ddtrace-3.19.8-cp313-cp313-win32.whl", hash = "sha256:2325a6c4c914d89e3e41f0738b745567e22b829cc3e85a954d8f98473fd0e98d", size = 5099704, upload-time = "2026-07-13T14:07:24.509Z" },
+    { url = "https://files.pythonhosted.org/packages/84/e0/cc3cdc3df94f0e00b8d01bcd4dc3617a44800519f8d5e145bb258a3b89f7/ddtrace-3.19.8-cp313-cp313-win_amd64.whl", hash = "sha256:cefae449a753f66beb8e7a71d3eb412f664f3b89624cb79c9d137e4e8e1c6919", size = 5650791, upload-time = "2026-07-13T14:07:27.374Z" },
+    { url = "https://files.pythonhosted.org/packages/44/71/e70b7ef069fa9a48158646fd929df3d6979adbe4a3ae33be6c6d061be5e6/ddtrace-3.19.8-cp313-cp313-win_arm64.whl", hash = "sha256:f961e867e93cab0ff24894a8653133d7be97ad7680128e8c75aecba09d1f5c30", size = 5309223, upload-time = "2026-07-13T14:07:30.6Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7e/6325e2615f77d3682b33428ea4a43d2bb9942d8fb413e83bc40fd652ac73/ddtrace-3.19.8-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:18a7e5e3853ea9a261ac7aab449382717248c4dca6c5399cdae0e54da5e7d3c0", size = 6132460, upload-time = "2026-07-13T14:07:33.43Z" },
+    { url = "https://files.pythonhosted.org/packages/69/23/9ea8a1c554a7f44a9377d288d27d2ec5d20c6ff2ab0b3bcfe0254609f294/ddtrace-3.19.8-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:5419dd5764d94d020253aa636f28dfca6daf533b70aa32fc38873931ecdb9e7f", size = 6471367, upload-time = "2026-07-13T14:07:36.396Z" },
+    { url = "https://files.pythonhosted.org/packages/97/5c/b0c32f08dc0d4f43ec1ca18cd56f0a70b9554bc753cc7c47887a73c363ec/ddtrace-3.19.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:be7aa24d8232c52a1d43358608b77702e39bc66492f8905ddbd1a6ba102bc435", size = 7059183, upload-time = "2026-07-13T14:07:39.479Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/26/c9e359aeb77f9a4fd906607374e1f2151395426cefcfedbfffbe85f3c0ef/ddtrace-3.19.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f1d1e651cb86bad6d0264d2808165030713a605ab6936c77e46c0e2c982bebab", size = 7333423, upload-time = "2026-07-13T14:07:42.979Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/1e/4891ad38cb0210172f24ca3097455f29a1984b3e27beef5dfde556f8aebb/ddtrace-3.19.8-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:ad816e7bc952e29813d89f0ea983836857360a24f5e80b68f5c5aa6507d57c2f", size = 5557355, upload-time = "2026-07-13T14:07:46.236Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/1c/1f81dd71677dca5313628ef9260a35b02680baf060272762074aaaa4f799/ddtrace-3.19.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c21cdfff1c08e115815384ce4e92ca0115d99c5dd7c337b1edc8b82fcda092ac", size = 8030180, upload-time = "2026-07-13T14:07:49.512Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/bf/6ffa317130b475a4a4e3e5c749060f59394d865c285bb3cba9bf38f31edf/ddtrace-3.19.8-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:c7d27fc05f8fdfc0dee315e06a8dcbba7aedaa8646fb37b14cdaf57c719b2ef1", size = 6682305, upload-time = "2026-07-13T14:07:52.668Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f5/2f6469dc7be522b0ebe17638c721bf4dcf94903ea40dae52846bff93b35e/ddtrace-3.19.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fa6caf9e7658a399a17883fb2dcb26f65b3c6370b7ba6b4fa1650cdd25f87617", size = 8363760, upload-time = "2026-07-13T14:07:55.801Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/61/02adc6d7a786ad3727f7c1f6f9c6b06c385d0775ff409efde566cb7ed3fb/ddtrace-3.19.8-cp314-cp314-win32.whl", hash = "sha256:61bfc493897620d8a31b84ebba255778bfc28667a7887f85e53bfb48f833bc5e", size = 5189171, upload-time = "2026-07-13T14:07:59.17Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/56/938a524152742b1f4c2cf2389eb401538171450dea573981a6b49963dcad/ddtrace-3.19.8-cp314-cp314-win_amd64.whl", hash = "sha256:1c87b80000a8476e05d67f360ff666c9277cb41e8454ab7a68b38b5ea986500b", size = 5779986, upload-time = "2026-07-13T14:08:02.522Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e8/71407936b587f7321dd820a80454e58dcd4b002990495ad4088338fb3dae/ddtrace-3.19.8-cp314-cp314-win_arm64.whl", hash = "sha256:1d0e603d94072a631d5e95ba9b33343c2d37ae2085770257a91dbb86f0781a17", size = 5450479, upload-time = "2026-07-13T14:08:06.052Z" },
+]
+
+[[package]]
 name = "deepagents"
 version = "0.6.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1015,6 +1112,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/39/a4/5180d9afc57e8fca05601dd652bdff19604c218814037fe90ffc7625a50a/docutils-0.23.tar.gz", hash = "sha256:746f5060322511280a1e50eb76846ed6bf2342984b2ac04dc42caa1a8d78799e", size = 2303823, upload-time = "2026-05-27T17:41:06.934Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/91/30151a39f7570f448ed84529390628a651d7f27c87d73c9b887f8189695e/docutils-0.23-py3-none-any.whl", hash = "sha256:25d013af9bf23bc1c7b2b093dff4208166c53a94786c9e447808335ef1185fea", size = 634701, upload-time = "2026-05-27T17:40:58.442Z" },
+]
+
+[[package]]
+name = "envier"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/e7/4fe4d3f6e21213cea9bcddc36ba60e6ae4003035f9ce8055e6a9f0322ddb/envier-0.6.1.tar.gz", hash = "sha256:3309a01bb3d8850c9e7a31a5166d5a836846db2faecb79b9cb32654dd50ca9f9", size = 10063, upload-time = "2024-10-22T09:56:47.226Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/e9/30493b1cc967f7c07869de4b2ab3929151a58e6bb04495015554d24b61db/envier-0.6.1-py3-none-any.whl", hash = "sha256:73609040a76be48bbcb97074d9969666484aa0de706183a6e9ef773156a8a6a9", size = 10638, upload-time = "2024-10-22T09:56:45.968Z" },
 ]
 
 [[package]]
@@ -2721,7 +2827,8 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
-    "python_full_version >= '3.11' and python_full_version < '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
@@ -4368,7 +4475,8 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
-    "python_full_version >= '3.11' and python_full_version < '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
 wheels = [
@@ -4711,6 +4819,9 @@ aioboto3 = [
     { name = "aioboto3" },
     { name = "types-aioboto3", extra = ["s3"] },
 ]
+datadog = [
+    { name = "ddtrace" },
+]
 deepagents = [
     { name = "deepagents", marker = "python_full_version >= '3.11'" },
     { name = "langchain", marker = "python_full_version >= '3.11'" },
@@ -4760,6 +4871,7 @@ dev = [
     { name = "basedpyright" },
     { name = "cibuildwheel" },
     { name = "cryptography" },
+    { name = "ddtrace" },
     { name = "deepagents", marker = "python_full_version >= '3.11'" },
     { name = "googleapis-common-protos" },
     { name = "grpcio-tools" },
@@ -4805,6 +4917,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aioboto3", marker = "extra == 'aioboto3'", specifier = ">=10.4.0" },
+    { name = "ddtrace", marker = "extra == 'datadog'", specifier = ">=2.9,<4" },
     { name = "deepagents", marker = "python_full_version >= '3.11' and extra == 'deepagents'", specifier = ">=0.6.12,<0.7" },
     { name = "google-adk", marker = "extra == 'google-adk'", specifier = ">=2.2.0,<3" },
     { name = "google-genai", marker = "extra == 'google-genai'", specifier = ">=2.10.0,<3.0.0" },
@@ -4832,7 +4945,7 @@ requires-dist = [
     { name = "types-protobuf", specifier = ">=3.20,<8.0.0" },
     { name = "typing-extensions", specifier = ">=4.2.0,<5" },
 ]
-provides-extras = ["grpc", "opentelemetry", "pydantic", "openai-agents", "google-adk", "langgraph", "langsmith", "deepagents", "lambda-worker-otel", "aioboto3", "google-genai", "strands-agents"]
+provides-extras = ["grpc", "opentelemetry", "pydantic", "openai-agents", "google-adk", "langgraph", "langsmith", "datadog", "deepagents", "lambda-worker-otel", "aioboto3", "google-genai", "strands-agents"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4840,6 +4953,7 @@ dev = [
     { name = "basedpyright", specifier = "==1.34.0" },
     { name = "cibuildwheel", specifier = ">=2.22.0,<3" },
     { name = "cryptography", specifier = ">=46" },
+    { name = "ddtrace", specifier = ">=2.9,<4" },
     { name = "deepagents", marker = "python_full_version >= '3.11'", specifier = ">=0.6.12,<0.7" },
     { name = "googleapis-common-protos", specifier = ">=1.75.0,<2" },
     { name = "grpcio-tools", specifier = ">=1.48.2,<2" },


### PR DESCRIPTION
This is a port of Datadog's internal Python tracing interceptor, used internally at Datadog with the Python SDK, adapted for open-source contribution. It has feature parity with the Go SDK's Datadog tracing interceptor, including deterministic span/trace IDs and replay-safe span emission, so traces stay coherent across worker restarts regardless of which SDK produced them.