### PR TITLE
Fix release changelog verification

### DIFF
--- a/.github/scripts/release_verify.py
+++ b/.github/scripts/release_verify.py
@@ -308,11 +308,18 @@ def _sdk_core_release_notes(version: str, path: str) -> list[str]:
         )
     except subprocess.CalledProcessError:
         _git(["fetch", "--quiet", "origin", "main"], cwd=submodule_path)
-        notes = _sdk_core_changelog_entries(
-            previous_commit,
-            current_commit,
-            submodule_path,
-        )
+        try:
+            notes = _sdk_core_changelog_entries(
+                previous_commit,
+                current_commit,
+                submodule_path,
+            )
+        except subprocess.CalledProcessError as error:
+            output = error.output.strip() if error.output else str(error)
+            raise RuntimeError(
+                "SDK Core changelog-release-notes failed after fetching origin/main:\n"
+                f"{output}"
+            ) from error
     if not notes:
         return []
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -125,6 +125,11 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+        with:
+          # Keep the generated Core protobuf code compatible with CI.
+          version: "23.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -124,6 +124,7 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
           submodules: recursive
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -91,6 +91,25 @@ def test_sdk_core_release_notes_embed_core_output(
     ]
 
 
+def test_sdk_core_release_notes_preserves_generator_failure_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    release_verify = _release_verify_module()
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(release_verify, "_previous_release_tag", lambda _version: "old")
+    monkeypatch.setattr(release_verify, "_gitlink", lambda revision, _path: revision)
+    monkeypatch.setattr(release_verify, "_git", lambda *_args, **_kwargs: "")
+    error = subprocess.CalledProcessError(101, ["cargo"], output="compiler output")
+    monkeypatch.setattr(
+        release_verify,
+        "_sdk_core_changelog_entries",
+        lambda *_args: (_ for _ in ()).throw(error),
+    )
+
+    with pytest.raises(RuntimeError, match="compiler output"):
+        release_verify._sdk_core_release_notes("1.30.0", str(tmp_path))
+
+
 def test_finalize_changelog_release() -> None:
     text = "## [Unreleased]\n\n### Added\n\n- A thing.\n"
     assert "## [1.30.0] - 2026-06-18" in finalize_changelog_release(


### PR DESCRIPTION
## Summary

- install the stable Rust toolchain before generating SDK Core release notes
- retain Cargo output if the changelog generator still fails after refreshing SDK Core history
- cover the propagated diagnostic with a unit test

## Validation

- `poe test -s tests/test_prepare_release.py`
- `poe lint`