### PR TITLE
Support payload-free system Nexus roots

### DIFF
--- a/scripts/gen_payload_visitor.py
+++ b/scripts/gen_payload_visitor.py
@@ -124,12 +124,20 @@ class VisitorGenerator:
 
         The generated code defines async visitor functions for each reachable
         protobuf message type starting from WorkflowActivation, including support
-        for repeated fields and map entries, and a convenience entrypoint
-        function `visit`.
+        for repeated fields and map entries. Payload-free roots get no-op methods
+        so the `visit` entrypoint recognizes them as supported.
         """
 
-        for r in roots:
-            self.walk(r)
+        for root in roots:
+            if not self.walk(root):
+                self.methods.append(
+                    f"""\
+    async def _visit_{name_for(root)}(
+        self, fs: VisitorFunctions, o: Any
+    ) -> None:
+        pass
+"""
+                )
 
         header = """
 from __future__ import annotations

--- a/temporalio/bridge/_visitor.py
+++ b/temporalio/bridge/_visitor.py
@@ -645,3 +645,8 @@ class PayloadVisitor:
             await self._visit_temporal_api_common_v1_Header(fs, o.header)
         if o.HasField("user_metadata"):
             await self._visit_temporal_api_sdk_v1_UserMetadata(fs, o.user_metadata)
+
+    async def _visit_temporal_api_workflowservice_v1_SignalWithStartWorkflowExecutionResponse(
+        self, fs: VisitorFunctions, o: Any
+    ) -> None:
+        pass

--- a/temporalio/nexus/system/__init__.py
+++ b/temporalio/nexus/system/__init__.py
@@ -15,6 +15,7 @@ from typing import Any
 import temporalio.api.common.v1
 import temporalio.common
 import temporalio.converter
+import temporalio.exceptions
 from temporalio.bridge._visitor_functions import VisitorFunctions
 from temporalio.converter import BinaryProtoPayloadConverter, CompositePayloadConverter
 from temporalio.converter._payload_converter import (
@@ -154,7 +155,14 @@ async def maybe_visit_payload(
 
     payload_visitor = PayloadVisitor(skip_search_attributes=skip_search_attributes)
     checkpoint = visitor_functions.checkpoint()
-    await payload_visitor.visit(visitor_functions, value)
+    try:
+        await payload_visitor.visit(visitor_functions, value)
+    except ValueError as err:
+        if not str(err).startswith("Unknown root message type: "):
+            raise
+        raise temporalio.exceptions.ApplicationError(
+            f"Unknown Temporal system payload: {value.DESCRIPTOR.full_name}"
+        ) from err
     if checkpoint is not None:
         await visitor_functions.drain_since(checkpoint)
     return payload_converter.to_payload(value)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-DEV_SERVER_DOWNLOAD_VERSION = "v1.7.4-standalone-nexus-operations"
+DEV_SERVER_DOWNLOAD_VERSION = "v1.8.3-server-1.32.0-162.0"

--- a/tests/nexus/test_temporal_operation.py
+++ b/tests/nexus/test_temporal_operation.py
@@ -44,9 +44,6 @@ from tests.helpers.nexus import (
 # See https://github.com/temporalio/sdk-python/issues/1704.
 pytestmark = pytest.mark.requires_local_server
 
-# Query response links require a newer server than the shared test environment.
-_QUERY_LINK_DEV_SERVER_DOWNLOAD_VERSION = "v1.8.3-server-1.32.0-162.0"
-
 
 @dataclass
 class Input:
@@ -854,14 +851,7 @@ class QueryWorkflowCaller:
         return await client.execute_operation(TestService.query_op, input.value)
 
 
-async def test_temporal_operation_query_workflow() -> None:
-    async with await WorkflowEnvironment.start_local(
-        dev_server_download_version=_QUERY_LINK_DEV_SERVER_DOWNLOAD_VERSION
-    ) as env:
-        await _assert_temporal_operation_query_workflow(env.client, env)
-
-
-async def _assert_temporal_operation_query_workflow(
+async def test_temporal_operation_query_workflow(
     client: Client, env: WorkflowEnvironment
 ) -> None:
     task_queue = str(uuid.uuid4())
@@ -1314,14 +1304,8 @@ async def test_temporal_operation_start_activity_raises_error(
                 id=str(uuid.uuid4()),
             )
 
-        operation_err = err.value.__cause__
-        assert isinstance(operation_err, temporalio.exceptions.ApplicationError)
-        assert operation_err.type == "OperationError"
-        assert "nexus operation completed unsuccessfully" in str(operation_err)
-
-        application_err = operation_err.__cause__
+        application_err = err.value.__cause__
         assert isinstance(application_err, temporalio.exceptions.ApplicationError)
-
         assert application_err.type == "test-activity-error-type"
         assert "test-activity-error-message" in str(application_err)
         assert application_err.__cause__ is None

--- a/tests/nexus/test_temporal_operation.py
+++ b/tests/nexus/test_temporal_operation.py
@@ -890,15 +890,17 @@ async def test_temporal_operation_query_workflow(
             target_history = await target_handle.fetch_history()
             assert not any(event.links for event in target_history.events)
 
-            assert target_handle.result_run_id is not None
-            assert Link(
-                workflow=Link.Workflow(
-                    namespace=client.namespace,
-                    workflow_id=target_workflow_id,
-                    run_id=target_handle.result_run_id,
-                    reason="Query processed",
-                )
-            ) in list(completed_event.links)
+            # The Java time-skipping test server does not return Nexus operation links.
+            if not env.supports_time_skipping:
+                assert target_handle.result_run_id is not None
+                assert Link(
+                    workflow=Link.Workflow(
+                        namespace=client.namespace,
+                        workflow_id=target_workflow_id,
+                        run_id=target_handle.result_run_id,
+                        reason="Query processed",
+                    )
+                ) in list(completed_event.links)
         finally:
             await target_handle.cancel()
 

--- a/tests/worker/test_visitor.py
+++ b/tests/worker/test_visitor.py
@@ -9,6 +9,7 @@ from google.protobuf.duration_pb2 import Duration
 import temporalio.api.workflowservice.v1.request_response_pb2 as workflowservice_pb2
 import temporalio.bridge.worker
 import temporalio.converter
+import temporalio.exceptions
 import temporalio.nexus.system as nexus_system
 from temporalio.api.common.v1.message_pb2 import (
     Payload,
@@ -302,6 +303,37 @@ async def test_system_nexus_envelope_without_payloads_is_visited():
     completed = completion.successful.commands[0].update_response.completed
     assert payload_converter.from_payload(completed) == response
     assert visitor.system_envelope_count == 1
+
+
+async def test_unknown_system_nexus_payload_raises_application_error():
+    data_converter = temporalio.converter.default()
+    payload_converter = nexus_system._get_payload_converter(
+        data_converter.payload_converter,
+        data_converter.failure_converter,
+    )
+    system_payload = payload_converter.to_payload(
+        workflowservice_pb2.StartWorkflowExecutionResponse(run_id="test-run-id")
+    )
+    assert system_payload is not None
+    completion = WorkflowActivationCompletion(
+        run_id="3",
+        successful=Success(
+            commands=[
+                WorkflowCommand(
+                    update_response=UpdateResponse(completed=system_payload),
+                )
+            ]
+        ),
+    )
+
+    with pytest.raises(temporalio.exceptions.ApplicationError) as err:
+        await PayloadVisitor().visit(Visitor(), completion)
+
+    assert (
+        err.value.message == "Unknown Temporal system payload: "
+        "temporal.api.workflowservice.v1.StartWorkflowExecutionResponse"
+    )
+    assert not err.value.non_retryable
 
 
 async def test_concurrent_throughput():

--- a/tests/worker/test_visitor.py
+++ b/tests/worker/test_visitor.py
@@ -266,6 +266,44 @@ async def test_system_nexus_envelope_is_detected_in_generic_payload_field():
     assert visitor.system_envelope_count == 1
 
 
+async def test_system_nexus_envelope_without_payloads_is_visited():
+    class SystemNexusVisitor(Visitor):
+        def __init__(self) -> None:
+            self.system_envelope_count = 0
+
+        async def visit_system_nexus_envelope(self, payload: Payload) -> None:
+            _ = payload
+            self.system_envelope_count += 1
+
+    response = workflowservice_pb2.SignalWithStartWorkflowExecutionResponse(
+        run_id="test-run-id"
+    )
+    data_converter = temporalio.converter.default()
+    payload_converter = nexus_system._get_payload_converter(
+        data_converter.payload_converter,
+        data_converter.failure_converter,
+    )
+    system_payload = payload_converter.to_payload(response)
+    assert system_payload is not None
+    completion = WorkflowActivationCompletion(
+        run_id="3",
+        successful=Success(
+            commands=[
+                WorkflowCommand(
+                    update_response=UpdateResponse(completed=system_payload),
+                )
+            ]
+        ),
+    )
+    visitor = SystemNexusVisitor()
+
+    await PayloadVisitor().visit(visitor, completion)
+
+    completed = completion.successful.commands[0].update_response.completed
+    assert payload_converter.from_payload(completed) == response
+    assert visitor.system_envelope_count == 1
+
+
 async def test_concurrent_throughput():
     """Demonstrate that concurrent visitation is faster than serialized for I/O-bound codecs."""
     N_CMDS = 10


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Update test server to Server 1.32
- Support payload-free system Nexus roots - Assert the original ApplicationError directly instead of expecting the legacy intermediate OperationError wrapper for Nexus
- Update payload visitor to work for SignalWithStartWorkflowExecutionResponse, which has no payloads.
## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
