### PR TITLE
Update dev server to Server 1.32

### DIFF
--- a/scripts/gen_payload_visitor.py
+++ b/scripts/gen_payload_visitor.py
@@ -124,12 +124,20 @@ class VisitorGenerator:
 
         The generated code defines async visitor functions for each reachable
         protobuf message type starting from WorkflowActivation, including support
-        for repeated fields and map entries, and a convenience entrypoint
-        function `visit`.
+        for repeated fields and map entries. Payload-free roots get no-op methods
+        so the `visit` entrypoint recognizes them as supported.
         """
 
-        for r in roots:
-            self.walk(r)
+        for root in roots:
+            if not self.walk(root):
+                self.methods.append(
+                    f"""\
+    async def _visit_{name_for(root)}(
+        self, fs: VisitorFunctions, o: Any
+    ) -> None:
+        pass
+"""
+                )
 
         header = """
 from __future__ import annotations

--- a/temporalio/bridge/_visitor.py
+++ b/temporalio/bridge/_visitor.py
@@ -635,3 +635,8 @@ class PayloadVisitor:
             await self._visit_temporal_api_common_v1_Header(fs, o.header)
         if o.HasField("user_metadata"):
             await self._visit_temporal_api_sdk_v1_UserMetadata(fs, o.user_metadata)
+
+    async def _visit_temporal_api_workflowservice_v1_SignalWithStartWorkflowExecutionResponse(
+        self, fs: VisitorFunctions, o: Any
+    ) -> None:
+        pass

--- a/temporalio/nexus/system/__init__.py
+++ b/temporalio/nexus/system/__init__.py
@@ -15,6 +15,7 @@ from typing import Any
 import temporalio.api.common.v1
 import temporalio.common
 import temporalio.converter
+import temporalio.exceptions
 from temporalio.bridge._visitor_functions import VisitorFunctions
 from temporalio.converter import BinaryProtoPayloadConverter, CompositePayloadConverter
 from temporalio.converter._payload_converter import (
@@ -154,7 +155,15 @@ async def maybe_visit_payload(
 
     payload_visitor = PayloadVisitor(skip_search_attributes=skip_search_attributes)
     checkpoint = visitor_functions.checkpoint()
-    await payload_visitor.visit(visitor_functions, value)
+    try:
+        await payload_visitor.visit(visitor_functions, value)
+    except ValueError as err:
+        if not str(err).startswith("Unknown root message type: "):
+            raise
+        raise temporalio.exceptions.ApplicationError(
+            f"Unknown Temporal system payload: {value.DESCRIPTOR.full_name}",
+            non_retryable=True,
+        ) from err
     if checkpoint is not None:
         await visitor_functions.drain_since(checkpoint)
     return payload_converter.to_payload(value)

--- a/temporalio/nexus/system/__init__.py
+++ b/temporalio/nexus/system/__init__.py
@@ -161,8 +161,7 @@ async def maybe_visit_payload(
         if not str(err).startswith("Unknown root message type: "):
             raise
         raise temporalio.exceptions.ApplicationError(
-            f"Unknown Temporal system payload: {value.DESCRIPTOR.full_name}",
-            non_retryable=True,
+            f"Unknown Temporal system payload: {value.DESCRIPTOR.full_name}"
         ) from err
     if checkpoint is not None:
         await visitor_functions.drain_since(checkpoint)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-DEV_SERVER_DOWNLOAD_VERSION = "v1.7.4-standalone-nexus-operations"
+DEV_SERVER_DOWNLOAD_VERSION = "v1.8.3-server-1.32.0-162.0"

--- a/tests/worker/test_visitor.py
+++ b/tests/worker/test_visitor.py
@@ -38,6 +38,7 @@ from temporalio.bridge.proto.workflow_completion.workflow_completion_pb2 import 
     Success,
     WorkflowActivationCompletion,
 )
+from temporalio.exceptions import ApplicationError
 from tests.worker.test_workflow import SimpleCodec
 
 
@@ -264,6 +265,75 @@ async def test_system_nexus_envelope_is_detected_in_generic_payload_field():
     assert decoded.input.payloads[0].metadata["visited"] == b"True"
     assert visitor.visited_payload_count == 1
     assert visitor.system_envelope_count == 1
+
+
+async def test_payload_free_system_nexus_envelope_is_detected():
+    class SystemNexusVisitor(Visitor):
+        def __init__(self) -> None:
+            self.system_envelope_count = 0
+
+        async def visit_system_nexus_envelope(self, payload: Payload) -> None:
+            _ = payload
+            self.system_envelope_count += 1
+
+    data_converter = temporalio.converter.default()
+    payload_converter = nexus_system._get_payload_converter(
+        data_converter.payload_converter,
+        data_converter.failure_converter,
+    )
+    response = workflowservice_pb2.SignalWithStartWorkflowExecutionResponse(
+        run_id="test-run-id"
+    )
+    system_payload = payload_converter.to_payload(response)
+    assert system_payload is not None
+    comp = WorkflowActivationCompletion(
+        run_id="3",
+        successful=Success(
+            commands=[
+                WorkflowCommand(
+                    update_response=UpdateResponse(completed=system_payload),
+                )
+            ]
+        ),
+    )
+    visitor = SystemNexusVisitor()
+
+    await PayloadVisitor().visit(visitor, comp)
+
+    completed = comp.successful.commands[0].update_response.completed
+    assert payload_converter.from_payload(completed) == response
+    assert visitor.system_envelope_count == 1
+
+
+async def test_unknown_system_nexus_payload_raises_application_error():
+    data_converter = temporalio.converter.default()
+    payload_converter = nexus_system._get_payload_converter(
+        data_converter.payload_converter,
+        data_converter.failure_converter,
+    )
+    system_payload = payload_converter.to_payload(
+        workflowservice_pb2.StartWorkflowExecutionResponse(run_id="test-run-id")
+    )
+    assert system_payload is not None
+    comp = WorkflowActivationCompletion(
+        run_id="3",
+        successful=Success(
+            commands=[
+                WorkflowCommand(
+                    update_response=UpdateResponse(completed=system_payload),
+                )
+            ]
+        ),
+    )
+
+    with pytest.raises(ApplicationError) as err:
+        await PayloadVisitor().visit(Visitor(), comp)
+
+    assert (
+        err.value.message == "Unknown Temporal system payload: "
+        "temporal.api.workflowservice.v1.StartWorkflowExecutionResponse"
+    )
+    assert err.value.non_retryable
 
 
 async def test_concurrent_throughput():

--- a/tests/worker/test_visitor.py
+++ b/tests/worker/test_visitor.py
@@ -333,7 +333,7 @@ async def test_unknown_system_nexus_payload_raises_application_error():
         err.value.message == "Unknown Temporal system payload: "
         "temporal.api.workflowservice.v1.StartWorkflowExecutionResponse"
     )
-    assert err.value.non_retryable
+    assert not err.value.non_retryable
 
 
 async def test_concurrent_throughput():


### PR DESCRIPTION
## What was changed
- Update the shared dev server to Server 1.32.
- Recognize payload-free Temporal system envelopes, including SignalWithStartWorkflowExecutionResponse.
- Report unsupported Temporal system payloads as retryable ApplicationErrors with the protobuf type in the message.

## Why?
Server 1.32 can return a payload-free SignalWithStartWorkflowExecutionResponse. Supporting that known envelope avoids an unhelpful unknown-root failure, while unsupported system payloads now provide a clear compatibility diagnostic.

## Validation
- poe lint
- poe test -s tests/worker/test_visitor.py -k "system_nexus_envelope or unknown_system_nexus_payload"