### PR TITLE
Fix tests with latest dependencies

### DIFF
--- a/tests/contrib/google_adk_agents/test_adk_streaming.py
+++ b/tests/contrib/google_adk_agents/test_adk_streaming.py
@@ -13,8 +13,7 @@ from datetime import timedelta
 import pytest
 from google.adk import Agent
 
-# ADK 2.7 marks StreamingMode as a private re-export, while older supported
-# versions do not have the suggested google.adk.agents._streaming_mode module.
+# ADK 2.7 marks StreamingMode as a private re-export.
 from google.adk.agents.run_config import (
     RunConfig,
     StreamingMode,  # pyright: ignore[reportPrivateImportUsage]

--- a/tests/contrib/google_adk_agents/test_adk_streaming.py
+++ b/tests/contrib/google_adk_agents/test_adk_streaming.py
@@ -12,7 +12,13 @@ from datetime import timedelta
 
 import pytest
 from google.adk import Agent
-from google.adk.agents.run_config import RunConfig, StreamingMode
+
+# ADK 2.7 marks StreamingMode as a private re-export, while older supported
+# versions do not have the suggested google.adk.agents._streaming_mode module.
+from google.adk.agents.run_config import (
+    RunConfig,
+    StreamingMode,  # pyright: ignore[reportPrivateImportUsage]
+)
 from google.adk.models import BaseLlm, LLMRegistry
 from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse

--- a/tests/contrib/google_genai/test_gemini.py
+++ b/tests/contrib/google_genai/test_gemini.py
@@ -292,8 +292,8 @@ class GeminiApiCallTracker:
         self, req: _GeminiUploadToFileSearchStoreRequest
     ) -> types.UploadToFileSearchStoreOperation:
         self.file_search_store_upload_requests.append(req)
-        return types.UploadToFileSearchStoreOperation.model_construct(
-            name="operations/test-op",
+        return types.UploadToFileSearchStoreOperation.model_validate(
+            {"name": "operations/test-op"}
         )
 
     @activity.defn
@@ -1387,8 +1387,8 @@ def _apply_plugin_with_mock_client(client: Client, mock_responses: list[str]) ->
     )
     gemini.aio.files.download = AsyncMock(return_value=b"mock download content")  # type: ignore[method-assign]
     gemini.aio.file_search_stores.upload_to_file_search_store = AsyncMock(  # type: ignore[method-assign]
-        return_value=types.UploadToFileSearchStoreOperation.model_construct(
-            name="operations/mock-op"
+        return_value=types.UploadToFileSearchStoreOperation.model_validate(
+            {"name": "operations/mock-op"}
         )
     )
 

--- a/tests/nexus/test_temporal_system_nexus.py
+++ b/tests/nexus/test_temporal_system_nexus.py
@@ -566,13 +566,10 @@ def _proto_scalar_sample(field: FieldDescriptor, *, path: str) -> Any:
 
 
 def _field_is_repeated(field: FieldDescriptor) -> bool:
-    return bool(
-        getattr(
-            field,
-            "is_repeated",
-            getattr(field, "label") == FieldDescriptor.LABEL_REPEATED,
-        )
-    )
+    is_repeated = getattr(field, "is_repeated", None)
+    if is_repeated is not None:
+        return bool(is_repeated)
+    return getattr(field, "label") == FieldDescriptor.LABEL_REPEATED
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- keep the Google ADK streaming test compatible with supported versions before 2.7 while suppressing the new private-re-export diagnostic in ADK 2.7
- construct Google GenAI file-search mock results through Pydantic validation so deferred serializers are built before Temporal encodes activity results
- support both old and new Protobuf descriptor APIs without eagerly reading the label property removed in Protobuf 7
- fix the test-latest-deps failures observed in https://github.com/temporalio/sdk-python/actions/runs/33324609939/job/99296636937

## Testing

With Python 3.13 and a temporary uv lock --upgrade / uv sync --all-extras environment:

- poe build-develop
- poe test -s tests/nexus/test_temporal_system_nexus.py tests/contrib/google_genai/test_gemini.py -k "test_system_nexus_proto_roundtrip or test_file_search_store_upload or test_full_integration_with_mock_client" (5 passed)
- poe lint