### PR TITLE
Prevent workflow stream subscriptions from hiding cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ to include examples, links to docs, or any other relevant information.
 
 ### Fixed
 
+- `WorkflowStreamClient.subscribe` now propagates task cancellation instead of
+  ending the subscription normally.
 - `StrandsPlugin` now disables Botocore retries for its default Bedrock model so
   model request retries are handled exclusively by Temporal.
 - `temporalio.contrib.openai_agents` now honors the `retry-after-ms` and

--- a/temporalio/contrib/workflow_streams/_client.py
+++ b/temporalio/contrib/workflow_streams/_client.py
@@ -551,7 +551,7 @@ class WorkflowStreamClient:
                 self._polled_run_id = handle.workflow_run_id
                 result: PollResult = await handle.result()
             except asyncio.CancelledError:
-                return
+                raise
             except WorkflowUpdateFailedError as e:
                 cause_type = getattr(e.cause, "type", None)
                 if cause_type == TRUNCATED_OFFSET_ERROR_TYPE:
@@ -577,7 +577,9 @@ class WorkflowStreamClient:
                         continue
                     return
                 raise
-            except WorkflowUpdateRPCTimeoutOrCancelledError:
+            except WorkflowUpdateRPCTimeoutOrCancelledError as e:
+                if isinstance(e.__cause__, asyncio.CancelledError):
+                    raise e.__cause__
                 if await self._follow_continue_as_new():
                     continue
                 return

--- a/tests/contrib/workflow_streams/test_workflow_streams.py
+++ b/tests/contrib/workflow_streams/test_workflow_streams.py
@@ -405,8 +405,11 @@ class CancellableSubscriber:
         heartbeat_task = asyncio.create_task(heartbeat())
         try:
             stream = WorkflowStreamClient.from_within_activity()
-            async for _ in stream.subscribe(result_type=bytes):
-                self.started.set()
+            try:
+                async for _ in stream.subscribe(result_type=bytes):
+                    self.started.set()
+            except asyncio.CancelledError:
+                return "subscription-cancelled"
             return "subscription-ended"
         finally:
             heartbeat_task.cancel()
@@ -1190,7 +1193,7 @@ async def test_activity_subscription_propagates_cancellation(client: Client) -> 
         async with _async_timeout(5):
             await subscriber.started.wait()
         await handle.signal(CancelSubscriptionWorkflow.cancel_subscription)
-        assert await handle.result() == "CancelledError"
+        assert await handle.result() == "subscription-cancelled"
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/workflow_streams/test_workflow_streams.py
+++ b/tests/contrib/workflow_streams/test_workflow_streams.py
@@ -48,7 +48,7 @@ from temporalio.contrib.workflow_streams import (
 )
 from temporalio.contrib.workflow_streams._types import _encode_payload
 from temporalio.converter import DataConverter
-from temporalio.exceptions import ApplicationError
+from temporalio.exceptions import ActivityError, ApplicationError
 from temporalio.nexus import WorkflowRunOperationContext, workflow_run_operation
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
@@ -86,6 +86,37 @@ class BasicWorkflowStreamWorkflow:
     @workflow.run
     async def run(self) -> None:
         await workflow.wait_condition(lambda: self._closed)
+
+
+@workflow.defn
+class CancelSubscriptionWorkflow:
+    @workflow.init
+    def __init__(self) -> None:
+        self.stream = WorkflowStream()
+        self._cancel_requested = False
+
+    @workflow.signal
+    def cancel_subscription(self) -> None:
+        self._cancel_requested = True
+
+    @workflow.run
+    async def run(self) -> str:
+        self.stream.topic("events", type=bytes).publish(b"seed")
+        handle = workflow.start_activity(
+            "subscribe_until_cancelled",
+            start_to_close_timeout=timedelta(seconds=30),
+            heartbeat_timeout=timedelta(seconds=1),
+            cancellation_type=workflow.ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
+        )
+        await workflow.wait_condition(lambda: self._cancel_requested)
+        handle.cancel()
+        try:
+            result = await handle
+        except ActivityError as err:
+            result = type(err.cause).__name__
+        self.stream.detach_pollers()
+        await workflow.wait_condition(workflow.all_handlers_finished)
+        return result
 
 
 @workflow.defn
@@ -358,6 +389,28 @@ async def publish_items(count: int) -> None:
         for i in range(count):
             activity.heartbeat()
             client.topic("events", type=bytes).publish(f"item-{i}".encode())
+
+
+class CancellableSubscriber:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+
+    @activity.defn(name="subscribe_until_cancelled")
+    async def subscribe(self) -> str:
+        async def heartbeat() -> None:
+            while True:
+                activity.heartbeat()
+                await asyncio.sleep(0.1)
+
+        heartbeat_task = asyncio.create_task(heartbeat())
+        try:
+            stream = WorkflowStreamClient.from_within_activity()
+            async for _ in stream.subscribe(result_type=bytes):
+                self.started.set()
+            return "subscription-ended"
+        finally:
+            heartbeat_task.cancel()
+            await asyncio.gather(heartbeat_task, return_exceptions=True)
 
 
 @activity.defn(name="publish_multi_topic")
@@ -1076,7 +1129,7 @@ async def test_priority_flush(client: Client) -> None:
 @pytest.mark.asyncio
 async def test_iterator_cancellation(client: Client) -> None:
     """Cancelling a subscription iterator after it has yielded an item
-    completes cleanly."""
+    propagates cancellation."""
     async with new_worker(
         client,
         BasicWorkflowStreamWorkflow,
@@ -1112,15 +1165,32 @@ async def test_iterator_cancellation(client: Client) -> None:
         async with _async_timeout(5):
             await first_item.wait()
         task.cancel()
-        try:
+        with pytest.raises(asyncio.CancelledError):
             await task
-        except asyncio.CancelledError:
-            pass
 
         assert len(items) == 1
         assert items[0].data == b"seed"
 
         await handle.signal(BasicWorkflowStreamWorkflow.close)
+
+
+@pytest.mark.asyncio
+async def test_activity_subscription_propagates_cancellation(client: Client) -> None:
+    subscriber = CancellableSubscriber()
+    async with new_worker(
+        client,
+        CancelSubscriptionWorkflow,
+        activities=[subscriber.subscribe],
+    ) as worker:
+        handle = await client.start_workflow(
+            CancelSubscriptionWorkflow.run,
+            id=f"workflow-stream-activity-cancel-{uuid.uuid4()}",
+            task_queue=worker.task_queue,
+        )
+        async with _async_timeout(5):
+            await subscriber.started.wait()
+        await handle.signal(CancelSubscriptionWorkflow.cancel_subscription)
+        assert await handle.result() == "CancelledError"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When an activity blocks in `WorkflowStreamClient.subscribe` and its workflow
cancels it, the subscription currently ends like a normal iterator. The activity
can then return success even though Temporal requested cancellation. This change
propagates the cancellation to the activity.

The subscription now rethrows direct task cancellation and cancellation wrapped
by `WorkflowUpdateRPCTimeoutOrCancelledError`. RPC timeouts and server-side RPC
cancellation keep their existing continue-as-new and terminal-workflow handling.

## Testing

The regression test starts a real Temporal dev server, waits until a heartbeating
activity is polling a workflow stream, and then cancels that activity. The
activity catches `CancelledError` directly around the subscription and returns a
distinct sentinel, so an error added later by the activity runtime cannot satisfy
the assertion.

<details><summary>Before</summary>

```console
$ git checkout upstream/main -- temporalio/contrib/workflow_streams/_client.py
$ uv run pytest tests/contrib/workflow_streams/test_workflow_streams.py::test_activity_subscription_propagates_cancellation -q --no-header
E           AssertionError: assert 'subscription-ended' == 'subscription-cancelled'
Results (3.30s):
         1 failed
```

</details>

<details><summary>After</summary>

```console
$ git checkout HEAD -- temporalio/contrib/workflow_streams/_client.py
$ uv run pytest tests/contrib/workflow_streams/test_workflow_streams.py::test_activity_subscription_propagates_cancellation -q --no-header
.                                                                        [100%]
Results (2.95s):
         1 passed
```

</details>
