### PR TITLE
Document root workflow namespace omission

### DIFF
--- a/temporalio/client/_workflow.py
+++ b/temporalio/client/_workflow.py
@@ -1255,10 +1255,18 @@ class WorkflowExecution:
     """Run ID for the parent workflow if this was started as a child."""
 
     root_id: str | None
-    """ID for the root workflow."""
+    """ID for the root workflow.
+
+    The root namespace is not retained and may differ from this workflow's namespace for
+    cross-namespace child workflows. Track it separately if needed.
+    """
 
     root_run_id: str | None
-    """Run ID for the root workflow."""
+    """Run ID for the root workflow.
+
+    The root namespace is not retained and may differ from this workflow's namespace for
+    cross-namespace child workflows. Track it separately if needed.
+    """
 
     raw_info: temporalio.api.workflow.v1.WorkflowExecutionInfo
     """Underlying protobuf info."""

--- a/temporalio/workflow/_context.py
+++ b/temporalio/workflow/_context.py
@@ -92,6 +92,8 @@ class Info:
     namespace: str
     parent: ParentInfo | None
     root: RootInfo | None
+    """Root information. Its namespace is not retained and may differ from this workflow's
+    namespace for cross-namespace child workflows. Track it separately if needed."""
     priority: temporalio.common.Priority
     """The priority of this workflow execution. If not set, or this server predates priorities,
     then returns a default instance."""
@@ -217,7 +219,11 @@ class ParentInfo:
 
 @dataclass(frozen=True)
 class RootInfo:
-    """Information about the root workflow."""
+    """Information about the root workflow.
+
+    The namespace is not retained and may differ from the current workflow's namespace for
+    cross-namespace child workflows. Track it separately if needed.
+    """
 
     run_id: str
     workflow_id: str


### PR DESCRIPTION
## What was changed
Document that root workflow execution information omits its namespace. The root namespace may differ for cross-namespace child workflows and must be tracked separately.

## Why?
Completes the documentation requirement from temporalio/features#605.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only changes with no behavioral impact on the SDK.
> 
> **Overview**
> Expands API docstrings so callers know **root workflow execution info does not include the root’s namespace**. For cross-namespace child workflows, that namespace can differ from the current workflow’s namespace and must be tracked separately.
> 
> On the **client** side, `WorkflowExecution.root_id` and `root_run_id` now note that the root namespace is not retained. In **workflow** code, the same guidance appears on `Info.root`, `RootInfo`, and contrasts with `ParentInfo`, which still exposes parent `namespace`.
> 
> No runtime or type changes—documentation only, aligned with temporalio/features#605.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d48bb8f3898dc8d92b27fe1c5bc0bdf8c05a9c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->