### PR TITLE
Fix heartbeat task-slot/poller info reporting 0 with MetricBuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ to include examples, links to docs, or any other relevant information.
 
 ### Fixed
 
+- Worker heartbeats reported through a `MetricBuffer` now include correct task-slot and poller
+  counts. Previously those labelled gauges always reported `0` when buffered metrics were
+  configured, hiding the slots and pollers from the Workers UI.
 - `StrandsPlugin` now disables Botocore retries for its default Bedrock model so
   model request retries are handled exclusively by Temporal.
 - `temporalio.contrib.openai_agents` now honors the `retry-after-ms` and


### PR DESCRIPTION
## What & Why

Fixes https://github.com/temporalio/sdk-python/issues/1817. When a worker uses `TelemetryConfig(metrics=MetricBuffer(...))`, every **labelled** worker-heartbeat metric (task-slot and poller counts) was reported to the server as `0`, hiding them from the Workers UI.

The bug is in Core: heartbeat slot/poller gauges are written via an in-memory tap that resolves labels from metric attributes, but the buffered attributes handle couldn't be read core-side. This PR bumps the `sdk-core` submodule to a commit that retains the key-value pairs core-side so label resolution works without touching the lang-held buffer.

The actual Core fix lives in https://github.com/temporalio/sdk-rust/pull/1593.

## Changes

- Bump `temporalio/bridge/sdk-core` submodule to `7d95a31e` (buffered heartbeat metric label fix).
- CHANGELOG entry under `[Unreleased]`.

## Validation

- `poe build-develop` (rebuilds the Rust bridge against the new submodule).
- `poe lint`, `poe test -s -k <metric pattern>`, `poe bridge-lint`.
- The public repro repo (https://github.com/bmcqueen-tmprl/temporal-py-heartbeat-slot-repro) was used to confirm slot/poller counts are no longer `0` with `MetricBuffer`.