### PR TITLE
Retry schedule updates on conflict token mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ to include examples, links to docs, or any other relevant information.
 
 ### Fixed
 
+- Schedule updates now pass the conflict token returned by the server and retry
+  the describe-update loop when a concurrent update changes the schedule.
 - **Experimental**: External storage metrics now report the wall-clock time storage was in flight.
   Previously each batch's duration was summed, over-reporting the time whenever storage operations
   ran concurrently.

--- a/temporalio/client/_impl.py
+++ b/temporalio/client/_impl.py
@@ -1364,49 +1364,57 @@ class _ClientImpl(OutboundInterceptor):  # pyright: ignore[reportUnusedClass]
         )
 
     async def update_schedule(self, input: UpdateScheduleInput) -> None:
-        # TODO(cretz): This is supposed to be a retry-conflict loop, but we do
-        # not yet have a way to know update failure is due to conflict token
-        # mismatch
-        update = input.updater(
-            ScheduleUpdateInput(
-                description=ScheduleDescription._from_proto(
-                    input.id,
-                    await self._client.workflow_service.describe_schedule(
-                        temporalio.api.workflowservice.v1.DescribeScheduleRequest(
-                            namespace=self._client.namespace,
-                            schedule_id=input.id,
-                        ),
-                        retry=True,
-                        metadata=input.rpc_metadata,
-                        timeout=input.rpc_timeout,
-                    ),
-                    self._client.data_converter,
+        while True:
+            describe_response = await self._client.workflow_service.describe_schedule(
+                temporalio.api.workflowservice.v1.DescribeScheduleRequest(
+                    namespace=self._client.namespace,
+                    schedule_id=input.id,
+                ),
+                retry=True,
+                metadata=input.rpc_metadata,
+                timeout=input.rpc_timeout,
+            )
+            update = input.updater(
+                ScheduleUpdateInput(
+                    description=ScheduleDescription._from_proto(
+                        input.id,
+                        describe_response,
+                        self._client.data_converter,
+                    )
                 )
             )
-        )
-        if inspect.iscoroutine(update):
-            update = await update
-        if not update:
-            return
-        assert isinstance(update, ScheduleUpdate)
-        request = temporalio.api.workflowservice.v1.UpdateScheduleRequest(
-            namespace=self._client.namespace,
-            schedule_id=input.id,
-            schedule=await update.schedule._to_proto(self._client),
-            identity=self._client.identity,
-            request_id=str(uuid.uuid4()),
-        )
-        if update.search_attributes is not None:
-            request.search_attributes.indexed_fields.clear()  # Ensure that we at least create an empty map
-            temporalio.converter.encode_search_attributes(
-                update.search_attributes, request.search_attributes
+            if inspect.iscoroutine(update):
+                update = await update
+            if not update:
+                return
+            assert isinstance(update, ScheduleUpdate)
+            request = temporalio.api.workflowservice.v1.UpdateScheduleRequest(
+                namespace=self._client.namespace,
+                schedule_id=input.id,
+                schedule=await update.schedule._to_proto(self._client),
+                conflict_token=describe_response.conflict_token,
+                identity=self._client.identity,
+                request_id=str(uuid.uuid4()),
             )
-        await self._client.workflow_service.update_schedule(
-            request,
-            retry=True,
-            metadata=input.rpc_metadata,
-            timeout=input.rpc_timeout,
-        )
+            if update.search_attributes is not None:
+                request.search_attributes.indexed_fields.clear()  # Ensure that we at least create an empty map
+                temporalio.converter.encode_search_attributes(
+                    update.search_attributes, request.search_attributes
+                )
+            try:
+                await self._client.workflow_service.update_schedule(
+                    request,
+                    retry=True,
+                    metadata=input.rpc_metadata,
+                    timeout=input.rpc_timeout,
+                )
+                return
+            except RPCError as err:
+                if (
+                    err.status != RPCStatusCode.FAILED_PRECONDITION
+                    or err.message != "mismatched conflict token"
+                ):
+                    raise
 
     async def update_worker_build_id_compatibility(
         self, input: UpdateWorkerBuildIdCompatibilityInput

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,6 +16,10 @@ import pytest
 from google.protobuf import json_format
 
 import temporalio.api.common.v1
+import temporalio.api.enums.v1
+import temporalio.api.schedule.v1
+import temporalio.api.taskqueue.v1
+import temporalio.api.workflow.v1
 import temporalio.api.workflowservice.v1
 import temporalio.common
 import temporalio.exceptions
@@ -325,6 +329,70 @@ async def test_rpc_already_exists_error_is_raised(client: Client):
             await client.start_workflow("fake", id="fake", task_queue="fake")
     assert err.value.status == RPCStatusCode.ALREADY_EXISTS
 
+
+async def test_schedule_update_retries_conflict_token() -> None:
+    schedule = temporalio.api.schedule.v1.Schedule(
+        spec=temporalio.api.schedule.v1.ScheduleSpec(),
+        action=temporalio.api.schedule.v1.ScheduleAction(
+            start_workflow=temporalio.api.workflow.v1.NewWorkflowExecutionInfo(
+                workflow_id="workflow-id",
+                workflow_type=temporalio.api.common.v1.WorkflowType(name="workflow"),
+                task_queue=temporalio.api.taskqueue.v1.TaskQueue(name="task-queue"),
+            )
+        ),
+        policies=temporalio.api.schedule.v1.SchedulePolicies(
+            overlap_policy=temporalio.api.enums.v1.ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_SKIP
+        ),
+        state=temporalio.api.schedule.v1.ScheduleState(),
+    )
+    workflow_service = mock.MagicMock()
+    workflow_service.describe_schedule = mock.AsyncMock(
+        side_effect=[
+            temporalio.api.workflowservice.v1.DescribeScheduleResponse(
+                schedule=schedule,
+                info=temporalio.api.schedule.v1.ScheduleInfo(),
+                conflict_token=b"first-token",
+            ),
+            temporalio.api.workflowservice.v1.DescribeScheduleResponse(
+                schedule=schedule,
+                info=temporalio.api.schedule.v1.ScheduleInfo(),
+                conflict_token=b"second-token",
+            ),
+        ]
+    )
+    workflow_service.update_schedule = mock.AsyncMock(
+        side_effect=[
+            RPCError(
+                "mismatched conflict token",
+                RPCStatusCode.FAILED_PRECONDITION,
+                b"",
+            ),
+            temporalio.api.workflowservice.v1.UpdateScheduleResponse(),
+        ]
+    )
+    service_client = mock.MagicMock()
+    service_client.config.identity = "test-identity"
+    service_client.workflow_service = workflow_service
+    client = Client(service_client)
+
+    updater_calls = 0
+
+    def updater(input: ScheduleUpdateInput) -> ScheduleUpdate:
+        nonlocal updater_calls
+        updater_calls += 1
+        return ScheduleUpdate(schedule=input.description.schedule)
+
+    await client.get_schedule_handle("schedule-id").update(updater)
+
+    assert updater_calls == 2
+    assert workflow_service.describe_schedule.await_count == 2
+    requests = [
+        call.args[0] for call in workflow_service.update_schedule.await_args_list
+    ]
+    assert [request.conflict_token for request in requests] == [
+        b"first-token",
+        b"second-token",
+    ]
 
 async def test_cancel_not_found(client: Client):
     with pytest.raises(RPCError) as err:


### PR DESCRIPTION
## What changed
- Pass the schedule describe response conflict token into update schedule requests.
- Retry the describe/update loop when the server reports a mismatched conflict token.
- Add a unit test covering the retry path and conflict token propagation.

Fixes #1367

## Checks
- uv run pytest tests/test_client.py::test_schedule_update_retries_conflict_token
- uv run ruff check --select I temporalio/client/_impl.py tests/test_client.py
- uv run ruff format --check temporalio/client/_impl.py tests/test_client.py
- uv run pyright temporalio/client/_impl.py tests/test_client.py
- git diff --check

---

Hi Temporal maintainers,

Could someone take a look when convenient and let me know if any changes are needed?
Thanks!