### PR TITLE
Use retrying client for worker deployment RPCs in tests

### DIFF
--- a/tests/worker/test_worker.py
+++ b/tests/worker/test_worker.py
@@ -1281,7 +1281,8 @@ async def wait_until_worker_deployment_visible(
                 DescribeWorkerDeploymentRequest(
                     namespace=client.namespace,
                     deployment_name=version.deployment_name,
-                )
+                ),
+                retry=True,
             )
         except RPCError:
             # Expected
@@ -1304,7 +1305,8 @@ async def set_current_deployment_version(
             deployment_name=version.deployment_name,
             version=version.to_canonical_string(),
             conflict_token=conflict_token,
-        )
+        ),
+        retry=True,
     )
 
 
@@ -1321,7 +1323,8 @@ async def set_ramping_version(
             version=version.to_canonical_string(),
             conflict_token=conflict_token,
             percentage=percentage,
-        )
+        ),
+        retry=True,
     )
     return response
 
@@ -1341,7 +1344,8 @@ async def wait_for_worker_deployment_routing_config_propagation(
             DescribeWorkerDeploymentRequest(
                 namespace=client.namespace,
                 deployment_name=deployment_name,
-            )
+            ),
+            retry=True,
         )
         routing_config = resp.worker_deployment_info.routing_config
         if (


### PR DESCRIPTION
## What was changed

The worker deployment helpers in `tests/worker/test_worker.py` call the raw service stubs with `retry=True`.

## Why

The frontend recycles client connections every 5 minutes with an HTTP/2 GOAWAY. A worker's long polls keep the old connection open, so hyper only notices when the next request is queued and drops it as `CANCELLED ('operation was canceled')` before it reaches the server. sdk-core retries transport-level cancels, but only through the retry client, which these helpers bypassed. CI sessions outlive the 5-minute window, so the first raw non-retried RPC after a recycle fails. Temporal Cloud recycles the same way.

## Testing

Dev server with `frontend.keepAliveMaxConnectionAge="5s"`, four deployment tests x10: 9/40 failed before, 40/40 after. Default config, `-k deployment` x8 under xdist: 48/48. Lint clean.
