### PR TITLE
Fix activity pause test races

### DIFF
--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -239,7 +239,7 @@ async def assert_workflow_exists_eventually(
 async def assert_pending_activity_exists_eventually(
     handle: WorkflowHandle,
     activity_id: str,
-    timeout: timedelta = timedelta(seconds=5),
+    timeout: timedelta = timedelta(seconds=10),
 ) -> PendingActivityInfo:
     """Wait until a pending activity with the given ID exists and return it."""
 
@@ -351,7 +351,11 @@ async def pause_and_assert(client: Client, handle: WorkflowHandle, activity_id: 
 
 
 async def unpause_and_assert(client: Client, handle: WorkflowHandle, activity_id: str):
-    """Unpause the given activity and assert it is not paused."""
+    """Unpause the given activity and assert it is no longer paused.
+
+    An unpaused activity may retry and close before we observe it, so an
+    activity that is no longer pending also counts as unpaused.
+    """
     desc = await handle.describe()
     req = UnpauseActivityRequest(
         namespace=client.namespace,
@@ -363,10 +367,9 @@ async def unpause_and_assert(client: Client, handle: WorkflowHandle, activity_id
     )
     await client.workflow_service.unpause_activity(req)
 
-    # Assert eventually not paused
     async def check_unpaused() -> None:
-        info = await assert_pending_activity_exists_eventually(handle, activity_id)
-        assert not info.paused, f"Activity {activity_id} still paused"
+        info = await get_pending_activity_info(handle, activity_id)
+        assert info is None or not info.paused, f"Activity {activity_id} still paused"
 
     await assert_eventually(check_unpaused)
 

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -8938,7 +8938,6 @@ class ActivityHeartbeatWorkflow:
                 True,
                 activity_id=activity_id,
                 start_to_close_timeout=timedelta(seconds=10),
-                heartbeat_timeout=timedelta(seconds=2),
                 retry_policy=RetryPolicy(maximum_attempts=1),
             )
         )
@@ -8948,7 +8947,6 @@ class ActivityHeartbeatWorkflow:
                 True,
                 activity_id=f"{activity_id}-2",
                 start_to_close_timeout=timedelta(seconds=10),
-                heartbeat_timeout=timedelta(seconds=2),
                 retry_policy=RetryPolicy(maximum_attempts=1),
             )
         )
@@ -8967,6 +8965,8 @@ async def test_activity_pause_cancellation_details(
             workflows=[ActivityHeartbeatWorkflow],
             activities=[heartbeat_activity, sync_heartbeat_activity],
             activity_executor=executor,
+            max_heartbeat_throttle_interval=timedelta(milliseconds=300),
+            default_heartbeat_throttle_interval=timedelta(milliseconds=300),
         ) as worker:
             test_activity_id = f"heartbeat-activity-{uuid.uuid4()}"
 
@@ -9019,7 +9019,6 @@ class ActivityHeartbeatPauseUnpauseWorkflow:
                 False,
                 activity_id=activity_id,
                 start_to_close_timeout=timedelta(seconds=10),
-                heartbeat_timeout=timedelta(seconds=1),
                 retry_policy=RetryPolicy(maximum_attempts=2),
             )
         )
@@ -9029,7 +9028,6 @@ class ActivityHeartbeatPauseUnpauseWorkflow:
                 False,
                 activity_id=f"{activity_id}-2",
                 start_to_close_timeout=timedelta(seconds=10),
-                heartbeat_timeout=timedelta(seconds=1),
                 retry_policy=RetryPolicy(maximum_attempts=2),
             )
         )
@@ -9127,7 +9125,6 @@ class ExternalActivityWorkflow:
             external_activity_heartbeat,
             activity_id=activity_id,
             start_to_close_timeout=timedelta(seconds=10),
-            heartbeat_timeout=timedelta(seconds=1),
             retry_policy=RetryPolicy(maximum_attempts=2),
         )
 
@@ -9167,12 +9164,11 @@ async def test_external_activity_cancellation_details(
         # Pause activity then assert it is paused
         await pause_and_assert(client, wf_handle, activity_info.activity_id)
 
-        try:
+        with pytest.raises(AsyncActivityCancelledError) as err:
             await external_activity_handle.heartbeat()
-        except AsyncActivityCancelledError as err:
-            assert err.details == temporalio.activity.ActivityCancellationDetails(
-                paused=True
-            )
+        assert err.value.details == temporalio.activity.ActivityCancellationDetails(
+            paused=True
+        )
 
 
 @activity.defn


### PR DESCRIPTION
## What was changed

`unpause_and_assert` accepts an activity that is no longer pending as unpaused; the pause tests drop their 1-2s heartbeat timeouts and set a 300ms heartbeat throttle; the cold-start bound for the first activity uses the suite's 10s default; the external cancellation test asserts the heartbeat raises instead of passing silently.

## Why

After unpause the retried attempt can complete within a second, so a slow `describe()` found nothing pending. With a 1-2s heartbeat timeout and the default 80% throttle the server had 200-400ms of slack before timing the attempt out, after which pause by ID fails with `Can't find pending activity`. A cold worker's first task exceeded the 5s bound on CI.

## Testing

Each mechanism reproduced by injecting describe or heartbeat latency: fails before, passes after. 120/120 flake-finder runs under load. Lint clean.
