### PR TITLE
Give manual activity tests time for the start handshake

### DIFF
--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -752,7 +752,7 @@ async def test_manual_completion(client: Client, env: WorkflowEnvironment):
         ActivityInput(event_workflow_id=event_workflow_id),
         id=activity_id,
         task_queue=task_queue,
-        start_to_close_timeout=timedelta(seconds=5),
+        start_to_close_timeout=timedelta(minutes=1),
     )
 
     async with Worker(
@@ -794,7 +794,7 @@ async def test_manual_cancellation(client: Client, env: WorkflowEnvironment):
         ActivityInput(event_workflow_id=event_workflow_id),
         id=activity_id,
         task_queue=task_queue,
-        start_to_close_timeout=timedelta(seconds=5),
+        start_to_close_timeout=timedelta(minutes=1),
     )
 
     async with Worker(
@@ -855,7 +855,7 @@ async def test_manual_failure(client: Client, env: WorkflowEnvironment):
         ActivityInput(event_workflow_id=event_workflow_id),
         id=activity_id,
         task_queue=task_queue,
-        start_to_close_timeout=timedelta(seconds=5),
+        start_to_close_timeout=timedelta(minutes=1),
     )
     async with Worker(
         client,
@@ -932,7 +932,7 @@ async def test_manual_heartbeat(client: Client, env: WorkflowEnvironment):
         ),
         id=activity_id,
         task_queue=task_queue,
-        start_to_close_timeout=timedelta(seconds=5),
+        start_to_close_timeout=timedelta(minutes=1),
     )
     wait_for_activity_start_wf_handle = await client.start_workflow(
         EventWorkflow.wait,


### PR DESCRIPTION
## What was changed

`test_manual_completion`, `test_manual_cancellation`, `test_manual_failure` and `test_manual_heartbeat` start their standalone activity with `start_to_close_timeout=timedelta(minutes=1)` instead of 5 seconds.

## Why

`tests/test_activity.py::test_manual_heartbeat` failed on macOS CI (run 33848127955 attempt 2) with `RPCError: activity not found for ID: <uuid>` (NOT_FOUND) from the heartbeat-by-ID call.

These tests learn that the activity attempt is running through a handshake: the activity signals an `EventWorkflow`, the test waits for that workflow, then completes/cancels/fails/heartbeats the attempt by ID. The handshake includes the first workflow task of a freshly started worker. In the failing run the captured log shows the attempt starting at 08:00:57 and the handshake workflow completing at 08:01:02, so by the time the test heartbeated, the 5 second start-to-close timeout had already closed the attempt. Nothing in these tests relies on the attempt timing out; the bound only decides how slow a runner may be before the test breaks, so it is raised well above anything the per-test pytest timeout allows.

## Testing

- The four tests pass 40/40 each with `--flake-finder -n 6` under CPU load (the handshake is too fast on a development machine to reproduce the CI timing).
- `poe lint` clean.
