### PR TITLE
Pass pydantic_core through the workflow sandbox by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ to include examples, links to docs, or any other relevant information.
   retried on its configured interval instead.
 - Nexus-context workflow/activity starts no longer set `on_conflict_options` when there are no links
   or callbacks to attach.
+- The workflow sandbox now passes `pydantic_core` through by default, alongside `pydantic`.
+  Libraries built on Pydantic (e.g. `openai`) import it lazily, so every sandboxed workflow used to
+  re-import it during its first activation. That import counted toward the deadlock detection
+  timeout and could fail workflow tasks on slow or overloaded workers.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,9 +67,6 @@ to include examples, links to docs, or any other relevant information.
 - Nexus-context workflow/activity starts no longer set `on_conflict_options` when there are no links
   or callbacks to attach.
 - The workflow sandbox now passes `pydantic_core` through by default, alongside `pydantic`.
-  Libraries built on Pydantic (e.g. `openai`) import it lazily, so every sandboxed workflow used to
-  re-import it during its first activation. That import counted toward the deadlock detection
-  timeout and could fail workflow tasks on slow or overloaded workers.
 
 ### Security
 

--- a/temporalio/worker/workflow_sandbox/_restrictions.py
+++ b/temporalio/worker/workflow_sandbox/_restrictions.py
@@ -513,6 +513,8 @@ SandboxRestrictions.passthrough_modules_with_temporal = (
         # Due to how Pydantic is importing lazily inside of some classes, we choose
         # to always pass it through
         "pydantic",
+        # Same for its compiled core, which Pydantic-based libraries import lazily
+        "pydantic_core",
     }
 )
 

--- a/tests/contrib/openai_agents/test_openai_replay.py
+++ b/tests/contrib/openai_agents/test_openai_replay.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 import pytest
@@ -32,6 +33,10 @@ async def test_replay(file_name: str) -> None:
     with (Path(__file__).with_name("histories") / file_name).open("r") as f:
         history_json = f.read()
 
+    with warnings.catch_warnings(record=True) as recorder:
+        warnings.filterwarnings(
+            "always", message=r"Module .* was imported after initial workflow load"
+        )
         await Replayer(
             workflows=[
                 ResearchWorkflow,
@@ -44,3 +49,10 @@ async def test_replay(file_name: str) -> None:
             ],
             plugins=[OpenAIAgentsPlugin()],
         ).replay_workflow(WorkflowHistory.from_json("fake", history_json))
+
+    # Sandbox imports during an activation count toward the deadlock timeout
+    assert not [
+        str(w.message)
+        for w in recorder
+        if "was imported after initial workflow load" in str(w.message)
+    ]


### PR DESCRIPTION
## What was changed

`pydantic_core` joins `pydantic` in the sandbox's default passthrough list. Regression assertion in the OpenAI Agents replay test and CHANGELOG entry.

## Why

Libraries built on Pydantic import `pydantic_core` lazily (`openai._compat` does on the first activity result), so each sandbox re-imported about 4.6k lines of it during its first activation, inside the deadlock-detector budget. On slow CI runners (the source of the motivating observation behind this PR), that tripped `Potential deadlock detected` in the replay tests. The compiled core has no time, random or IO behavior, and its extension objects were already shared across sandboxes.

## Testing

First activation with an activity result: 6-57ms before, 1-2ms after; under emulated starvation 925ms max before, 0.1ms after. Replay tests 35/35 under load on 3.10 and 3.14. The exact 2s trip did not reproduce locally; the CI traces are the evidence for it.
