### PR TITLE
Remove redundant workflow deadlines from google_genai and openai_agents tests

### DIFF
--- a/tests/contrib/google_genai/test_gemini.py
+++ b/tests/contrib/google_genai/test_gemini.py
@@ -769,7 +769,7 @@ class RegisterFilesWorkflow:
         # Missing credentials is a permanent error; retrying only delays it.
         client = TemporalAsyncClient(
             activity_config=ActivityConfig(
-                start_to_close_timeout=timedelta(seconds=30),
+                start_to_close_timeout=timedelta(seconds=60),
                 retry_policy=RetryPolicy(maximum_attempts=1),
             )
         )

--- a/tests/contrib/google_genai/test_gemini.py
+++ b/tests/contrib/google_genai/test_gemini.py
@@ -766,7 +766,13 @@ class RegisterFilesWorkflow:
 
     @workflow.run
     async def run(self, uris: list[str]) -> str:
-        client = TemporalAsyncClient()
+        # Missing credentials is a permanent error; retrying only delays it.
+        client = TemporalAsyncClient(
+            activity_config=ActivityConfig(
+                start_to_close_timeout=timedelta(seconds=30),
+                retry_policy=RetryPolicy(maximum_attempts=1),
+            )
+        )
         # auth arg is ignored by TemporalAsyncFiles — the activity uses
         # credentials from GoogleGenAIPlugin init.  We pass a dummy here;
         # can't import google.auth.credentials in the sandbox so we
@@ -901,7 +907,6 @@ async def test_simple_generate_content(client: Client):
             "Say hello",
             id=f"gemini-simple-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert result == "Hello from Gemini!"
@@ -928,7 +933,6 @@ async def test_tool_call_single_arg(client: Client):
             "What's the weather in Tokyo?",
             id=f"gemini-tool-single-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert tool_tracker.calls == [("get_weather", {"city": "Tokyo"})]
@@ -958,7 +962,6 @@ async def test_tool_call_multi_arg(client: Client):
             "What's the weather in Paris, France?",
             id=f"gemini-tool-multi-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert tool_tracker.calls == [
@@ -988,7 +991,6 @@ async def test_tool_failure_propagation(client: Client):
                 "Weather in Nowhere?",
                 id=f"gemini-tool-fail-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
 
     assert tool_tracker.calls == [("get_weather_failure", {"city": "Nowhere"})]
@@ -1021,7 +1023,6 @@ async def test_multiple_tools_sequential(client: Client):
             "Compare Tokyo and Paris weather",
             id=f"gemini-multi-tools-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=15),
         )
 
     assert tool_tracker.calls == [
@@ -1047,7 +1048,6 @@ async def test_workflow_method_as_tool(client: Client):
             "Tell me about Berlin",
             id=f"gemini-wf-method-tool-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
         result = await handle.result()
         # Query must happen while worker is alive
@@ -1069,7 +1069,6 @@ async def test_streamed_generate_content(client: Client):
             "Say something",
             id=f"gemini-streamed-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     # The tracker splits the text into per-word chunks
@@ -1092,7 +1091,6 @@ async def test_http_options_headers_propagate(client: Client):
             args=["hi", {"headers": {"X-Custom": "test-value"}}],
             id=f"gemini-http-headers-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert len(api_tracker.requests) == 1
@@ -1111,7 +1109,6 @@ async def test_http_options_api_version_propagates(client: Client):
             args=["hi", {"api_version": "v1"}],
             id=f"gemini-http-version-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert len(api_tracker.requests) == 1
@@ -1130,7 +1127,6 @@ async def test_http_options_base_url_propagates(client: Client):
             args=["hi", {"base_url": "https://custom.example.com"}],
             id=f"gemini-http-base-url-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert len(api_tracker.requests) == 1
@@ -1156,7 +1152,6 @@ async def test_http_options_multiple_fields_propagate(client: Client):
             ],
             id=f"gemini-http-multi-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert len(api_tracker.requests) == 1
@@ -1177,7 +1172,6 @@ async def test_no_http_options_passes_none(client: Client):
             "hi",
             id=f"gemini-http-none-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert len(api_tracker.requests) == 1
@@ -1199,7 +1193,6 @@ async def test_file_upload_str_path(client: Client):
             "/tmp/test.txt",
             id=f"gemini-file-upload-str-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert len(api_tracker.file_upload_requests) == 1
@@ -1221,7 +1214,6 @@ async def test_file_upload_bytes(client: Client):
             b"hello world",
             id=f"gemini-file-upload-bytes-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert len(api_tracker.file_upload_requests) == 1
@@ -1243,7 +1235,6 @@ async def test_file_download(client: Client):
             "files/some-file",
             id=f"gemini-file-download-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert len(api_tracker.file_download_requests) == 1
@@ -1266,7 +1257,6 @@ async def test_file_search_store_upload(client: Client):
             args=["fileSearchStores/my-store", "/tmp/doc.txt"],
             id=f"gemini-fss-upload-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert len(api_tracker.file_search_store_upload_requests) == 1
@@ -1299,7 +1289,6 @@ async def test_chat_multi_turn(client: Client):
             "Hello",
             id=f"gemini-chat-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert len(api_tracker.requests) == 2
@@ -1448,7 +1437,6 @@ async def test_full_integration_with_mock_client(client: Client):
             "test prompt",
             id=f"gemini-full-integration-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=15),
         )
 
     assert result["generate"] == "Real activity response"
@@ -1482,7 +1470,6 @@ async def test_register_files_without_credentials_fails(client: Client):
                 ["gs://bucket/file.txt"],
                 id=f"gemini-register-no-creds-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
 
     # The error is nested: WorkflowFailureError → ActivityError → ApplicationError
@@ -1737,7 +1724,6 @@ async def test_interaction_create(client: Client):
             "What's an interaction?",
             id=f"gemini-interaction-create-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert result == {"id": INTERACTION_ID, "status": "completed"}
@@ -1760,7 +1746,6 @@ async def test_interaction_create_stream(client: Client):
             "Stream me",
             id=f"gemini-interaction-stream-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert result == [
@@ -1783,7 +1768,6 @@ async def test_interaction_lifecycle(client: Client):
             "interactions/abc",
             id=f"gemini-interaction-lifecycle-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert result["got_id"] == INTERACTION_ID
@@ -1801,7 +1785,6 @@ async def test_agents_crud(client: Client):
             AgentsWorkflow.run,
             id=f"gemini-agents-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert result["created_id"] == "test-agent"
@@ -1825,7 +1808,6 @@ async def test_webhooks_unsupported(client: Client):
             WebhooksUnsupportedWorkflow.run,
             id=f"gemini-webhooks-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
 
     assert "client.webhooks is not supported in Temporal workflows" in result
@@ -1949,7 +1931,6 @@ async def test_replay_simple_generate(client: Client):
             "Say hello",
             id=f"gemini-replay-simple-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
         await handle.result()
         history = await handle.fetch_history()
@@ -2034,7 +2015,6 @@ async def test_side_effects_activity_scheduling(client: Client):
             "Compare Tokyo and Paris weather",
             id=f"gemini-side-effects-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=15),
         )
         await handle.result()
 

--- a/tests/contrib/google_genai/test_gemini_mcp.py
+++ b/tests/contrib/google_genai/test_gemini_mcp.py
@@ -193,7 +193,6 @@ async def test_mcp_tool_discovery_and_call(client: Client):
             args=[server, "echo hello"],
             id=f"gemini-mcp-{uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=30),
         )
         result = await handle.result()
         names = await _activity_names(handle)
@@ -227,7 +226,6 @@ async def test_mcp_connection_pooling(client: Client):
             args=[server, "echo twice"],
             id=f"gemini-mcp-pool-{uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=30),
         )
         assert await handle.result() == "Done!"
         names = await _activity_names(handle)
@@ -255,7 +253,6 @@ async def test_mcp_full_schema_propagation(client: Client):
             args=[server, "echo hi"],
             id=f"gemini-mcp-schema-{uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=30),
         )
 
     # The first generate request carries the tool declarations the SDK built
@@ -285,7 +282,6 @@ async def test_mcp_replay(client: Client):
             args=[server, "echo hello"],
             id=f"gemini-mcp-replay-{uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=30),
         )
         await handle.result()
         history = await handle.fetch_history()
@@ -316,7 +312,6 @@ async def test_mcp_side_effects(client: Client):
             args=[server, "echo hello"],
             id=f"gemini-mcp-side-effects-{uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=30),
         )
         await handle.result()
         names = await _activity_names(handle)
@@ -356,7 +351,6 @@ async def test_mcp_via_gemini_test_server(client: Client):
             args=[server, "echo the phrase: durable execution"],
             id=f"gemini-mcp-public-{uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=30),
         )
         result = await handle.result()
         names = await _activity_names(handle)

--- a/tests/contrib/google_genai/test_gemini_streaming.py
+++ b/tests/contrib/google_genai/test_gemini_streaming.py
@@ -81,7 +81,6 @@ async def test_streaming_publishes_to_workflow_stream(client: Client):
             "say hi",
             id=wf_id,
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=15),
         )
 
         stream = WorkflowStreamClient.create(new_client, wf_id)
@@ -116,7 +115,6 @@ async def test_streaming_without_workflow_stream_raises(client: Client):
                 "hi",
                 id=f"gemini-stream-nostream-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
 
     assert "WorkflowStream" in str(exc_info.value.cause)

--- a/tests/contrib/openai_agents/test_openai.py
+++ b/tests/contrib/openai_agents/test_openai.py
@@ -109,7 +109,12 @@ from temporalio.contrib.openai_agents.testing import (
     TestModelProvider,
 )
 from temporalio.contrib.pydantic import pydantic_data_converter
-from temporalio.exceptions import ApplicationError, CancelledError, TemporalError
+from temporalio.exceptions import (
+    ActivityError,
+    ApplicationError,
+    CancelledError,
+    TemporalError,
+)
 from temporalio.testing import WorkflowEnvironment
 from temporalio.workflow import ActivityConfig
 from tests.contrib.openai_agents.research_agents.research_manager import (
@@ -1352,7 +1357,6 @@ async def test_output_guardrail(client: Client, use_local_model: bool):
                 OutputGuardrailWorkflow.run,
                 id=f"output-guardrail-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             result = await workflow_handle.result()
 
@@ -1407,7 +1411,6 @@ async def test_workflow_method_tools(client: Client):
             WorkflowToolWorkflow.run,
             id=f"workflow-tool-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
         await workflow_handle.result()
 
@@ -1469,10 +1472,12 @@ async def assert_status_retry_behavior(
                 "Input",
                 id=f"workflow-tool-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
-            with pytest.raises(WorkflowFailureError):
+            with pytest.raises(WorkflowFailureError) as err:
                 await workflow_handle.result()
+            assert isinstance(err.value.cause, ActivityError)
+            assert isinstance(err.value.cause.cause, ApplicationError)
+            assert err.value.cause.cause.type == "APIStatusError"
 
             found = False
             async for event in workflow_handle.fetch_history_events():
@@ -1591,7 +1596,6 @@ async def test_chat_completions_model(client: Client):
                 WorkflowToolWorkflow.run,
                 id=f"workflow-tool-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             await workflow_handle.result()
 
@@ -1664,7 +1668,6 @@ async def test_alternative_model(client: Client):
                 "Hello",
                 id=f"alternative-model-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             await workflow_handle.result()
 
@@ -1690,7 +1693,6 @@ async def test_heartbeat(client: Client, env: WorkflowEnvironment):
                 "Tell me about recursion in programming.",
                 id=f"workflow-tool-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=5.0),
             )
             await workflow_handle.result()
 
@@ -1722,7 +1724,6 @@ async def test_session(client: Client):
                 SessionWorkflow.run,
                 id=f"session-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10.0),
                 retry_policy=RetryPolicy(maximum_attempts=1),
             )
 
@@ -1767,7 +1768,6 @@ async def test_lite_llm(client: Client):
                 "Tell me about recursion in programming",
                 id=f"lite-llm-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             await workflow_handle.result()
 
@@ -2215,7 +2215,6 @@ async def test_multiple_models(client: Client):
                 False,
                 id=f"multiple-model-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             await workflow_handle.result()
             assert provider.model_names == {None, "gpt-4o-mini"}
@@ -2240,7 +2239,6 @@ async def test_run_config_models(client: Client):
                 True,
                 id=f"run-config-model-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             await workflow_handle.result()
 
@@ -2297,7 +2295,6 @@ async def test_dict_run_config_models(client: Client):
                 DictRunConfigWorkflow.run,
                 id=f"dict-run-config-model-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             result = await workflow_handle.result()
 
@@ -2354,7 +2351,6 @@ async def test_summary_provider(client: Client):
                 "Prompt",
                 id=f"summary-provider-model-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             await workflow_handle.result()
             async for e in workflow_handle.fetch_history_events():
@@ -2410,7 +2406,6 @@ async def test_output_type(client: Client):
                 OutputTypeWorkflow.run,
                 id=f"output-type-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             result = await workflow_handle.result()
             assert isinstance(result, OutputType)
@@ -2859,7 +2854,6 @@ async def test_local_hello_world_agent(client: Client):
                 "Tell me about recursion in programming.",
                 id=f"hello-workflow-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=5),
             )
             result = await handle.result()
             assert result == "test"


### PR DESCRIPTION
## What was changed

Dropped the 5-30s `execution_timeout` values from the google_genai and openai_agents integration tests, following #1816. `RegisterFilesWorkflow` uses `maximum_attempts=1` for the permanent missing-credentials error it relied on the deadline to cut short. `assert_status_retry_behavior` asserts the failure cause chain.

## Why

Failing CI logs show activities completing within a second, then a 10-40s runner stall, after which a healthy workflow was killed by a deadline that only duplicated pytest-timeout's 60s bound.

## Testing

Stall injection (SIGSTOP the test process 12s x3): 2/80 failed before, 80/80 after. An emulated 11s first-task stall reproduces both openai_agents failures before and passes after. Lint clean.
