### PR TITLE
Cancel activities Core stopped tracking at worker shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,8 @@ to include examples, links to docs, or any other relevant information.
 
 - Worker shutdown no longer waits forever for an activity that Core has stopped tracking, such as a
   local activity whose cancellation was lost when its workflow run was evicted. Once activity polling
-  has shut down, any activity still executing is cancelled with `worker_shutdown` cancellation details.
+  has shut down, any activity still executing is cancelled, with `worker_shutdown` cancellation
+  details if it has none yet.
 - **Experimental**: External storage metrics now report the wall-clock time storage was in flight.
   Previously each batch's duration was summed, over-reporting the time whenever storage operations
   ran concurrently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ to include examples, links to docs, or any other relevant information.
 
 ### Fixed
 
+- Worker shutdown no longer waits forever for an activity that Core has stopped tracking, such as a
+  local activity whose cancellation was lost when its workflow run was evicted. Once activity polling
+  has shut down, any activity still executing is cancelled with `worker_shutdown` cancellation details.
 - **Experimental**: External storage metrics now report the wall-clock time storage was in flight.
   Previously each batch's duration was summed, over-reporting the time whenever storage operations
   ran concurrently.

--- a/temporalio/worker/_activity.py
+++ b/temporalio/worker/_activity.py
@@ -202,11 +202,13 @@ class _ActivityWorker:
                     "Cancelling activity %s still running after worker shutdown",
                     task_token,
                 )
-                activity.cancellation_details.details = (
-                    temporalio.activity.ActivityCancellationDetails(
-                        worker_shutdown=True
+                # Cancellation details are set once, so keep any already received
+                if not activity.cancellation_details.details:
+                    activity.cancellation_details.details = (
+                        temporalio.activity.ActivityCancellationDetails(
+                            worker_shutdown=True
+                        )
                     )
-                )
                 activity.cancel(cancelled_by_request=True)
         running_tasks = [v.task for v in self._running_activities.values() if v.task]
         if running_tasks:

--- a/temporalio/worker/_activity.py
+++ b/temporalio/worker/_activity.py
@@ -195,6 +195,19 @@ class _ActivityWorker:
     # Only call this after run()/drain_poll_queue() have returned. This will not
     # raise an exception.
     async def wait_all_completed(self) -> None:
+        # Core tracks no activities once polling has shut down, so cancel stragglers
+        for task_token, activity in self._running_activities.items():
+            if not activity.done:
+                logger.warning(
+                    "Cancelling activity %s still running after worker shutdown",
+                    task_token,
+                )
+                activity.cancellation_details.details = (
+                    temporalio.activity.ActivityCancellationDetails(
+                        worker_shutdown=True
+                    )
+                )
+                activity.cancel(cancelled_by_request=True)
         running_tasks = [v.task for v in self._running_activities.values() if v.task]
         if running_tasks:
             await asyncio.gather(*running_tasks, return_exceptions=False)

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -43,6 +43,7 @@ import temporalio.converter
 import temporalio.converter._extstore
 import temporalio.worker
 import temporalio.worker._command_aware_visitor
+import temporalio.worker._workflow
 import temporalio.worker._workflow_instance
 import temporalio.workflow
 from temporalio import activity, workflow
@@ -55,7 +56,10 @@ from temporalio.api.workflowservice.v1 import (
     PollWorkflowExecutionUpdateResponse,
     ResetStickyTaskQueueRequest,
 )
-from temporalio.bridge.proto.workflow_activation import WorkflowActivation
+from temporalio.bridge.proto.workflow_activation import (
+    RemoveFromCache,
+    WorkflowActivation,
+)
 from temporalio.bridge.proto.workflow_completion import WorkflowActivationCompletion
 from temporalio.client import (
     AsyncActivityCancelledError,
@@ -1151,6 +1155,7 @@ async def test_worker_shutdown_cancels_local_activity_untracked_by_core(
     client: Client,
 ):
     started = asyncio.Event()
+    workflow_poll_shut_down = asyncio.Event()
     details: list[temporalio.activity.ActivityCancellationDetails | None] = []
 
     @activity.defn(name="wait_forever_local_activity")
@@ -1161,21 +1166,35 @@ async def test_worker_shutdown_cancels_local_activity_untracked_by_core(
         except asyncio.CancelledError:
             details.append(activity.cancellation_details())
 
-    # Delay the next poll so run invalidation drops the queued cancel before dispatch
-    orig_poll = temporalio.bridge.worker.Worker.poll_activity_task
-    delay_next_poll = False
+    # Hold the next poll until Core has evicted the run, so its queued cancel is never delivered
+    bridge_worker = temporalio.bridge.worker.Worker
+    orig_poll_activity = bridge_worker.poll_activity_task
+    orig_poll_workflow = bridge_worker.poll_workflow_activation
+    hold_next_poll = False
 
-    async def slow_poll(self: temporalio.bridge.worker.Worker):
-        nonlocal delay_next_poll
-        if delay_next_poll:
-            delay_next_poll = False
-            await asyncio.sleep(3)
-        task = await orig_poll(self)
+    async def poll_activity_task(self: temporalio.bridge.worker.Worker):
+        nonlocal hold_next_poll
+        if hold_next_poll:
+            hold_next_poll = False
+            await workflow_poll_shut_down.wait()
+        task = await orig_poll_activity(self)
         if task.HasField("start") and task.start.is_local:
-            delay_next_poll = True
+            hold_next_poll = True
         return task
 
-    with patch.object(temporalio.bridge.worker.Worker, "poll_activity_task", slow_poll):
+    async def poll_workflow_activation(self: temporalio.bridge.worker.Worker):
+        try:
+            return await orig_poll_workflow(self)
+        except temporalio.bridge.worker.PollShutdownError:  # type: ignore[reportPrivateLocalImportUsage]
+            workflow_poll_shut_down.set()
+            raise
+
+    with (
+        patch.object(bridge_worker, "poll_activity_task", poll_activity_task),
+        patch.object(
+            bridge_worker, "poll_workflow_activation", poll_workflow_activation
+        ),
+    ):
         worker = new_worker(
             client,
             OrphanedLocalActivityWorkflow,
@@ -1186,16 +1205,72 @@ async def test_worker_shutdown_cancels_local_activity_untracked_by_core(
             OrphanedLocalActivityWorkflow.run,
             id=f"workflow-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            task_timeout=timedelta(seconds=1),
+            task_timeout=timedelta(seconds=3),
         )
         await started.wait()
         # Terminating fails the workflow task heartbeat, which evicts the run
         await handle.terminate()
-        await asyncio.sleep(4)
         await asyncio.wait_for(worker.shutdown(), 20)
         await run_task
-    assert len(details) == 1 and details[0]
-    assert details[0].worker_shutdown or details[0].cancel_requested
+    assert details == [
+        temporalio.activity.ActivityCancellationDetails(worker_shutdown=True)
+    ]
+
+
+async def test_worker_shutdown_keeps_details_of_local_activity_ignoring_cancel(
+    client: Client,
+):
+    started = asyncio.Event()
+    cancel_seen = asyncio.Event()
+    details: list[temporalio.activity.ActivityCancellationDetails | None] = []
+
+    @activity.defn(name="wait_forever_local_activity")
+    async def wait_forever_local_activity() -> None:
+        started.set()
+        while True:
+            try:
+                await asyncio.sleep(1000)
+            except asyncio.CancelledError:
+                details.append(activity.cancellation_details())
+                cancel_seen.set()
+                if activity.is_worker_shutdown():
+                    raise
+
+    # Finish evicting only after the cancel reached the activity, so Core drops it afterwards
+    workflow_worker = temporalio.worker._workflow._WorkflowWorker
+    orig_evict = workflow_worker._handle_cache_eviction
+
+    async def handle_cache_eviction(
+        self: temporalio.worker._workflow._WorkflowWorker,
+        act: WorkflowActivation,
+        job: RemoveFromCache,
+    ):
+        await cancel_seen.wait()
+        await orig_evict(self, act, job)
+
+    with patch.object(workflow_worker, "_handle_cache_eviction", handle_cache_eviction):
+        worker = new_worker(
+            client,
+            OrphanedLocalActivityWorkflow,
+            activities=[wait_forever_local_activity],
+        )
+        run_task = asyncio.create_task(worker.run())
+        handle = await client.start_workflow(
+            OrphanedLocalActivityWorkflow.run,
+            id=f"workflow-{uuid.uuid4()}",
+            task_queue=worker.task_queue,
+            task_timeout=timedelta(seconds=3),
+        )
+        await started.wait()
+        # Terminating fails the workflow task heartbeat, which evicts the run
+        await handle.terminate()
+        await asyncio.wait_for(cancel_seen.wait(), 20)
+        await asyncio.wait_for(worker.shutdown(), 20)
+        await run_task
+    assert (
+        details
+        == [temporalio.activity.ActivityCancellationDetails(cancel_requested=True)] * 2
+    )
 
 
 @workflow.defn

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -27,6 +27,7 @@ from typing import (
     NoReturn,
     cast,
 )
+from unittest.mock import patch
 from urllib.request import urlopen
 
 import pydantic
@@ -36,6 +37,7 @@ from typing_extensions import Protocol, runtime_checkable
 
 import temporalio.activity
 import temporalio.api.sdk.v1
+import temporalio.bridge.worker
 import temporalio.client
 import temporalio.converter
 import temporalio.converter._extstore
@@ -1133,6 +1135,67 @@ async def test_workflow_cancel_activity_while_workflow_cancelled(client: Client)
         )
         for activation, _ in runner._pairs
     )
+
+
+@workflow.defn
+class OrphanedLocalActivityWorkflow:
+    @workflow.run
+    async def run(self) -> None:
+        await workflow.execute_local_activity(
+            "wait_forever_local_activity",
+            start_to_close_timeout=timedelta(minutes=5),
+        )
+
+
+async def test_worker_shutdown_cancels_local_activity_untracked_by_core(
+    client: Client,
+):
+    started = asyncio.Event()
+    details: list[temporalio.activity.ActivityCancellationDetails | None] = []
+
+    @activity.defn(name="wait_forever_local_activity")
+    async def wait_forever_local_activity() -> None:
+        started.set()
+        try:
+            await asyncio.sleep(1000)
+        except asyncio.CancelledError:
+            details.append(activity.cancellation_details())
+
+    # Delay the next poll so run invalidation drops the queued cancel before dispatch
+    orig_poll = temporalio.bridge.worker.Worker.poll_activity_task
+    delay_next_poll = False
+
+    async def slow_poll(self: temporalio.bridge.worker.Worker):
+        nonlocal delay_next_poll
+        if delay_next_poll:
+            delay_next_poll = False
+            await asyncio.sleep(3)
+        task = await orig_poll(self)
+        if task.HasField("start") and task.start.is_local:
+            delay_next_poll = True
+        return task
+
+    with patch.object(temporalio.bridge.worker.Worker, "poll_activity_task", slow_poll):
+        worker = new_worker(
+            client,
+            OrphanedLocalActivityWorkflow,
+            activities=[wait_forever_local_activity],
+        )
+        run_task = asyncio.create_task(worker.run())
+        handle = await client.start_workflow(
+            OrphanedLocalActivityWorkflow.run,
+            id=f"workflow-{uuid.uuid4()}",
+            task_queue=worker.task_queue,
+            task_timeout=timedelta(seconds=1),
+        )
+        await started.wait()
+        # Terminating fails the workflow task heartbeat, which evicts the run
+        await handle.terminate()
+        await asyncio.sleep(4)
+        await asyncio.wait_for(worker.shutdown(), 20)
+        await run_task
+    assert len(details) == 1 and details[0]
+    assert details[0].worker_shutdown or details[0].cancel_requested
 
 
 @workflow.defn


### PR DESCRIPTION
## What was changed

After activity polling has shut down, the worker cancels any activity still running, with a warning and, if it has no cancellation details yet, `worker_shutdown` cancellation details, before waiting for completions. Regression tests and CHANGELOG entry.

## Why

On a workflow eviction Core queues a cancel for a running local activity, then invalidates the run and drops the activity from its outstanding set, so the queued cancel is discarded as untracked while Python keeps running the activity. Core then reports shutdown complete and `wait_all_completed` waits forever; this is the 60s timeout in `test_workflow_cancel_activity[True]` across 17 CI attempts. Once polling is down Core tracks nothing, so anything still running is orphaned. The lost cancel itself is a Core race worth an sdk-core issue.

## Testing

Two tests force each ordering with events instead of sleeps. One holds the activity poll until the workflow poller has shut down, so the queued cancel is never delivered and shutdown must cancel the activity with `worker_shutdown` details. The other delivers the cancel first, has the activity ignore it, and checks that the shutdown cancel keeps its `cancel_requested` details. Both hang for the 20s limit without the fix; 100/100 and 60/60 runs under heavy load on Python 3.14 and 3.10. Lint clean.
