### PR TITLE
Derive reset point from history in random seed test

### DIFF
--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -9729,7 +9729,6 @@ class RandomSeedTestWorkflow:
     def __init__(self) -> None:
         self.seed_changes: list[int] = []
         self.continue_signal_received = False
-        self._ready = False
 
     @workflow.run
     async def run(self) -> dict[str, Any]:
@@ -9751,8 +9750,6 @@ class RandomSeedTestWorkflow:
             "Hi",
             schedule_to_close_timeout=timedelta(seconds=5),
         )
-
-        self._ready = True
 
         # Wait for signal to continue - this allows for workflow reset
         await workflow.wait_condition(lambda: self.continue_signal_received)
@@ -9777,10 +9774,6 @@ class RandomSeedTestWorkflow:
     def continue_workflow(self) -> None:
         self.continue_signal_received = True
 
-    @workflow.query
-    def ready(self) -> bool:
-        return self._ready
-
 
 async def test_random_seed_functionality(
     client: Client, worker: Worker, env: WorkflowEnvironment
@@ -9797,12 +9790,23 @@ async def test_random_seed_functionality(
             task_queue=worker.task_queue,
         )
 
-        # Let workflow generate some random values
-        # Wait for workflow to be ready
-        async def ready() -> bool:
-            return await handle.query(RandomSeedTestWorkflow.ready)
-
-        await assert_eq_eventually(True, ready)
+        # Reset point: the workflow task started after the activity completed
+        activity_completed = False
+        reset_event_id = 0
+        async for event in handle.fetch_history_events(wait_new_event=True):
+            if event.event_type is EventType.EVENT_TYPE_ACTIVITY_TASK_COMPLETED:
+                activity_completed = True
+            elif (
+                activity_completed
+                and event.event_type is EventType.EVENT_TYPE_WORKFLOW_TASK_STARTED
+            ):
+                reset_event_id = event.event_id
+            elif (
+                reset_event_id
+                and event.event_type is EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED
+            ):
+                break
+        assert reset_event_id
 
         # Reset workflow using raw gRPC call to trigger seed change
         from temporalio.api.common.v1.message_pb2 import WorkflowExecution
@@ -9819,7 +9823,7 @@ async def test_random_seed_functionality(
                 reason="Test seed change",
                 reset_reapply_type=ResetReapplyType.RESET_REAPPLY_TYPE_UNSPECIFIED,
                 request_id=str(uuid.uuid4()),
-                workflow_task_finish_event_id=9,  # Reset to after activity completion
+                workflow_task_finish_event_id=reset_event_id,
             )
         )
 


### PR DESCRIPTION
## What was changed

`test_random_seed_functionality` long-polls history for the workflow task that follows `ActivityTaskCompleted` and resets to that task's started event; the readiness query is removed.

## Why

Observed a CI flake with current behavior. The 10s readiness poll can expire (e.g, my most recent run took 9s on CI), and each poll replayed the workflow in a fresh sandbox (`max_cached_workflows=0`), competing with the awaited task. The hard-coded reset `event_id=9` is also invalid after any task retry.

## Testing

Emulated 9s and 11s stalls (the latter retries the first task): passes, deriving event 12. 240/240 under load. Lint clean.
