### PR TITLE
Remove short workflow deadlines from openai_agents tests

### DIFF
--- a/tests/contrib/openai_agents/test_openai.py
+++ b/tests/contrib/openai_agents/test_openai.py
@@ -109,7 +109,12 @@ from temporalio.contrib.openai_agents.testing import (
     TestModelProvider,
 )
 from temporalio.contrib.pydantic import pydantic_data_converter
-from temporalio.exceptions import ApplicationError, CancelledError, TemporalError
+from temporalio.exceptions import (
+    ActivityError,
+    ApplicationError,
+    CancelledError,
+    TemporalError,
+)
 from temporalio.testing import WorkflowEnvironment
 from temporalio.workflow import ActivityConfig
 from tests.contrib.openai_agents.research_agents.research_manager import (
@@ -1352,7 +1357,6 @@ async def test_output_guardrail(client: Client, use_local_model: bool):
                 OutputGuardrailWorkflow.run,
                 id=f"output-guardrail-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             result = await workflow_handle.result()
 
@@ -1407,7 +1411,6 @@ async def test_workflow_method_tools(client: Client):
             WorkflowToolWorkflow.run,
             id=f"workflow-tool-{uuid.uuid4()}",
             task_queue=worker.task_queue,
-            execution_timeout=timedelta(seconds=10),
         )
         await workflow_handle.result()
 
@@ -1469,10 +1472,12 @@ async def assert_status_retry_behavior(
                 "Input",
                 id=f"workflow-tool-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
-            with pytest.raises(WorkflowFailureError):
+            with pytest.raises(WorkflowFailureError) as err:
                 await workflow_handle.result()
+            assert isinstance(err.value.cause, ActivityError)
+            assert isinstance(err.value.cause.cause, ApplicationError)
+            assert err.value.cause.cause.type == "APIStatusError"
 
             found = False
             async for event in workflow_handle.fetch_history_events():
@@ -1591,7 +1596,6 @@ async def test_chat_completions_model(client: Client):
                 WorkflowToolWorkflow.run,
                 id=f"workflow-tool-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             await workflow_handle.result()
 
@@ -1664,7 +1668,6 @@ async def test_alternative_model(client: Client):
                 "Hello",
                 id=f"alternative-model-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             await workflow_handle.result()
 
@@ -1690,7 +1693,6 @@ async def test_heartbeat(client: Client, env: WorkflowEnvironment):
                 "Tell me about recursion in programming.",
                 id=f"workflow-tool-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=5.0),
             )
             await workflow_handle.result()
 
@@ -1722,7 +1724,6 @@ async def test_session(client: Client):
                 SessionWorkflow.run,
                 id=f"session-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10.0),
                 retry_policy=RetryPolicy(maximum_attempts=1),
             )
 
@@ -1767,7 +1768,6 @@ async def test_lite_llm(client: Client):
                 "Tell me about recursion in programming",
                 id=f"lite-llm-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             await workflow_handle.result()
 
@@ -2215,7 +2215,6 @@ async def test_multiple_models(client: Client):
                 False,
                 id=f"multiple-model-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             await workflow_handle.result()
             assert provider.model_names == {None, "gpt-4o-mini"}
@@ -2240,7 +2239,6 @@ async def test_run_config_models(client: Client):
                 True,
                 id=f"run-config-model-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             await workflow_handle.result()
 
@@ -2297,7 +2295,6 @@ async def test_dict_run_config_models(client: Client):
                 DictRunConfigWorkflow.run,
                 id=f"dict-run-config-model-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             result = await workflow_handle.result()
 
@@ -2354,7 +2351,6 @@ async def test_summary_provider(client: Client):
                 "Prompt",
                 id=f"summary-provider-model-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             await workflow_handle.result()
             async for e in workflow_handle.fetch_history_events():
@@ -2410,7 +2406,6 @@ async def test_output_type(client: Client):
                 OutputTypeWorkflow.run,
                 id=f"output-type-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=10),
             )
             result = await workflow_handle.result()
             assert isinstance(result, OutputType)
@@ -2859,7 +2854,6 @@ async def test_local_hello_world_agent(client: Client):
                 "Tell me about recursion in programming.",
                 id=f"hello-workflow-{uuid.uuid4()}",
                 task_queue=worker.task_queue,
-                execution_timeout=timedelta(seconds=5),
             )
             result = await handle.result()
             assert result == "test"


### PR DESCRIPTION
## What was changed

- The 5-10s `execution_timeout` values in `tests/contrib/openai_agents/test_openai.py` are removed (14 call sites), following #1816.
- `assert_status_retry_behavior` asserts the workflow failure cause chain (`ActivityError` -> `ApplicationError` of type `APIStatusError`) before inspecting history.

## Why

On loaded macOS CI runners the first workflow task is occasionally delayed past the default 10s workflow task timeout; the failing jobs log the agent starting 13s after the workflow was started, immediately followed by `Evicting workflow ... Error reporting WFT to server`. The server retries the task, but by then the workflow's own 10s execution timeout has fired, so `test_run_config_models` fails with `TimeoutError: Workflow timed out` (run 34253408987 attempt 1, 3.14/macos-arm) and `test_exception_handling` gets a `WorkflowFailureError` with no activity in history and fails on `assert found` (run 33848127955 attempt 1, 3.10/macos-arm).

These deadlines are nested inside pytest-timeout's 60s bound and serve no other purpose in these tests, so a stalled runner can only turn a healthy workflow into a timed-out one. Dropping them matches #1816; the remaining 30-120s deadlines in the file were not part of the failures and are left alone. Asserting the cause in `assert_status_retry_behavior` makes an unexpected failure mode show up directly rather than as a missing history event.

## Testing

- The tests use `TestModel` (no API key); nothing here touches the live-model paths.
- Emulated an 11s stall of the first workflow task (worker in debug mode with an interceptor blocking the first activation): both tests fail exactly as in CI before the change (`TimeoutError('Workflow timed out')`, `assert found`) and pass after it (the retried task runs, the model activity fails with `APIStatusError` on attempt 2, cause chain as asserted).
- `pytest --flake-finder --flake-runs=30` of both tests alongside a concurrent `-n 8` pytest session: all passes (30 runs each; the run covered the eight tests from the same investigation, 240/240 in total, load average 45-53). The unmodified tests also pass 240/240 on the same machine, so the CI failures only reproduce through the stall emulation above.
- `poe lint` clean.
