### PR TITLE
Take activity tests off one-second clocks

### DIFF
--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -752,7 +752,7 @@ async def test_manual_completion(client: Client, env: WorkflowEnvironment):
         ActivityInput(event_workflow_id=event_workflow_id),
         id=activity_id,
         task_queue=task_queue,
-        start_to_close_timeout=timedelta(seconds=5),
+        start_to_close_timeout=timedelta(minutes=1),
     )
 
     async with Worker(
@@ -794,7 +794,7 @@ async def test_manual_cancellation(client: Client, env: WorkflowEnvironment):
         ActivityInput(event_workflow_id=event_workflow_id),
         id=activity_id,
         task_queue=task_queue,
-        start_to_close_timeout=timedelta(seconds=5),
+        start_to_close_timeout=timedelta(minutes=1),
     )
 
     async with Worker(
@@ -855,7 +855,7 @@ async def test_manual_failure(client: Client, env: WorkflowEnvironment):
         ActivityInput(event_workflow_id=event_workflow_id),
         id=activity_id,
         task_queue=task_queue,
-        start_to_close_timeout=timedelta(seconds=5),
+        start_to_close_timeout=timedelta(minutes=1),
     )
     async with Worker(
         client,
@@ -932,7 +932,7 @@ async def test_manual_heartbeat(client: Client, env: WorkflowEnvironment):
         ),
         id=activity_id,
         task_queue=task_queue,
-        start_to_close_timeout=timedelta(seconds=5),
+        start_to_close_timeout=timedelta(minutes=1),
     )
     wait_for_activity_start_wf_handle = await client.start_workflow(
         EventWorkflow.wait,

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -981,6 +981,12 @@ async def test_workflow_cancel_activity(client: Client, local: bool):
     assert_timeout = timedelta(seconds=10)
     activity_inst = ActivityWaitCancelNotify()
 
+    async def wait_cancel_complete() -> None:
+        await asyncio.wait_for(
+            activity_inst.wait_cancel_complete.wait(), assert_timeout.total_seconds()
+        )
+        activity_inst.wait_cancel_complete.clear()
+
     async with new_worker(
         client,
         CancelActivityWorkflow,
@@ -988,7 +994,6 @@ async def test_workflow_cancel_activity(client: Client, local: bool):
         max_heartbeat_throttle_interval=timedelta(milliseconds=300),
     ) as worker:
         # Try cancel - confirm error and activity was sent the cancel
-        activity_inst.wait_cancel_complete.clear()
         handle = await client.start_workflow(
             CancelActivityWorkflow.run,
             CancelActivityWorkflowParams(
@@ -1006,13 +1011,10 @@ async def test_workflow_cancel_activity(client: Client, local: bool):
         await assert_eq_eventually(
             "Error: CancelledError", activity_result, timeout=assert_timeout
         )
-        await asyncio.wait_for(
-            activity_inst.wait_cancel_complete.wait(), assert_timeout.total_seconds()
-        )
+        await wait_cancel_complete()
         await handle.cancel()
 
         # Wait cancel - confirm no error due to graceful cancel handling
-        activity_inst.wait_cancel_complete.clear()
         handle = await client.start_workflow(
             CancelActivityWorkflow.run,
             CancelActivityWorkflowParams(
@@ -1028,13 +1030,10 @@ async def test_workflow_cancel_activity(client: Client, local: bool):
             activity_result,
             timeout=assert_timeout,
         )
-        await asyncio.wait_for(
-            activity_inst.wait_cancel_complete.wait(), assert_timeout.total_seconds()
-        )
+        await wait_cancel_complete()
         await handle.cancel()
 
         # Abandon - confirm error and that activity stays running
-        activity_inst.wait_cancel_complete.clear()
         handle = await client.start_workflow(
             CancelActivityWorkflow.run,
             CancelActivityWorkflowParams(
@@ -1051,9 +1050,7 @@ async def test_workflow_cancel_activity(client: Client, local: bool):
         await asyncio.sleep(0.5)
         assert not activity_inst.wait_cancel_complete.is_set()
         await handle.cancel()
-        await asyncio.wait_for(
-            activity_inst.wait_cancel_complete.wait(), assert_timeout.total_seconds()
-        )
+        await wait_cancel_complete()
 
 
 @workflow.defn

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -946,7 +946,7 @@ class CancelActivityWorkflow:
         if params.local:
             handle = workflow.start_local_activity_method(
                 ActivityWaitCancelNotify.wait_cancel,
-                schedule_to_close_timeout=timedelta(seconds=5),
+                schedule_to_close_timeout=timedelta(minutes=1),
                 cancellation_type=workflow.ActivityCancellationType[
                     params.cancellation_type
                 ],
@@ -955,7 +955,7 @@ class CancelActivityWorkflow:
             handle = workflow.start_activity_method(
                 ActivityWaitCancelNotify.wait_cancel,
                 schedule_to_close_timeout=timedelta(seconds=5),
-                heartbeat_timeout=timedelta(seconds=1),
+                heartbeat_timeout=timedelta(seconds=5),
                 cancellation_type=workflow.ActivityCancellationType[
                     params.cancellation_type
                 ],
@@ -976,16 +976,19 @@ class CancelActivityWorkflow:
 
 @pytest.mark.parametrize("local", [True, False])
 async def test_workflow_cancel_activity(client: Client, local: bool):
-    # Need short task timeout to timeout LA task and longer assert timeout
-    # so the task can timeout
-    task_timeout = timedelta(seconds=1)
+    # Core completes the task holding a local activity at 80% of this timeout
+    task_timeout = timedelta(seconds=5)
     assert_timeout = timedelta(seconds=10)
     activity_inst = ActivityWaitCancelNotify()
 
     async with new_worker(
-        client, CancelActivityWorkflow, activities=[activity_inst.wait_cancel]
+        client,
+        CancelActivityWorkflow,
+        activities=[activity_inst.wait_cancel],
+        max_heartbeat_throttle_interval=timedelta(milliseconds=300),
     ) as worker:
         # Try cancel - confirm error and activity was sent the cancel
+        activity_inst.wait_cancel_complete.clear()
         handle = await client.start_workflow(
             CancelActivityWorkflow.run,
             CancelActivityWorkflowParams(
@@ -1003,10 +1006,13 @@ async def test_workflow_cancel_activity(client: Client, local: bool):
         await assert_eq_eventually(
             "Error: CancelledError", activity_result, timeout=assert_timeout
         )
-        await activity_inst.wait_cancel_complete.wait()
+        await asyncio.wait_for(
+            activity_inst.wait_cancel_complete.wait(), assert_timeout.total_seconds()
+        )
         await handle.cancel()
 
         # Wait cancel - confirm no error due to graceful cancel handling
+        activity_inst.wait_cancel_complete.clear()
         handle = await client.start_workflow(
             CancelActivityWorkflow.run,
             CancelActivityWorkflowParams(
@@ -1022,10 +1028,13 @@ async def test_workflow_cancel_activity(client: Client, local: bool):
             activity_result,
             timeout=assert_timeout,
         )
-        await activity_inst.wait_cancel_complete.wait()
+        await asyncio.wait_for(
+            activity_inst.wait_cancel_complete.wait(), assert_timeout.total_seconds()
+        )
         await handle.cancel()
 
         # Abandon - confirm error and that activity stays running
+        activity_inst.wait_cancel_complete.clear()
         handle = await client.start_workflow(
             CancelActivityWorkflow.run,
             CancelActivityWorkflowParams(
@@ -1042,7 +1051,9 @@ async def test_workflow_cancel_activity(client: Client, local: bool):
         await asyncio.sleep(0.5)
         assert not activity_inst.wait_cancel_complete.is_set()
         await handle.cancel()
-        await activity_inst.wait_cancel_complete.wait()
+        await asyncio.wait_for(
+            activity_inst.wait_cancel_complete.wait(), assert_timeout.total_seconds()
+        )
 
 
 @workflow.defn


### PR DESCRIPTION
## What was changed

`test_workflow_cancel_activity`: task timeout 1s to 5s (Core completes the task holding a local activity at 80% of it), local activity schedule-to-close 5s to 1 minute, heartbeat timeout 1s to 5s with a 300ms throttle, and one bounded `wait_cancel_complete()` helper per phase. `tests/test_activity.py`: the four manual activity tests use a 1-minute start-to-close timeout instead of 5s.

## Why

Nothing in these tests depends on the short bounds firing, and loaded runners regularly miss them. The 1s task timeout produced the `Error reporting WFT to server` evictions behind the most frequent macOS failure of the last two weeks, including the shutdown hang fixed in #1837. The manual tests' 5s bound closed the attempt before the start handshake finished.

## Testing

Cancel test 40/40 per parameter under load, 15/15 after the helper; manual tests 40/40 each. Lint clean.
