### PR TITLE
Raise the dev server's default workflow task timeout in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,6 +145,9 @@ async def env(env_type: str) -> AsyncGenerator[WorkflowEnvironment, None]:
             dev_server_extra_args=[
                 "--dynamic-config-value",
                 "system.forceSearchAttributesCacheRefreshOnRead=true",
+                # Keep a stalled first workflow task from timing out and retrying on slow CI
+                "--dynamic-config-value",
+                'history.defaultWorkflowTaskTimeout="60s"',
                 "--dynamic-config-value",
                 f"limit.historyCount.suggestContinueAsNew={CONTINUE_AS_NEW_SUGGEST_HISTORY_COUNT}",
                 "--dynamic-config-value",

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -227,7 +227,7 @@ class InfoWorkflow:
         return json.loads(json.dumps(ret, default=str))
 
 
-async def test_workflow_info(client: Client, env: WorkflowEnvironment):
+async def test_workflow_info(client: Client, env: WorkflowEnvironment, env_type: str):
     # TODO(cretz): Fix
     if env.supports_time_skipping:
         pytest.skip(
@@ -258,7 +258,8 @@ async def test_workflow_info(client: Client, env: WorkflowEnvironment):
         assert uuid.UUID(info["run_id"]).version == 7
         assert info["run_timeout"] is None
         assert info["task_queue"] == worker.task_queue
-        assert info["task_timeout"] == "0:01:00"
+        # Only the local dev server gets the 60s default from tests/conftest.py
+        assert info["task_timeout"] == ("0:01:00" if env_type == "local" else "0:00:10")
         assert info["workflow_id"] == workflow_id
         assert info["workflow_type"] == "InfoWorkflow"
 

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -258,7 +258,7 @@ async def test_workflow_info(client: Client, env: WorkflowEnvironment):
         assert uuid.UUID(info["run_id"]).version == 7
         assert info["run_timeout"] is None
         assert info["task_queue"] == worker.task_queue
-        assert info["task_timeout"] == "0:00:10"
+        assert info["task_timeout"] == "0:01:00"
         assert info["workflow_id"] == workflow_id
         assert info["workflow_type"] == "InfoWorkflow"
 


### PR DESCRIPTION
## What was changed

`tests/conftest.py` starts the dev server with `history.defaultWorkflowTaskTimeout="60s"`; `test_workflow_info` asserts the new default. Explicit `task_timeout` values are unaffected.

## Why

Most recent macOS failures start with a 10-30s worker stall (`Evicting workflow ... Error reporting WFT to server`) that pushes the first workflow task past the 10s default. The retry then breaks tests in different ways: attempt-dependent assertions see a second attempt, and at attempt 3 the server fails updates and queries fast. A longer default fixes the class instead of one test at a time. Local dev server only; the time-skipping server ignores dynamic config. Supersedes #1838 and #1844.

## Testing

`test_workflow_info` confirms the default; the tests those PRs touched pass under it, 63 passed. `ruff` clean.
