### PR TITLE
Skip cloud tests for Dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,9 +288,9 @@ jobs:
           path: junit-xml
           retention-days: 14
 
-  # Run the test suite against Temporal Cloud (skipped on forks)
+  # Run the test suite against Temporal Cloud (skipped on forks and Dependabot-triggered runs)
   cloud-test:
-    if: ${{ github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-python' }}
+    if: ${{ github.actor != 'dependabot[bot]' && (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/sdk-python') }}
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- skip the Temporal Cloud test job for Dependabot-authored pull requests
- retain cloud testing for pushes and other internal pull requests

## Why
Dependabot-triggered workflows do not receive GitHub Actions secrets. The Cloud API key is therefore empty and namespace creation fails before tests run.

## Validation
- git diff --check