### PR TITLE
Bound full GC passes in tests to one test's allocations

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+import gc
 import multiprocessing.context
 import os
 import sys
@@ -56,6 +57,13 @@ def pytest_runtest_setup(item):  # type: ignore[reportMissingParameterType]
     """Print a newline so that custom printed output starts on new line."""
     if item.config.getoption("-s"):
         print()
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_teardown() -> None:
+    # Freeze survivors so later full GC passes only cover one test's allocations
+    gc.collect()
+    gc.freeze()
 
 
 def pytest_addoption(parser):  # type: ignore[reportMissingParameterType]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,9 +59,8 @@ def pytest_runtest_setup(item):  # type: ignore[reportMissingParameterType]
         print()
 
 
-@pytest.hookimpl(trylast=True)
-def pytest_runtest_teardown() -> None:
-    # Freeze survivors so later full GC passes only cover one test's allocations
+def pytest_collection_finish(session: pytest.Session) -> None:
+    # Freeze the import-time heap once so full GC passes only cover test allocations
     gc.collect()
     gc.freeze()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def pytest_runtest_setup(item):  # type: ignore[reportMissingParameterType]
         print()
 
 
-def pytest_collection_finish(session: pytest.Session) -> None:
+def pytest_collection_finish() -> None:
     # Freeze the import-time heap once so full GC passes only cover test allocations
     gc.collect()
     gc.freeze()

--- a/tests/contrib/langgraph/test_replay.py
+++ b/tests/contrib/langgraph/test_replay.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 from datetime import timedelta
 from uuid import uuid4
 
@@ -52,10 +53,21 @@ async def test_replay(client: Client):
         )
         await handle.result()
 
-    await Replayer(
-        workflows=[TwoNodesWorkflow],
-        plugins=[plugin],
-    ).replay_workflow(await handle.fetch_history())
+    with warnings.catch_warnings(record=True) as recorder:
+        warnings.filterwarnings(
+            "always", message=r"Module .* was imported after initial workflow load"
+        )
+        await Replayer(
+            workflows=[TwoNodesWorkflow],
+            plugins=[plugin],
+        ).replay_workflow(await handle.fetch_history())
+
+    # Sandbox imports during an activation count toward the deadlock timeout
+    assert not [
+        str(w.message)
+        for w in recorder
+        if "was imported after initial workflow load" in str(w.message)
+    ]
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## What was changed

- `tests/conftest.py`: a `pytest_collection_finish` hook runs `gc.collect()` then `gc.freeze()` once, after all test modules are imported.
- `tests/contrib/langgraph/test_replay.py`: asserts the replay imports nothing into the sandbox after initial workflow load (same guard as the OpenAI Agents replay test).

## Why

`test_replay` tripped the deadlock detector on the 3.10 macOS runner while the first activation was in `StateGraph.compile()`; the interrupt landed in a weakref callback inside `ast.parse`, i.e. during a cyclic GC pass. That activation does 3-8 ms of work and imports nothing into the sandbox. The test process heap grows to ~1.7M objects, and a full GC pass over it (160-290 ms locally, several times that on a 3-core runner shared by three xdist workers) runs on whichever thread allocates, so first activations occasionally absorb it inside the 2 s budget. Freezing the import-time heap once removes it from every later full pass. An earlier revision froze after every test; that made each test's survivors permanent (RSS 77 MB to 3.6 GB over 229 serial tests, versus a 490 MB plateau without the hook) and killed the 2-core ubuntu-arm CI runners mid-run on every attempt.

## Testing

Serial `tests/worker/test_workflow.py` with RSS sampled: no hook plateaus at 490 MB, single freeze at 390 MB, per-test freeze climbs to 3.6 GB. Full `gc.collect()` per test on a 51-test subset: 70 ms mean / 179 ms max without the hook, 37 ms / 122 ms with the single freeze. LangGraph replay and sandbox suites pass on 3.10 and 3.14; `poe lint` clean.
