### PR TITLE
Replace traced readiness query polls with untraced waits

### DIFF
--- a/tests/contrib/langgraph/test_summary_fn.py
+++ b/tests/contrib/langgraph/test_summary_fn.py
@@ -19,7 +19,7 @@ from temporalio.client import Client
 from temporalio.contrib.langgraph import LangGraphPlugin, graph
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Replayer, Worker
-from tests.helpers import assert_eq_eventually
+from tests.helpers import wait_for_workflow_idle
 
 SummaryFn = Callable[[tuple[Any, ...], dict[str, Any]], "str | None"]
 
@@ -235,26 +235,16 @@ class WorkflowNodeSummaryWorkflow:
     def __init__(self) -> None:
         self.app = graph("wf-node-graph").compile()
         self._done = False
-        self._invoked = False
 
     @workflow.run
     async def run(self, input: str) -> Any:
         result = await self.app.ainvoke({"value": input})
-        self._invoked = True
         await workflow.wait_condition(lambda: self._done)
         return result
 
     @workflow.signal
     def finish(self) -> None:
         self._done = True
-
-    @workflow.query
-    def ran(self) -> bool:
-        return workflow.get_current_details() != ""
-
-    @workflow.query
-    def invoked(self) -> bool:
-        return self._invoked
 
 
 async def test_workflow_node_sets_current_details(
@@ -285,9 +275,7 @@ async def test_workflow_node_sets_current_details(
             id=f"wf-node-{uuid.uuid4()}",
             task_queue=task_queue,
         )
-        await assert_eq_eventually(
-            True, lambda: handle.query(WorkflowNodeSummaryWorkflow.ran)
-        )
+        await wait_for_workflow_idle(handle)
         md: temporalio.api.sdk.v1.WorkflowMetadata = await handle.query(
             "__temporal_workflow_metadata",
             result_type=temporalio.api.sdk.v1.WorkflowMetadata,
@@ -328,9 +316,7 @@ async def test_workflow_node_clears_current_details_on_empty(
             id=f"wf-node-clear-{uuid.uuid4()}",
             task_queue=task_queue,
         )
-        await assert_eq_eventually(
-            True, lambda: handle.query(WorkflowNodeSummaryWorkflow.invoked)
-        )
+        await wait_for_workflow_idle(handle)
         md: temporalio.api.sdk.v1.WorkflowMetadata = await handle.query(
             "__temporal_workflow_metadata",
             result_type=temporalio.api.sdk.v1.WorkflowMetadata,

--- a/tests/contrib/openai_agents/test_openai_tracing.py
+++ b/tests/contrib/openai_agents/test_openai_tracing.py
@@ -244,7 +244,11 @@ async def simple_no_context_activity() -> str:
 
 
 async def wait_for_activity_processed(client: Client, workflow_id: str) -> None:
-    """Wait, via an untraced history poll, until the workflow task that handled the activity result completed."""
+    """Wait, via an untraced history poll, until the workflow task that handled the activity result completed.
+
+    Assumes the workflow's first completed activity is the one right before its park point, which
+    holds for every workflow in this module.
+    """
     await assert_event_subsequence(
         client.get_workflow_handle(workflow_id),
         [

--- a/tests/contrib/openai_agents/test_openai_tracing.py
+++ b/tests/contrib/openai_agents/test_openai_tracing.py
@@ -10,6 +10,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from temporalio import activity, workflow
+from temporalio.api.enums.v1 import EventType
 from temporalio.client import Client
 from temporalio.contrib.openai_agents import _temporal_openai_agents
 from temporalio.contrib.openai_agents.testing import (
@@ -24,7 +25,7 @@ from tests.contrib.openai_agents.test_openai import (
     ResearchWorkflow,
     research_mock_model,
 )
-from tests.helpers import assert_eq_eventually, new_worker
+from tests.helpers import assert_event_subsequence, new_worker
 
 
 class MemoryTracingProcessor(TracingProcessor):
@@ -242,11 +243,22 @@ async def simple_no_context_activity() -> str:
     return "success"
 
 
+async def wait_for_activity_processed(client: Client, workflow_id: str) -> None:
+    """Wait, via an untraced history poll, until the workflow task that handled the activity result completed."""
+    await assert_event_subsequence(
+        client.get_workflow_handle(workflow_id),
+        [
+            EventType.EVENT_TYPE_ACTIVITY_TASK_COMPLETED,
+            EventType.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
+        ],
+        timeout=timedelta(seconds=10),
+    )
+
+
 @workflow.defn
 class TraceWorkflow:
     def __init__(self) -> None:
         self._proceed = False
-        self._ready = False
 
     @workflow.run
     async def run(self):
@@ -256,13 +268,8 @@ class TraceWorkflow:
                 simple_no_context_activity,
                 start_to_close_timeout=timedelta(seconds=10),
             )
-            self._ready = True
             await workflow.wait_condition(lambda: self._proceed)
         return "done"
-
-    @workflow.query
-    def ready(self) -> bool:
-        return self._ready
 
     @workflow.signal
     def proceed(self) -> None:
@@ -273,7 +280,6 @@ class TraceWorkflow:
 class SelfTracingWorkflow:
     def __init__(self) -> None:
         self._proceed = False
-        self._ready = False
 
     @workflow.run
     async def run(self):
@@ -284,13 +290,8 @@ class SelfTracingWorkflow:
                     simple_no_context_activity,
                     start_to_close_timeout=timedelta(seconds=10),
                 )
-                self._ready = True
                 await workflow.wait_condition(lambda: self._proceed)
         return "done"
-
-    @workflow.query
-    def ready(self) -> bool:
-        return self._ready
 
     @workflow.signal
     def proceed(self) -> None:
@@ -366,11 +367,7 @@ async def test_external_trace_to_workflow_spans(
             max_cached_workflows=0,
             task_queue=task_queue,
         ):
-            # Wait for workflow to be ready
-            async def ready() -> bool:
-                return await workflow_handle.query(TraceWorkflow.ready)
-
-            await assert_eq_eventually(True, ready)
+            await wait_for_activity_processed(client, workflow_handle.id)
 
     # Second worker: Complete the workflow with fresh objects (new instrumentation)
     async with AgentEnvironment(
@@ -458,11 +455,7 @@ async def test_external_trace_and_span_to_workflow_spans(
             max_cached_workflows=0,
             task_queue=task_queue,
         ):
-            # Wait for workflow to be ready
-            async def ready() -> bool:
-                return await workflow_handle.query(TraceWorkflow.ready)
-
-            await assert_eq_eventually(True, ready)
+            await wait_for_activity_processed(client, workflow_handle.id)
 
     # Second worker: Complete the workflow with fresh objects (new instrumentation)
     async with AgentEnvironment(
@@ -554,11 +547,7 @@ async def test_workflow_only_trace_to_spans(
             )
             workflow_id = workflow_handle.id
 
-            # Wait for workflow to be ready
-            async def ready() -> bool:
-                return await workflow_handle.query(SelfTracingWorkflow.ready)
-
-            await assert_eq_eventually(True, ready)
+            await wait_for_activity_processed(client, workflow_handle.id)
 
     # Second worker: Complete the workflow with fresh objects (new instrumentation)
     async with AgentEnvironment(
@@ -805,7 +794,6 @@ async def test_otel_tracing_in_runner(
 class OtelSpanWorkflow:
     def __init__(self) -> None:
         self._proceed = False
-        self._ready = False
 
     @workflow.run
     async def run(self):
@@ -818,13 +806,8 @@ class OtelSpanWorkflow:
                     simple_no_context_activity,
                     start_to_close_timeout=timedelta(seconds=10),
                 )
-                self._ready = True
                 await workflow.wait_condition(lambda: self._proceed)
         return "done"
-
-    @workflow.query
-    def ready(self) -> bool:
-        return self._ready
 
     @workflow.signal
     def proceed(self) -> None:
@@ -868,11 +851,7 @@ async def test_sdk_trace_to_otel_span_parenting(
                 )
                 workflow_id = workflow_handle.id
 
-                # Wait for workflow to be ready
-                async def ready() -> bool:
-                    return await workflow_handle.query(OtelSpanWorkflow.ready)
-
-                await assert_eq_eventually(True, ready)
+                await wait_for_activity_processed(client, workflow_handle.id)
 
     # Second worker: Complete the workflow with fresh objects (new instrumentation)
     async with AgentEnvironment(

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -90,9 +90,9 @@ async def assert_eventually(
             if timedelta(seconds=time.monotonic() - start_sec) >= timeout:
                 raise
         except RPCError as e:
-            if retry_on_rpc_cancelled and e.status == RPCStatusCode.CANCELLED:
-                continue
-            else:
+            if not (retry_on_rpc_cancelled and e.status == RPCStatusCode.CANCELLED):
+                raise
+            if timedelta(seconds=time.monotonic() - start_sec) >= timeout:
                 raise
         await asyncio.sleep(interval.total_seconds())
 
@@ -142,7 +142,7 @@ async def wait_for_workflow_idle(
             if present
         ]
         assert not pending, (
-            f"Workflow {handle.id} still has pending {', '.join(pending)}"
+            f"Workflow {handle.id} still has pending {', '.join(pending)} after {timeout}"
         )
 
     await assert_eventually(check, timeout=timeout, interval=interval)

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -31,7 +31,12 @@ from temporalio.api.workflowservice.v1 import (
     PollWorkflowExecutionUpdateRequest,
     UnpauseActivityRequest,
 )
-from temporalio.client import BuildIdOpAddNewDefault, Client, WorkflowHandle
+from temporalio.client import (
+    BuildIdOpAddNewDefault,
+    Client,
+    WorkflowExecutionStatus,
+    WorkflowHandle,
+)
 from temporalio.common import SearchAttributeKey
 from temporalio.converter import DataConverter
 from temporalio.service import RPCError, RPCStatusCode
@@ -101,6 +106,37 @@ async def assert_eq_eventually(
         assert expected == await fn()
 
     await assert_eventually(check, timeout=timeout, interval=interval)
+
+
+async def wait_for_workflow_idle(
+    handle: WorkflowHandle[Any, Any],
+    *,
+    timeout: timedelta = timedelta(seconds=10),
+    interval: timedelta = timedelta(milliseconds=200),
+) -> None:
+    """Wait until the running workflow has no pending workflow task, activity, child or Nexus op.
+
+    Pass a handle from a client without tracing interceptors so the probe itself is untraced.
+    """
+    # The time-skipping test server never reports pending_workflow_task, so this can return early there.
+    deadline = time.monotonic() + timeout.total_seconds()
+    while True:
+        desc = await handle.describe()
+        assert desc.status == WorkflowExecutionStatus.RUNNING, (
+            f"Workflow {handle.id} is {desc.status}, not RUNNING"
+        )
+        raw = desc.raw_description
+        if not (
+            raw.HasField("pending_workflow_task")
+            or raw.pending_activities
+            or raw.pending_children
+            or raw.pending_nexus_operations
+        ):
+            return
+        assert time.monotonic() < deadline, (
+            f"Workflow {handle.id} still has pending work after {timeout}"
+        )
+        await asyncio.sleep(interval.total_seconds())
 
 
 async def assert_task_fail_eventually(

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -16,6 +16,8 @@ from typing import (
     cast,
 )
 
+import pytest
+
 from temporalio.api.common.v1 import WorkflowExecution
 from temporalio.api.enums.v1 import EventType as EventType
 from temporalio.api.enums.v1 import IndexedValueType
@@ -116,27 +118,34 @@ async def wait_for_workflow_idle(
 ) -> None:
     """Wait until the running workflow has no pending workflow task, activity, child or Nexus op.
 
-    Pass a handle from a client without tracing interceptors so the probe itself is untraced.
+    Use as an untraced readiness probe before a traced query, signal or update: pass a handle
+    from a client without tracing interceptors. Fails fast if the workflow is no longer running.
+
+    Limits: a workflow blocked only on a timer also counts as idle, and the time-skipping test
+    server never reports ``pending_workflow_task``, so this returns immediately there.
     """
-    # The time-skipping test server never reports pending_workflow_task, so this can return early there.
-    deadline = time.monotonic() + timeout.total_seconds()
-    while True:
+
+    async def check() -> None:
         desc = await handle.describe()
-        assert desc.status == WorkflowExecutionStatus.RUNNING, (
-            f"Workflow {handle.id} is {desc.status}, not RUNNING"
-        )
+        if desc.status != WorkflowExecutionStatus.RUNNING:
+            status = desc.status.name if desc.status is not None else "UNKNOWN"
+            pytest.fail(f"Workflow {handle.id} is {status}, not RUNNING")
         raw = desc.raw_description
-        if not (
-            raw.HasField("pending_workflow_task")
-            or raw.pending_activities
-            or raw.pending_children
-            or raw.pending_nexus_operations
-        ):
-            return
-        assert time.monotonic() < deadline, (
-            f"Workflow {handle.id} still has pending work after {timeout}"
+        pending = [
+            name
+            for name, present in (
+                ("workflow task", raw.HasField("pending_workflow_task")),
+                ("activities", bool(raw.pending_activities)),
+                ("child workflows", bool(raw.pending_children)),
+                ("Nexus operations", bool(raw.pending_nexus_operations)),
+            )
+            if present
+        ]
+        assert not pending, (
+            f"Workflow {handle.id} still has pending {', '.join(pending)}"
         )
-        await asyncio.sleep(interval.total_seconds())
+
+    await assert_eventually(check, timeout=timeout, interval=interval)
 
 
 async def assert_task_fail_eventually(


### PR DESCRIPTION
**TLDR:** Tracing tests polled a traced readiness query against a running workflow; the server attaches such a query to every attempt of a pending workflow task, so it could run twice or time out client-side, and every poll ran through the instrumented client. The langgraph tests now query the *completed* workflow (no task can be in flight), and the OpenAI tracing tests use an untraced history probe for the one case that genuinely needs to stop a worker mid-run.

## What was changed
- langgraph `test_summary_fn.py`: the `ran`/`invoked` query polls, the `_done` park and its `finish` signal are gone. The workflow returns the graph result directly and the tests query `__temporal_workflow_metadata` after `handle.result()`: the workflow-side node sets current details last-writer-wins and nothing clears them at graph end, so the completed workflow answers the same as a mid-run probe would.
- openai_agents `test_openai_tracing.py`: the four `ready` query polls become an untraced history poll (plain client) for `ACTIVITY_TASK_COMPLETED` then `WORKFLOW_TASK_COMPLETED`. These tests must stop the first worker mid-run for the cross-worker span-parenting coverage, so run-to-completion is not an option there; history works on both the dev server and the time-skipping server.
- `assert_eventually`: a cancelled RPC now retries on the normal interval and gives up at the deadline instead of spinning until pytest's timeout.
- The now-unused queries and flags are removed. An earlier revision added a `wait_for_workflow_idle` helper; it was dropped per review since these were its only callers and it was a silent no-op on the time-skipping server (which never reports `pending_workflow_task`).

## Testing
- Earlier revision: `--flake-finder --flake-runs=20` per converted test under CPU load, 120/120 on the dev server and 80/80 for the OpenAI tests on time-skipping (the originals also passed, so this is hardening, not a reproduced failure).
- Final revision: `test_summary_fn.py` 3× (14/14 each), `test_openai_tracing.py` 8/8, full lint gate clean. The converted langgraph tests skip on the time-skipping server as before (metadata query unreliable there).