### PR TITLE
fix(worker): evict cached workflows during shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ to include examples, links to docs, or any other relevant information.
 
 ### Fixed
 
+- Safely evict cached workflows during worker shutdown so asynchronous cleanup finishes before the workflow executor stops.
+
 - **Experimental**: External storage metrics now report the wall-clock time storage was in flight.
   Previously each batch's duration was summed, over-reporting the time whenever storage operations
   ran concurrently.

--- a/temporalio/worker/_worker.py
+++ b/temporalio/worker/_worker.py
@@ -922,6 +922,9 @@ class Worker:
         shut down as it runs.
 
         This will not return until the worker has completed shutting down.
+        Cached workflows are safely evicted before the workflow executor stops,
+        unless safe workflow eviction was explicitly disabled. This only closes
+        local workflow tasks; it does not cancel workflows on the server.
         """
         self._shutdown_event.set()
         await self._shutdown_complete_event.wait()

--- a/temporalio/worker/_workflow.py
+++ b/temporalio/worker/_workflow.py
@@ -251,6 +251,27 @@ class _WorkflowWorker:  # type:ignore[reportUnusedClass]
             ]
             if our_tasks:
                 await asyncio.wait(our_tasks)
+            # Core does not emit eviction jobs for workflows left in the cache
+            # when polling stops. Close them on their owning loop before GC can
+            # resume their cleanup on an unrelated thread or event loop.
+            evictions = []
+            for run_id in list(self._running_workflows):
+                job = temporalio.bridge.proto.workflow_activation.RemoveFromCache(
+                    message="Worker shutdown",
+                    reason=temporalio.bridge.proto.workflow_activation.RemoveFromCache.LANG_REQUESTED,
+                )
+                activation = temporalio.bridge.proto.workflow_activation.WorkflowActivation(
+                    run_id=run_id,
+                    jobs=[
+                        temporalio.bridge.proto.workflow_activation.WorkflowActivationJob(
+                            remove_from_cache=job
+                        )
+                    ],
+                )
+                evictions.append(
+                    self._handle_cache_eviction(activation, job, report_to_core=False)
+                )
+            await asyncio.gather(*evictions)
             # Shutdown the thread pool executor if we created it
             if not self._workflow_task_executor_user_provided:
                 self._workflow_task_executor.shutdown()
@@ -536,6 +557,8 @@ class _WorkflowWorker:  # type:ignore[reportUnusedClass]
         self,
         act: temporalio.bridge.proto.workflow_activation.WorkflowActivation,
         job: temporalio.bridge.proto.workflow_activation.RemoveFromCache,
+        *,
+        report_to_core: bool = True,
     ) -> None:
         logger.debug(
             "Evicting workflow with run ID %s, message: %s", act.run_id, job.message
@@ -634,18 +657,19 @@ class _WorkflowWorker:  # type:ignore[reportUnusedClass]
         # Remove from map and send completion
         if act.run_id in self._running_workflows:
             del self._running_workflows[act.run_id]
-        try:
-            await self._bridge_worker().complete_workflow_activation(
-                temporalio.bridge.proto.workflow_completion.WorkflowActivationCompletion(
-                    run_id=act.run_id,
-                    successful=temporalio.bridge.proto.workflow_completion.Success(),
+        if report_to_core:
+            try:
+                await self._bridge_worker().complete_workflow_activation(
+                    temporalio.bridge.proto.workflow_completion.WorkflowActivationCompletion(
+                        run_id=act.run_id,
+                        successful=temporalio.bridge.proto.workflow_completion.Success(),
+                    )
                 )
-            )
-        except Exception:
-            logger.exception(
-                "Failed completing eviction activation on workflow with run ID %s",
-                act.run_id,
-            )
+            except Exception:
+                logger.exception(
+                    "Failed completing eviction activation on workflow with run ID %s",
+                    act.run_id,
+                )
 
         # Run eviction hook if present
         if self._on_eviction_hook is not None:

--- a/tests/worker/test_workflow.py
+++ b/tests/worker/test_workflow.py
@@ -10127,3 +10127,52 @@ async def test_workflow_cancel_no_shielded_future_log(
     assert not any(
         "exception in shielded future" in record.message for record in caplog.records
     )
+
+
+shutdown_cleanup_results: dict[str, bool] = {}
+
+
+@workflow.defn(sandboxed=False)
+class ShutdownAsyncCleanupWorkflow:
+    @workflow.run
+    async def run(self) -> None:
+        try:
+            await workflow.wait_condition(lambda: False)
+        finally:
+            await asyncio.sleep(0)
+            shutdown_cleanup_results[workflow.info().workflow_id] = (
+                workflow.unsafe.is_replaying()
+            )
+
+    @workflow.query
+    def ready(self) -> bool:
+        return True
+
+
+@pytest.mark.parametrize("user_executor", [False, True])
+async def test_worker_shutdown_cleans_cached_workflows(
+    client: Client, user_executor: bool
+):
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+        async with new_worker(
+            client,
+            ShutdownAsyncCleanupWorkflow,
+            workflow_task_executor=executor if user_executor else None,
+        ) as worker:
+            handles = [
+                await client.start_workflow(
+                    ShutdownAsyncCleanupWorkflow.run,
+                    id=f"workflow-{uuid.uuid4()}",
+                    task_queue=worker.task_queue,
+                )
+                for _ in range(3)
+            ]
+            for handle in handles:
+                assert await handle.query(ShutdownAsyncCleanupWorkflow.ready)
+                assert handle.id not in shutdown_cleanup_results
+
+        for handle in handles:
+            assert shutdown_cleanup_results.pop(handle.id)
+            assert (await handle.describe()).status == WorkflowExecutionStatus.RUNNING
+        if user_executor:
+            assert executor.submit(lambda: True).result()


### PR DESCRIPTION
## Problem

Core does not evict idle cached workflows when a worker shuts down. In sdk-core, `shutdown_done` (`workflow_stream.rs`) only waits for runs that `has_any_pending_work`: an outstanding WFT, activation, buffered task, or an eviction that was *already* requested. An idle cached run has none of those, so Core reports shutdown complete and the run stays in the cache without ever receiving a `remove_from_cache` job.

On the Python side those workflows are then left as suspended coroutines. Python later closes them during garbage collection, which throws `GeneratorExit` into the workflow on whatever thread or event loop happens to be running GC. Any cleanup that needs to `await` in a `finally` raises `RuntimeError: coroutine ignored GeneratorExit`, and any commands issued there can cross workflow contexts (the failure mode documented in #494).

A workflow that waits on a condition and awaits `asyncio.sleep(0)` in `finally` reproduces this with no framework integration. The practical trigger is any deployment that stops a worker with open workflows; the workflows resume fine on the replacement worker, but the stopped worker fails its own teardown.

## Fix

After in-flight activations finish and before the workflow executor stops, the workflow worker builds a local eviction activation for every run still in `_running_workflows` and drives it through the existing safe-eviction path. The activation has the same shape as Core's `create_evict_activation`: no timestamp, `is_replaying` false, a single `remove_from_cache` job. A new `report_to_core` keyword on `_handle_cache_eviction` skips the completion acknowledgment, since polling has stopped and Core never issued the job.

This mirrors what sdk-typescript already does: when the poller leaves the `POLLING` state it injects a synthetic eviction activation (`SELF_INDUCED_SHUTDOWN_EVICTION`) into every cached workflow and does not send its completion to Core. This PR brings the Python worker to parity.

Evictions run concurrently, honor the explicit `disable_safe_workflow_eviction` opt-out, do not cancel workflows on the server, and do not close a caller-owned executor. The reason is `LANG_REQUESTED`, which the replayer's eviction hook already treats as a non-failure.

## Behavior to be aware of

Shutdown now waits for these evictions the same way it waits for Core-driven ones. A workflow that swallows `BaseException` and keeps waiting will make eviction retry forever and hold shutdown open, exactly as `test_workflow_eviction_swallow` documents for the Core-driven case. Previously such a workflow was silently garbage-collected instead. The existing "Timed out running eviction job" log fires so the cause is visible.

## Tests

`test_worker_shutdown_cleans_cached_workflows` starts three cached workflows, shuts the worker down, and asserts each `finally` ran under eviction (`is_replaying()` is set to true on eviction, so the assertion proves the cleanup ran on the workflow's own loop rather than in GC). It is parametrized over the default and a caller-owned executor; both fail before the patch and pass after. The server-side workflows are asserted still `RUNNING`.

## Validation

- `poe test -n 0 tests/worker/test_workflow.py -k 'shutdown_cleans_cached or cache_eviction_tear_down or workflow_eviction_exception or workflow_eviction_swallow'` on Python 3.12.8: all selected tests pass.
- `poe lint` passes (Ruff, Pyright, mypy, BasedPyright, docstyle).
- Python-only change; tested against the released 1.32.0 native bridge. No Rust changes.
