### PR TITLE
Fix OpenTelemetry exporter examples in the openai_agents README

### DIFF
--- a/temporalio/contrib/openai_agents/README.md
+++ b/temporalio/contrib/openai_agents/README.md
@@ -905,19 +905,18 @@ Choose the appropriate OTEL exporter for your monitoring system:
 # For OTLP (works with most OTEL collectors and monitoring systems)
 pip install opentelemetry-exporter-otlp
 
-# For Console output (development/debugging)
-pip install opentelemetry-exporter-console
-
 # Other exporters available for specific systems
 pip install opentelemetry-exporter-<your-system>
 ```
+
+`ConsoleSpanExporter` (development/debugging) ships with `opentelemetry-sdk`, so it needs no extra package.
 
 ### Example: Multiple Exporters
 
 ```python
 from temporalio.contrib.opentelemetry import create_tracer_provider
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.exporter.console import ConsoleSpanExporter
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
 from opentelemetry import trace
 
 exporters = [
@@ -934,8 +933,10 @@ exporters = [
     ConsoleSpanExporter(),
 ]
 
-# Set up global tracer provider with multiple exporters
-tracer_provider = create_tracer_provider(exporters=exporters)
+# Set up the global tracer provider with one span processor per exporter
+tracer_provider = create_tracer_provider()
+for exporter in exporters:
+    tracer_provider.add_span_processor(BatchSpanProcessor(exporter))
 trace.set_tracer_provider(tracer_provider)
 
 plugin = OpenAIAgentsPlugin(use_otel_instrumentation=True)


### PR DESCRIPTION
The "Example: Multiple Exporters" snippet in the OpenAI Agents README called `create_tracer_provider(exporters=...)`, but `create_tracer_provider` has no `exporters` parameter. It also imported `ConsoleSpanExporter` from `opentelemetry.exporter.console`, which does not exist, and the dependency list told readers to `pip install opentelemetry-exporter-console`, which is not a package. All three fail on copy-paste.

The example now creates the provider and adds one `BatchSpanProcessor` per exporter, imports `ConsoleSpanExporter` from `opentelemetry.sdk.trace.export`, and the dependency list notes that the console exporter ships with `opentelemetry-sdk`.

Docs-only change; no code or tests affected.